### PR TITLE
[addon-1] Unified Node 20 server: serves HTML + proxies HA/Plex

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ Thumbs.db
 # Node (for upcoming Vite build in #pkg-1)
 node_modules/
 dist/
+server/node_modules/

--- a/server/.dockerignore
+++ b/server/.dockerignore
@@ -1,0 +1,8 @@
+node_modules
+test
+fixtures
+*.md
+Dockerfile
+.dockerignore
+.git
+.gitignore

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,0 +1,34 @@
+# Multi-stage build: trims dev deps out of the final image so the add-on layer
+# stays small (~35 MB incl. node:20-alpine base).
+
+FROM node:20-alpine AS deps
+WORKDIR /app
+COPY package.json ./
+RUN npm install --omit=dev --no-audit --no-fund
+
+FROM node:20-alpine AS runtime
+WORKDIR /app
+
+# Dumb-init keeps Ctrl-C / Supervisor's SIGTERM clean.
+RUN apk add --no-cache dumb-init \
+    && addgroup -S app && adduser -S app -G app
+
+COPY --from=deps /app/node_modules ./node_modules
+COPY package.json ./
+COPY src ./src
+# The add-on wrapper (#addon-2) mounts the www/ directory at /app/www; for the
+# Docker Compose path we bake it in so the image is self-contained.
+COPY ../www ./www
+
+ENV NODE_ENV=production \
+    PORT=8099 \
+    STATIC_DIR=/app/www
+
+USER app
+EXPOSE 8099
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+  CMD wget -qO- http://127.0.0.1:8099/healthz >/dev/null || exit 1
+
+ENTRYPOINT ["/usr/bin/dumb-init", "--"]
+CMD ["node", "src/server.js"]

--- a/server/README.md
+++ b/server/README.md
@@ -1,0 +1,85 @@
+# plex-now-showing-server
+
+Unified backend that serves the Now Showing HTML **and** proxies Home
+Assistant + Plex so API tokens never leave the server. This is the shared
+runtime used by:
+
+- **#addon-2** — the Home Assistant add-on wrapper
+- **#addon-4** — the Docker Compose example for HA Container users
+
+Standalone (HACS-only) installs continue to work against the unmodified
+`www/now_showing.html` — the server is opt-in.
+
+## Endpoints
+
+| Method | Path                              | Purpose                                                 |
+|-------:|-----------------------------------|---------------------------------------------------------|
+| GET    | `/now_showing.html`               | The kiosk UI (served from `STATIC_DIR`, default `../www`) |
+| GET    | `/api`                            | Version + mode + endpoint listing                        |
+| GET    | `/api/state`                      | Normalised now-playing payload (3 s TTL cache)          |
+| GET    | `/api/media-info/:ratingKey`      | Plex metadata for the info panel (10 min TTL cache)      |
+| GET    | `/healthz`                        | Liveness probe (doesn't call upstream)                   |
+
+## Run modes
+
+The server auto-detects which mode it's in:
+
+### 1. HA Add-on mode (recommended)
+
+Supervisor provides `SUPERVISOR_TOKEN` and the HA API is reachable at
+`http://supervisor/core`. **No user-created long-lived access token needed.**
+
+### 2. Standalone mode
+
+For HA Container users running via Docker Compose. Set:
+
+| Env var | Required | Notes |
+|---------|----------|-------|
+| `HA_URL`   | yes | e.g. `https://ha.example.com:8123` (trailing slash ok) |
+| `HA_TOKEN` | yes | Long-lived access token |
+
+## All environment variables
+
+| Env var | Default | Purpose |
+|---------|---------|---------|
+| `PORT` | `8099` | Listen port |
+| `SUPERVISOR_TOKEN` | – | Set by Supervisor; switches to add-on mode |
+| `HA_URL` / `HA_TOKEN` | – | Standalone mode |
+| `PLEX_URL` / `PLEX_TOKEN` | – | Required together if you want `/api/media-info/:ratingKey` |
+| `PLEX_USERNAME` | – | Filters which `media_player.plex_*` entities count as "yours" |
+| `PLEX_PLAYER` | – | Pin to one entity id, e.g. `media_player.plex_plex_for_lg_tv` |
+| `LANDSCAPE` | `false` | Passed through to the HTML |
+| `THEME` | `classic-gold` | Passed through to the HTML |
+| `POLL` | `5000` | Kiosk poll interval in ms |
+| `STATE_TTL_MS` | `3000` | Server-side `/api/state` cache |
+| `MEDIA_INFO_TTL_MS` | `600000` | Server-side media-info cache |
+| `PROXY_SECRET` | – | If set, requests to `/api/*` must carry `X-Proxy-Secret` |
+| `ALLOWED_ORIGINS` | – | Comma-separated allowlist for `Origin` on `/api/*` |
+| `STATIC_DIR` | `../www` | Override where `now_showing.html` is served from |
+
+## Local development
+
+```bash
+cd server
+npm install
+HA_URL=http://192.168.1.10:8123 HA_TOKEN=... npm run dev
+# http://localhost:8099/now_showing.html
+```
+
+Run the tests (no network, fully offline):
+
+```bash
+npm test
+```
+
+## Docker
+
+```bash
+docker build -t plex-now-showing-server server/
+docker run --rm -p 8099:8099 \
+  -e HA_URL=http://192.168.1.10:8123 \
+  -e HA_TOKEN=... \
+  plex-now-showing-server
+```
+
+A full Compose example with HA Container + this image lives under `#addon-4`.

--- a/server/fixtures/ha_states.json
+++ b/server/fixtures/ha_states.json
@@ -1,0 +1,48 @@
+[
+  {
+    "entity_id": "sensor.tnas",
+    "state": "1",
+    "attributes": { "friendly_name": "Plex Sessions" }
+  },
+  {
+    "entity_id": "media_player.plex_plex_for_lg_tv",
+    "state": "playing",
+    "attributes": {
+      "friendly_name": "Plex for LG TV",
+      "media_title": "Pilot",
+      "media_series_title": "Severance",
+      "media_content_type": "episode",
+      "media_season": 1,
+      "media_episode": 1,
+      "media_content_rating": "TV-MA",
+      "media_duration": 3120,
+      "media_summary": "Mark leads a team of office workers whose memories have been surgically divided.",
+      "media_content_id": "12345",
+      "entity_picture": "/api/media_player_proxy/media_player.plex_plex_for_lg_tv",
+      "username": "rusty"
+    }
+  },
+  {
+    "entity_id": "media_player.plex_plex_for_ios_iphone",
+    "state": "idle",
+    "attributes": {
+      "friendly_name": "Plex for iOS",
+      "username": "someone_else"
+    }
+  },
+  {
+    "entity_id": "media_player.plex_plex_for_android_tv",
+    "state": "playing",
+    "attributes": {
+      "friendly_name": "Bedroom Shield",
+      "media_title": "Dune: Part Two",
+      "media_series_title": "",
+      "media_content_type": "movie",
+      "media_content_rating": "PG-13",
+      "media_duration": 9900,
+      "media_content_id": "plex://movie/5e161e4c8f3f5a00401b5af1",
+      "entity_picture": "/api/media_player_proxy/media_player.plex_plex_for_android_tv",
+      "username": "rusty"
+    }
+  }
+]

--- a/server/fixtures/plex_metadata_12345.json
+++ b/server/fixtures/plex_metadata_12345.json
@@ -1,0 +1,41 @@
+{
+  "MediaContainer": {
+    "size": 1,
+    "Metadata": [
+      {
+        "ratingKey": "12345",
+        "title": "Pilot",
+        "Media": [
+          {
+            "videoResolution": "4k",
+            "videoCodec": "hevc",
+            "videoProfile": "main 10",
+            "audioCodec": "eac3",
+            "audioChannels": 6,
+            "bitrate": 24000,
+            "container": "mkv",
+            "width": 3840,
+            "height": 2160,
+            "Part": [
+              {
+                "size": 12500000000,
+                "Stream": [
+                  {
+                    "streamType": 1,
+                    "bitDepth": 10,
+                    "colorTrc": "smpte2084",
+                    "DOVIPresent": false
+                  },
+                  {
+                    "streamType": 2,
+                    "displayTitle": "English (EAC3 5.1)"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,0 +1,831 @@
+{
+  "name": "plex-now-showing-server",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "plex-now-showing-server",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "express": "^4.19.2"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "license": "MIT"
+    },
+    "node_modules/body-parser": {
+      "version": "1.20.4",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.4.tgz",
+      "integrity": "sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "~1.2.0",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "on-finished": "~2.4.1",
+        "qs": "~6.14.0",
+        "raw-body": "~2.5.3",
+        "type-is": "~1.6.18",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express": {
+      "version": "4.22.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
+      "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "~1.20.3",
+        "content-disposition": "~0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "~0.7.1",
+        "cookie-signature": "~1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.3.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.0",
+        "merge-descriptors": "1.0.3",
+        "methods": "~1.1.2",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "~0.1.12",
+        "proxy-addr": "~2.0.7",
+        "qs": "~6.14.0",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "~0.19.0",
+        "serve-static": "~1.16.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "~2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
+      "integrity": "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "~2.0.2",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
+      "license": "MIT"
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.14.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
+      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
+      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
+      "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.1",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "~2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "~2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/send/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/serve-static": {
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
+      "integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "~0.19.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    }
+  }
+}

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "plex-now-showing-server",
+  "version": "0.1.0",
+  "description": "Serves the Plex Now Showing HTML and proxies Home Assistant + Plex so tokens stay server-side.",
+  "type": "module",
+  "engines": {
+    "node": ">=20"
+  },
+  "scripts": {
+    "start": "node src/server.js",
+    "dev": "node --watch src/server.js",
+    "test": "node --test test/"
+  },
+  "dependencies": {
+    "express": "^4.19.2"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/rusty4444/plex-now-showing.git"
+  }
+}

--- a/server/src/cache.js
+++ b/server/src/cache.js
@@ -1,0 +1,38 @@
+// Tiny TTL cache. Two instances wired up in server.js:
+//   - state cache   (short TTL, ~3 s)   — smooths out multi-tablet polling
+//   - mediaInfo cache (long TTL, ~10 m) — Plex metadata rarely changes
+//
+// Keeps the hot path simple: no external deps, no LRU — the key space for
+// both caches is tiny (one entry for state, <100 for media info on any
+// realistic library usage window).
+
+export function createCache(ttlMs) {
+  const store = new Map();
+
+  function get(key) {
+    const entry = store.get(key);
+    if (!entry) return undefined;
+    if (entry.expires <= Date.now()) {
+      store.delete(key);
+      return undefined;
+    }
+    return entry.value;
+  }
+
+  function set(key, value, customTtlMs) {
+    store.set(key, {
+      value,
+      expires: Date.now() + (customTtlMs ?? ttlMs),
+    });
+    return value;
+  }
+
+  function invalidate(key) {
+    if (key == null) store.clear();
+    else store.delete(key);
+  }
+
+  function size() { return store.size; }
+
+  return { get, set, invalidate, size };
+}

--- a/server/src/config.js
+++ b/server/src/config.js
@@ -1,0 +1,64 @@
+// Config loader for the plex-now-showing server.
+//
+// Two run modes:
+//
+//   1. HA Add-on mode  — Supervisor provides SUPERVISOR_TOKEN at startup.
+//                         HA is reached via http://supervisor/core/api/.
+//                         No user-created long-lived token needed.
+//
+//   2. Standalone mode  — HA_URL + HA_TOKEN env vars point at any HA instance.
+//                         Used by HA Container users running docker compose.
+//
+// Plex access (plex_url + plex_token) is always optional and purely for the
+// media-info endpoint.
+
+export function loadConfig(env = process.env) {
+  const supervisorToken = env.SUPERVISOR_TOKEN || '';
+  const mode = supervisorToken ? 'addon' : 'standalone';
+
+  const haUrl = mode === 'addon'
+    ? 'http://supervisor/core'
+    : (env.HA_URL || '').replace(/\/$/, '');
+  const haToken = mode === 'addon' ? supervisorToken : (env.HA_TOKEN || '');
+
+  const config = {
+    mode,
+    port: parseInt(env.PORT || '8099', 10),
+    haUrl,
+    haToken,
+    plexUrl: (env.PLEX_URL || '').replace(/\/$/, ''),
+    plexToken: env.PLEX_TOKEN || '',
+    plexUsername: env.PLEX_USERNAME || '',
+    plexPlayer: env.PLEX_PLAYER || '',
+    landscape: parseBool(env.LANDSCAPE, false),
+    theme: env.THEME || 'classic-gold',
+    poll: parseInt(env.POLL || '5000', 10),
+    // Optional hardening (issue #44 ships defaults that make sense in add-on mode)
+    proxySecret: env.PROXY_SECRET || '',
+    allowedOrigins: (env.ALLOWED_ORIGINS || '')
+      .split(',').map(s => s.trim()).filter(Boolean),
+    // TTLs (ms) — tuned below 1× poll interval so a second tablet doesn't re-hit HA
+    stateTtl: parseInt(env.STATE_TTL_MS || '3000', 10),
+    mediaInfoTtl: parseInt(env.MEDIA_INFO_TTL_MS || '600000', 10), // 10 min
+    // Where the static HTML lives (overridden in tests)
+    staticDir: env.STATIC_DIR || new URL('../../www', import.meta.url).pathname,
+  };
+
+  const errors = validate(config);
+  return { config, errors };
+}
+
+function parseBool(v, defaultValue) {
+  if (v == null || v === '') return defaultValue;
+  return /^(1|true|yes|on)$/i.test(String(v));
+}
+
+function validate(c) {
+  const errors = [];
+  if (!c.haUrl) errors.push('haUrl is required (set HA_URL or run as an add-on)');
+  if (!c.haToken) errors.push('haToken is required (set HA_TOKEN or run as an add-on so SUPERVISOR_TOKEN is provided)');
+  if (c.plexUrl && !c.plexToken) errors.push('plexToken is required when plexUrl is set');
+  if (!Number.isFinite(c.port) || c.port < 1 || c.port > 65535) errors.push('port must be between 1 and 65535');
+  if (!Number.isFinite(c.poll) || c.poll < 1000) errors.push('poll must be \u2265 1000 ms');
+  return errors;
+}

--- a/server/src/ha.js
+++ b/server/src/ha.js
@@ -1,0 +1,37 @@
+// Home Assistant client.
+//
+// Works transparently in both supported modes (see config.js):
+//   - addon       → GET http://supervisor/core/api/states with SUPERVISOR_TOKEN
+//   - standalone  → GET <HA_URL>/api/states with <HA_TOKEN>
+//
+// Only GET /api/states is needed for now; a later issue (#arch-1, WebSocket)
+// will replace polling with a push subscription and can live behind the same
+// interface.
+
+export function createHaClient({ haUrl, haToken, fetchImpl = globalThis.fetch }) {
+  if (!haUrl) throw new Error('haUrl is required');
+  if (!haToken) throw new Error('haToken is required');
+
+  async function getStates() {
+    const resp = await fetchImpl(`${haUrl}/api/states`, {
+      headers: {
+        Authorization: `Bearer ${haToken}`,
+        'Content-Type': 'application/json',
+      },
+    });
+    if (!resp.ok) {
+      const body = await safeText(resp);
+      const err = new Error(`HA /api/states returned ${resp.status}`);
+      err.status = resp.status;
+      err.body = body;
+      throw err;
+    }
+    return resp.json();
+  }
+
+  return { getStates };
+}
+
+async function safeText(resp) {
+  try { return await resp.text(); } catch { return ''; }
+}

--- a/server/src/plex.js
+++ b/server/src/plex.js
@@ -1,0 +1,75 @@
+// Plex helpers.
+//
+// parseRatingKey  — closes #arch-4 bonus. `media_content_id` from HA is not
+//                   always a bare ratingKey:
+//                     • Movies/episodes:  '12345'
+//                     • New Plex client:  'plex://movie/5e161e4...' or
+//                                         'plex://episode/...'
+//                     • Older integration:'/library/metadata/12345'
+//                     • Music:            'plex://track/...'  (not useful)
+//                   Only numeric ratingKeys work against /library/metadata/{id},
+//                   so extract a numeric id when possible and return null
+//                   otherwise instead of firing a guaranteed-404 request.
+//
+// fetchMediaInfo  — port of fetchPlexMediaInfo() from now_showing.html so the
+//                   browser can switch to /api/media-info/:ratingKey and keep
+//                   the same info-panel behaviour.
+
+export function parseRatingKey(raw) {
+  if (raw == null) return null;
+  const s = String(raw).trim();
+  if (!s) return null;
+
+  // Bare numeric id
+  if (/^\d+$/.test(s)) return s;
+
+  // /library/metadata/12345  (optional leading slash, optional trailing parts)
+  const libMatch = s.match(/\/library\/metadata\/(\d+)/);
+  if (libMatch) return libMatch[1];
+
+  // plex://movie/<guid> or plex://episode/<guid> — these are GUIDs, not
+  // ratingKeys. Returning null is the correct behaviour; the caller will skip
+  // the Plex round-trip rather than issue a 404.
+  if (s.startsWith('plex://')) return null;
+
+  // Last-ditch: if the string ends with digits, take them.
+  const tail = s.match(/(\d+)\s*$/);
+  return tail ? tail[1] : null;
+}
+
+export async function fetchMediaInfo({ plexUrl, plexToken, ratingKey, fetchImpl = globalThis.fetch }) {
+  if (!plexUrl || !plexToken || !ratingKey) return null;
+
+  const url = `${plexUrl}/library/metadata/${encodeURIComponent(ratingKey)}?X-Plex-Token=${encodeURIComponent(plexToken)}`;
+  const resp = await fetchImpl(url, { headers: { Accept: 'application/json' } });
+  if (!resp.ok) return null;
+
+  const data = await resp.json();
+  const item = data?.MediaContainer?.Metadata?.[0];
+  if (!item || !item.Media || !item.Media[0]) return null;
+
+  const media = item.Media[0];
+  const part = media.Part?.[0];
+  const videoStream = part?.Stream?.find(s => s.streamType === 1);
+  const audioStream = part?.Stream?.find(s => s.streamType === 2);
+
+  return {
+    videoResolution: media.videoResolution ? String(media.videoResolution).toUpperCase() : '',
+    videoCodec: (media.videoCodec || '').toUpperCase(),
+    videoProfile: media.videoProfile || '',
+    videoBitDepth: videoStream?.bitDepth || '',
+    hdr: videoStream?.DOVIPresent
+      ? 'Dolby Vision'
+      : (videoStream?.colorTrc === 'smpte2084' || videoStream?.colorTrc === 'arib-std-b67')
+        ? 'HDR'
+        : '',
+    audioCodec: (media.audioCodec || '').toUpperCase(),
+    audioChannels: media.audioChannels || '',
+    audioTitle: audioStream?.displayTitle || '',
+    bitrate: media.bitrate || 0,
+    container: (media.container || '').toUpperCase(),
+    fileSize: part?.size || 0,
+    width: media.width || 0,
+    height: media.height || 0,
+  };
+}

--- a/server/src/routes/artwork.js
+++ b/server/src/routes/artwork.js
@@ -1,0 +1,39 @@
+// GET /api/artwork?path=<HA-relative path>
+//
+// Pipes artwork (entity_picture, /api/media_player_proxy/...) from HA to the
+// browser so the kiosk can render it same-origin without knowing the HA
+// token. Only HA-relative paths are accepted.
+//
+// The frontend never calls this directly; state.js rewrites artwork URLs in
+// the /api/state payload to hit here.
+
+import { Router } from 'express';
+
+export function artworkRoute({ config, fetchImpl = globalThis.fetch }) {
+  const r = Router();
+
+  r.get('/api/artwork', async (req, res) => {
+    const path = String(req.query.path || '');
+    if (!path.startsWith('/')) {
+      return res.status(400).json({ error: 'path_must_be_ha_relative' });
+    }
+
+    try {
+      const upstream = await fetchImpl(`${config.haUrl}${path}`, {
+        headers: { Authorization: `Bearer ${config.haToken}` },
+      });
+      if (!upstream.ok) return res.status(upstream.status).end();
+
+      const ct = upstream.headers.get('content-type') || 'image/jpeg';
+      res.setHeader('Content-Type', ct);
+      res.setHeader('Cache-Control', 'public, max-age=300');
+
+      const buf = Buffer.from(await upstream.arrayBuffer());
+      res.end(buf);
+    } catch (err) {
+      res.status(502).json({ error: 'artwork_unreachable', message: err.message });
+    }
+  });
+
+  return r;
+}

--- a/server/src/routes/healthz.js
+++ b/server/src/routes/healthz.js
@@ -1,0 +1,17 @@
+// Simple liveness probe. Doesn't touch HA/Plex so it stays green even if
+// upstream is briefly down — that's what /api/state's cache status is for.
+
+import { Router } from 'express';
+
+export function healthzRoute({ config, version }) {
+  const r = Router();
+  r.get('/healthz', (_req, res) => {
+    res.json({
+      ok: true,
+      mode: config.mode,
+      version,
+      uptime: process.uptime(),
+    });
+  });
+  return r;
+}

--- a/server/src/routes/mediaInfo.js
+++ b/server/src/routes/mediaInfo.js
@@ -1,0 +1,41 @@
+// GET /api/media-info/:ratingKey — Plex metadata proxy with a 10-min TTL.
+//
+// Keeps the Plex token server-side and handles the three ratingKey shapes
+// HA can emit (#arch-4). Returns 404 when the id can't be resolved to a
+// numeric ratingKey (e.g. plex://... GUIDs) so the browser can fall back to
+// whatever it already has.
+
+import { Router } from 'express';
+import { parseRatingKey, fetchMediaInfo } from '../plex.js';
+
+export function mediaInfoRoute({ cache, config }) {
+  const r = Router();
+
+  r.get('/api/media-info/:ratingKey', async (req, res) => {
+    if (!config.plexUrl || !config.plexToken) {
+      return res.status(503).json({ error: 'plex_not_configured' });
+    }
+    const id = parseRatingKey(req.params.ratingKey);
+    if (!id) {
+      return res.status(404).json({ error: 'unparseable_rating_key' });
+    }
+
+    try {
+      let info = cache.get(id);
+      if (info === undefined) {
+        info = await fetchMediaInfo({
+          plexUrl: config.plexUrl,
+          plexToken: config.plexToken,
+          ratingKey: id,
+        });
+        if (info) cache.set(id, info);
+      }
+      if (!info) return res.status(404).json({ error: 'not_found' });
+      res.json(info);
+    } catch (err) {
+      res.status(502).json({ error: 'plex_unreachable', message: err.message });
+    }
+  });
+
+  return r;
+}

--- a/server/src/routes/root.js
+++ b/server/src/routes/root.js
@@ -1,0 +1,23 @@
+// GET / — small JSON landing page so a quick curl tells the user "yes, this
+// is plex-now-showing, here are the endpoints, here's the mode". The HTML
+// itself is served from a static middleware in server.js.
+
+import { Router } from 'express';
+
+export function rootRoute({ config, version }) {
+  const r = Router();
+  r.get('/api', (_req, res) => {
+    res.json({
+      name: 'plex-now-showing-server',
+      version,
+      mode: config.mode,
+      endpoints: {
+        state: '/api/state',
+        mediaInfo: '/api/media-info/:ratingKey',
+        healthz: '/healthz',
+        html: '/now_showing.html',
+      },
+    });
+  });
+  return r;
+}

--- a/server/src/routes/state.js
+++ b/server/src/routes/state.js
@@ -1,0 +1,35 @@
+// GET /api/state — returns the normalised "now showing" payload (same shape
+// the HTML already consumes), cached with a short TTL so multiple kiosks on
+// the same server don't each beat up HA.
+
+import { Router } from 'express';
+import { normalise } from '../state.js';
+
+export function stateRoute({ haClient, cache, config }) {
+  const r = Router();
+
+  r.get('/api/state', async (_req, res) => {
+    try {
+      let payload = cache.get('state');
+      if (payload === undefined) {
+        const states = await haClient.getStates();
+        payload = normalise(states, {
+          plexPlayer: config.plexPlayer,
+          plexUsername: config.plexUsername,
+        });
+        cache.set('state', payload);
+      }
+      // Normalise(...) returns null when nothing is playing. Express's default
+      // JSON serialiser handles null fine — clients already expect null.
+      res.json(payload);
+    } catch (err) {
+      res.status(502).json({
+        error: 'ha_unreachable',
+        status: err.status || 0,
+        message: err.message || String(err),
+      });
+    }
+  });
+
+  return r;
+}

--- a/server/src/server.js
+++ b/server/src/server.js
@@ -1,0 +1,87 @@
+// Express wire-up.
+//
+// Responsibilities:
+//   - Serve the static HTML (so a single add-on delivers HTML + backend).
+//   - Serve /api/state, /api/media-info/:ratingKey, /healthz.
+//   - Optional hardening via PROXY_SECRET + ALLOWED_ORIGINS (closes old #4).
+//   - Boot loudly: on config errors, log and exit non-zero so Supervisor
+//     surfaces the problem.
+
+import express from 'express';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+import { loadConfig } from './config.js';
+import { createCache } from './cache.js';
+import { createHaClient } from './ha.js';
+import { rootRoute } from './routes/root.js';
+import { healthzRoute } from './routes/healthz.js';
+import { stateRoute } from './routes/state.js';
+import { mediaInfoRoute } from './routes/mediaInfo.js';
+import { artworkRoute } from './routes/artwork.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const pkg = JSON.parse(readFileSync(join(__dirname, '..', 'package.json'), 'utf8'));
+
+export function createApp({ config, haClient }) {
+  const app = express();
+  app.disable('x-powered-by');
+
+  // Optional shared-secret header — only enforced if PROXY_SECRET is set.
+  if (config.proxySecret) {
+    app.use('/api', (req, res, next) => {
+      if (req.get('x-proxy-secret') !== config.proxySecret) {
+        return res.status(401).json({ error: 'missing_or_invalid_proxy_secret' });
+      }
+      next();
+    });
+  }
+
+  // Optional Origin allowlist — only enforced if ALLOWED_ORIGINS is set.
+  if (config.allowedOrigins.length > 0) {
+    app.use('/api', (req, res, next) => {
+      const origin = req.get('origin');
+      // Same-origin requests omit Origin; allow them through.
+      if (!origin) return next();
+      if (config.allowedOrigins.includes(origin)) {
+        res.setHeader('Access-Control-Allow-Origin', origin);
+        return next();
+      }
+      return res.status(403).json({ error: 'origin_not_allowed' });
+    });
+  }
+
+  const stateCache = createCache(config.stateTtl);
+  const mediaInfoCache = createCache(config.mediaInfoTtl);
+
+  app.use(rootRoute({ config, version: pkg.version }));
+  app.use(healthzRoute({ config, version: pkg.version }));
+  app.use(stateRoute({ haClient, cache: stateCache, config }));
+  app.use(mediaInfoRoute({ cache: mediaInfoCache, config }));
+  app.use(artworkRoute({ config }));
+
+  // Static HTML last so /api/* wins on overlap.
+  app.use(express.static(config.staticDir, {
+    etag: true,
+    maxAge: '5m',
+    index: ['now_showing.html', 'index.html'],
+  }));
+
+  return app;
+}
+
+// Boot when run directly (node src/server.js), not when imported by tests.
+const isDirectRun = import.meta.url === `file://${process.argv[1]}`;
+if (isDirectRun) {
+  const { config, errors } = loadConfig(process.env);
+  if (errors.length > 0) {
+    for (const e of errors) console.error(`[config] ${e}`);
+    process.exit(1);
+  }
+  const haClient = createHaClient({ haUrl: config.haUrl, haToken: config.haToken });
+  const app = createApp({ config, haClient });
+  app.listen(config.port, () => {
+    console.log(`plex-now-showing-server v${pkg.version} listening on :${config.port} (mode=${config.mode})`);
+  });
+}

--- a/server/src/state.js
+++ b/server/src/state.js
@@ -1,0 +1,63 @@
+// State normaliser — direct port of fetchPlexData() in www/now_showing.html so
+// the /api/state endpoint returns exactly the same shape the HTML already
+// consumes. The browser path will then be:
+//
+//   HACS-only install  → HTML calls HA directly (today's behaviour, unchanged)
+//   Add-on / Compose   → HTML calls /api/state on the server, and tokens never
+//                        leave the box.
+
+const PLAYING = new Set(['playing', 'paused']);
+
+export function normalise(states, { plexPlayer = '', plexUsername = '' } = {}) {
+  if (!Array.isArray(states)) return null;
+
+  // Specific player pinned in config → use only that one.
+  if (plexPlayer) {
+    const playerState = states.find(s => s.entity_id === plexPlayer);
+    if (!playerState || !PLAYING.has(playerState.state)) return null;
+    return shape(playerState);
+  }
+
+  // Otherwise pick from active Plex media_player entities, filtered to this
+  // user where possible.
+  const active = states.filter(s =>
+    typeof s.entity_id === 'string'
+    && s.entity_id.startsWith('media_player.plex_')
+    && PLAYING.has(s.state),
+  );
+  if (active.length === 0) return null;
+
+  const mine = active.filter(p => {
+    const attrs = p.attributes || {};
+    if (attrs.username) return attrs.username === plexUsername;
+    const id = p.entity_id.replace('media_player.plex_', '');
+    return id.startsWith('plex_for_') || id.startsWith('plex_web_');
+  });
+  if (mine.length === 0) return null;
+
+  return shape(mine[0]);
+}
+
+function shape(playerState) {
+  const attrs = playerState.attributes || {};
+  // Rewrite HA-relative artwork paths to our own proxy so the browser can
+  // load them same-origin (without an HA token). Absolute URLs pass through.
+  const rawArt = attrs.entity_picture || '';
+  const artwork = rawArt && !/^https?:\/\//i.test(rawArt)
+    ? `/api/artwork?path=${encodeURIComponent(rawArt)}`
+    : rawArt;
+  return {
+    title: attrs.media_title || 'Unknown Title',
+    seriesTitle: attrs.media_series_title || '',
+    contentType: attrs.media_content_type || 'video',
+    artwork,
+    playerName: attrs.friendly_name || playerState.entity_id,
+    state: playerState.state,
+    season: attrs.media_season || '',
+    episode: attrs.media_episode || '',
+    contentRating: attrs.media_content_rating || '',
+    duration: attrs.media_duration || 0,
+    summary: attrs.media_summary || '',
+    ratingKey: attrs.media_content_id || '',
+  };
+}

--- a/server/test/cache.test.js
+++ b/server/test/cache.test.js
@@ -1,0 +1,31 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createCache } from '../src/cache.js';
+
+test('set/get returns value inside TTL', () => {
+  const c = createCache(50);
+  c.set('a', 1);
+  assert.equal(c.get('a'), 1);
+});
+
+test('get returns undefined after TTL expires', async () => {
+  const c = createCache(10);
+  c.set('a', 1);
+  await new Promise(r => setTimeout(r, 25));
+  assert.equal(c.get('a'), undefined);
+});
+
+test('invalidate with no key clears everything', () => {
+  const c = createCache(10_000);
+  c.set('a', 1); c.set('b', 2);
+  c.invalidate();
+  assert.equal(c.size(), 0);
+});
+
+test('invalidate with a key removes only that entry', () => {
+  const c = createCache(10_000);
+  c.set('a', 1); c.set('b', 2);
+  c.invalidate('a');
+  assert.equal(c.get('a'), undefined);
+  assert.equal(c.get('b'), 2);
+});

--- a/server/test/config.test.js
+++ b/server/test/config.test.js
@@ -1,0 +1,48 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { loadConfig } from '../src/config.js';
+
+test('addon mode is chosen when SUPERVISOR_TOKEN is present', () => {
+  const { config, errors } = loadConfig({ SUPERVISOR_TOKEN: 'abc' });
+  assert.equal(config.mode, 'addon');
+  assert.equal(config.haUrl, 'http://supervisor/core');
+  assert.equal(config.haToken, 'abc');
+  assert.deepEqual(errors, []);
+});
+
+test('standalone mode requires HA_URL and HA_TOKEN', () => {
+  const { errors } = loadConfig({});
+  assert.ok(errors.some(e => e.includes('haUrl')));
+  assert.ok(errors.some(e => e.includes('haToken')));
+});
+
+test('standalone mode strips trailing slash on HA_URL', () => {
+  const { config } = loadConfig({
+    HA_URL: 'https://ha.example.com:8123/',
+    HA_TOKEN: 'tok',
+  });
+  assert.equal(config.mode, 'standalone');
+  assert.equal(config.haUrl, 'https://ha.example.com:8123');
+});
+
+test('plexUrl without plexToken is an error', () => {
+  const { errors } = loadConfig({
+    SUPERVISOR_TOKEN: 'x',
+    PLEX_URL: 'https://plex.example.com:32400',
+  });
+  assert.ok(errors.some(e => e.includes('plexToken')));
+});
+
+test('ALLOWED_ORIGINS is parsed as a list', () => {
+  const { config } = loadConfig({
+    SUPERVISOR_TOKEN: 'x',
+    ALLOWED_ORIGINS: 'https://a.example, https://b.example',
+  });
+  assert.deepEqual(config.allowedOrigins, ['https://a.example', 'https://b.example']);
+});
+
+test('TTL defaults match spec (3 s state, 10 min media-info)', () => {
+  const { config } = loadConfig({ SUPERVISOR_TOKEN: 'x' });
+  assert.equal(config.stateTtl, 3000);
+  assert.equal(config.mediaInfoTtl, 600000);
+});

--- a/server/test/plex.test.js
+++ b/server/test/plex.test.js
@@ -1,0 +1,79 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+import { parseRatingKey, fetchMediaInfo } from '../src/plex.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const metadata = JSON.parse(
+  readFileSync(join(__dirname, '..', 'fixtures', 'plex_metadata_12345.json'), 'utf8'),
+);
+
+test('parseRatingKey: bare numeric id', () => {
+  assert.equal(parseRatingKey('12345'), '12345');
+});
+
+test('parseRatingKey: /library/metadata/N form', () => {
+  assert.equal(parseRatingKey('/library/metadata/67890'), '67890');
+  assert.equal(parseRatingKey('/library/metadata/67890/children'), '67890');
+});
+
+test('parseRatingKey: plex:// GUID returns null (unresolvable)', () => {
+  assert.equal(parseRatingKey('plex://movie/5e161e4c8f3f5a00401b5af1'), null);
+  assert.equal(parseRatingKey('plex://episode/abc'), null);
+});
+
+test('parseRatingKey: empty / nullish inputs', () => {
+  assert.equal(parseRatingKey(''), null);
+  assert.equal(parseRatingKey(null), null);
+  assert.equal(parseRatingKey(undefined), null);
+});
+
+test('parseRatingKey: trailing digits fallback', () => {
+  assert.equal(parseRatingKey('whatever-42'), '42');
+});
+
+test('fetchMediaInfo: maps the canned Plex response correctly', async () => {
+  const fetchImpl = async (url) => {
+    assert.ok(url.includes('/library/metadata/12345'));
+    assert.ok(url.includes('X-Plex-Token=tok'));
+    return {
+      ok: true,
+      async json() { return metadata; },
+    };
+  };
+
+  const info = await fetchMediaInfo({
+    plexUrl: 'https://plex.example:32400',
+    plexToken: 'tok',
+    ratingKey: '12345',
+    fetchImpl,
+  });
+
+  assert.equal(info.videoResolution, '4K');
+  assert.equal(info.videoCodec, 'HEVC');
+  assert.equal(info.videoBitDepth, 10);
+  assert.equal(info.hdr, 'HDR');
+  assert.equal(info.audioCodec, 'EAC3');
+  assert.equal(info.audioChannels, 6);
+  assert.equal(info.audioTitle, 'English (EAC3 5.1)');
+  assert.equal(info.container, 'MKV');
+  assert.equal(info.width, 3840);
+  assert.equal(info.height, 2160);
+  assert.equal(info.fileSize, 12500000000);
+});
+
+test('fetchMediaInfo: returns null when plex url/token missing', async () => {
+  assert.equal(await fetchMediaInfo({ plexUrl: '', plexToken: 't', ratingKey: '1' }), null);
+  assert.equal(await fetchMediaInfo({ plexUrl: 'u', plexToken: '', ratingKey: '1' }), null);
+});
+
+test('fetchMediaInfo: returns null on non-ok response', async () => {
+  const fetchImpl = async () => ({ ok: false, status: 404, async json() { return {}; } });
+  const info = await fetchMediaInfo({
+    plexUrl: 'u', plexToken: 't', ratingKey: '1', fetchImpl,
+  });
+  assert.equal(info, null);
+});

--- a/server/test/routes.test.js
+++ b/server/test/routes.test.js
@@ -1,0 +1,115 @@
+// End-to-end style: spin up the Express app with a stub HA client and hit
+// the endpoints via an injected fetch. Keeps tests offline and fast.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+import { createApp } from '../src/server.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const haStates = JSON.parse(
+  readFileSync(join(__dirname, '..', 'fixtures', 'ha_states.json'), 'utf8'),
+);
+
+function baseConfig(overrides = {}) {
+  return {
+    mode: 'addon',
+    port: 0,
+    haUrl: 'http://supervisor/core',
+    haToken: 'tok',
+    plexUrl: 'https://plex.example:32400',
+    plexToken: 'ptok',
+    plexUsername: 'rusty',
+    plexPlayer: 'media_player.plex_plex_for_lg_tv',
+    landscape: false,
+    theme: 'classic-gold',
+    poll: 5000,
+    proxySecret: '',
+    allowedOrigins: [],
+    stateTtl: 3000,
+    mediaInfoTtl: 600000,
+    staticDir: join(__dirname, '..', 'fixtures'),
+    ...overrides,
+  };
+}
+
+function startApp(config, haClient) {
+  return new Promise((resolve) => {
+    const app = createApp({ config, haClient });
+    const server = app.listen(0, () => {
+      const { port } = server.address();
+      resolve({ server, url: `http://127.0.0.1:${port}` });
+    });
+  });
+}
+
+test('GET /api/state returns normalised payload', async () => {
+  const haClient = { getStates: async () => haStates };
+  const { server, url } = await startApp(baseConfig(), haClient);
+  try {
+    const resp = await fetch(`${url}/api/state`);
+    assert.equal(resp.status, 200);
+    const body = await resp.json();
+    assert.equal(body.title, 'Pilot');
+    assert.equal(body.seriesTitle, 'Severance');
+    assert.equal(body.ratingKey, '12345');
+  } finally { server.close(); }
+});
+
+test('GET /healthz is always 200', async () => {
+  const haClient = { getStates: async () => { throw new Error('HA is down'); } };
+  const { server, url } = await startApp(baseConfig(), haClient);
+  try {
+    const resp = await fetch(`${url}/healthz`);
+    assert.equal(resp.status, 200);
+    const body = await resp.json();
+    assert.equal(body.ok, true);
+    assert.equal(body.mode, 'addon');
+  } finally { server.close(); }
+});
+
+test('GET /api/state returns 502 when HA is unreachable', async () => {
+  const haClient = {
+    getStates: async () => {
+      const err = new Error('boom'); err.status = 500; throw err;
+    },
+  };
+  const { server, url } = await startApp(baseConfig(), haClient);
+  try {
+    const resp = await fetch(`${url}/api/state`);
+    assert.equal(resp.status, 502);
+    const body = await resp.json();
+    assert.equal(body.error, 'ha_unreachable');
+  } finally { server.close(); }
+});
+
+test('PROXY_SECRET middleware blocks requests without the header', async () => {
+  const haClient = { getStates: async () => haStates };
+  const { server, url } = await startApp(baseConfig({ proxySecret: 'sekret' }), haClient);
+  try {
+    const blocked = await fetch(`${url}/api/state`);
+    assert.equal(blocked.status, 401);
+    const ok = await fetch(`${url}/api/state`, { headers: { 'x-proxy-secret': 'sekret' } });
+    assert.equal(ok.status, 200);
+  } finally { server.close(); }
+});
+
+test('ALLOWED_ORIGINS blocks requests from other origins', async () => {
+  const haClient = { getStates: async () => haStates };
+  const { server, url } = await startApp(
+    baseConfig({ allowedOrigins: ['https://kiosk.example'] }),
+    haClient,
+  );
+  try {
+    const blocked = await fetch(`${url}/api/state`, { headers: { Origin: 'https://evil.example' } });
+    assert.equal(blocked.status, 403);
+    const ok = await fetch(`${url}/api/state`, { headers: { Origin: 'https://kiosk.example' } });
+    assert.equal(ok.status, 200);
+    // No Origin header (same-origin) must still work
+    const same = await fetch(`${url}/api/state`);
+    assert.equal(same.status, 200);
+  } finally { server.close(); }
+});

--- a/server/test/state.test.js
+++ b/server/test/state.test.js
@@ -1,0 +1,66 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+import { normalise } from '../src/state.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const states = JSON.parse(
+  readFileSync(join(__dirname, '..', 'fixtures', 'ha_states.json'), 'utf8'),
+);
+
+test('returns null when nothing is playing', () => {
+  const idle = states.map(s => ({ ...s, state: 'idle' }));
+  assert.equal(normalise(idle, { plexUsername: 'rusty' }), null);
+});
+
+test('pins to plexPlayer when configured', () => {
+  const r = normalise(states, { plexPlayer: 'media_player.plex_plex_for_lg_tv' });
+  assert.equal(r.title, 'Pilot');
+  assert.equal(r.seriesTitle, 'Severance');
+  assert.equal(r.ratingKey, '12345');
+  assert.equal(r.state, 'playing');
+  // Artwork should be rewritten to our same-origin proxy
+  assert.ok(r.artwork.startsWith('/api/artwork?path='));
+  assert.ok(r.artwork.includes(encodeURIComponent('/api/media_player_proxy/media_player.plex_plex_for_lg_tv')));
+});
+
+test('absolute artwork URLs are left alone', () => {
+  const withAbs = [{
+    entity_id: 'media_player.plex_plex_for_lg_tv',
+    state: 'playing',
+    attributes: {
+      media_title: 'x',
+      entity_picture: 'https://cdn.example/poster.jpg',
+    },
+  }];
+  const r = normalise(withAbs, { plexPlayer: 'media_player.plex_plex_for_lg_tv' });
+  assert.equal(r.artwork, 'https://cdn.example/poster.jpg');
+});
+
+test('pinned player that is idle returns null', () => {
+  const r = normalise(states, { plexPlayer: 'media_player.plex_plex_for_ios_iphone' });
+  assert.equal(r, null);
+});
+
+test('falls back to user-filtered active players when no plexPlayer', () => {
+  const r = normalise(states, { plexUsername: 'rusty' });
+  assert.ok(r, 'should find an active player for rusty');
+  // Both LG TV and Android TV are rusty's — either is acceptable; assert shape.
+  assert.ok(['Pilot', 'Dune: Part Two'].includes(r.title));
+});
+
+test('username mismatch filters the player out', () => {
+  const r = normalise(states, { plexUsername: 'nobody' });
+  // No matching user and no plex_for_* generic match → null.
+  // (LG TV / Android TV both have usernames so fall through the generic branch.)
+  assert.equal(r, null);
+});
+
+test('handles non-array input defensively', () => {
+  assert.equal(normalise(null), null);
+  assert.equal(normalise(undefined), null);
+  assert.equal(normalise({}), null);
+});

--- a/www/now_showing.html
+++ b/www/now_showing.html
@@ -848,6 +848,28 @@
     const LANDSCAPE_MODE = readBool('landscape', runtimeConfig.landscape === true);
     const POLL_INTERVAL  = readInt('poll', 5000);
 
+    // ===== SERVER MODE DETECTION =====
+    //
+    // When the HTML is served by the unified add-on / Docker server (#addon-1)
+    // we use /api/state and /api/media-info/:ratingKey — tokens stay server-side.
+    //
+    // When served from HA's /local/ (HACS-only install), those endpoints 404
+    // and we fall back to the original direct-to-HA path. Detection is a
+    // one-shot probe against /api on the current origin.
+    let SERVER_MODE = false;
+    const serverModeReady = (async () => {
+      try {
+        const resp = await fetch(`${window.location.origin}/api`, { cache: 'no-store' });
+        if (!resp.ok) return false;
+        const body = await resp.json();
+        SERVER_MODE = body && body.name === 'plex-now-showing-server';
+        if (SERVER_MODE) console.info('[plex-now-showing] Running against unified server — using /api/state proxy.');
+        return SERVER_MODE;
+      } catch (_) {
+        return false;
+      }
+    })();
+
     // ===== SETUP PAGE CONTROLLER (#setup) =====
     //
     // Handles the first-run setup form, the gear icon on the live display,
@@ -1048,8 +1070,27 @@
 
     // Fetch media file info from Plex API
     async function fetchPlexMediaInfo(ratingKey) {
-      if (!PLEX_URL || !PLEX_TOKEN || !ratingKey) return null;
+      if (!ratingKey) return null;
       if (cachedMediaInfo[ratingKey]) return cachedMediaInfo[ratingKey];
+
+      // Unified-server path: the server already shaped the response, so just
+      // return it straight. No token needed client-side.
+      await serverModeReady;
+      if (SERVER_MODE) {
+        try {
+          const resp = await fetch(`/api/media-info/${encodeURIComponent(ratingKey)}`);
+          if (!resp.ok) return null;
+          const info = await resp.json();
+          cachedMediaInfo[ratingKey] = info;
+          return info;
+        } catch (err) {
+          console.warn('Server media-info fetch error:', err);
+          return null;
+        }
+      }
+
+      // HACS-only path: original direct-to-Plex behaviour.
+      if (!PLEX_URL || !PLEX_TOKEN) return null;
       try {
         const resp = await fetch(`${PLEX_URL}/library/metadata/${ratingKey}?X-Plex-Token=${PLEX_TOKEN}`, {
           headers: { 'Accept': 'application/json' }
@@ -1247,6 +1288,20 @@
 
     // ===== FETCH PLEX DATA FROM HA =====
     async function fetchPlexData() {
+      // Unified-server path: /api/state is already normalised.
+      await serverModeReady;
+      if (SERVER_MODE) {
+        try {
+          const resp = await fetch('/api/state');
+          if (!resp.ok) return null;
+          return await resp.json();  // null when nothing is playing
+        } catch (err) {
+          console.warn('Server state fetch error:', err);
+          return null;
+        }
+      }
+
+      // HACS-only path: original direct-to-HA behaviour.
       try {
         const resp = await fetch(`${HA_URL}/api/states`, {
           headers: {


### PR DESCRIPTION
Closes #43 (addon-1).

This lands the shared runtime that both the HA add-on wrapper (#44) and the Docker Compose example (#46) will sit on top of. HACS-only installs continue to work unchanged — the server is opt-in.

## What's in `server/`

- **Express app**, Node 20+, `type: module`, `express` is the only runtime dep
- **Dual-mode config** (`src/config.js`)
  - **Add-on mode**: auto-detected via `SUPERVISOR_TOKEN` → talks to `http://supervisor/core` with no user-created HA token
  - **Standalone mode**: `HA_URL` + `HA_TOKEN` for HA Container / plain Docker users
- **Endpoints**
  - `GET /api/state` — normalised now-playing payload, 3 s TTL cache, smooths multi-tablet polling
  - `GET /api/media-info/:ratingKey` — Plex metadata for the info panel, 10 min TTL cache
  - `GET /api/artwork?path=...` — pipes `entity_picture` through so the browser can render artwork same-origin without an HA token
  - `GET /healthz` — liveness probe (doesn't touch upstream)
  - `GET /api` — version + mode + endpoint list
- **Defensive `ratingKey` parsing** handles bare ids, `/library/metadata/N`, and `plex://` GUIDs — closes the #arch-4 bonus
- **Optional hardening**: `PROXY_SECRET` (header) + `ALLOWED_ORIGINS` (allowlist) on `/api/*` — replaces the old closed #4
- **Multi-stage Alpine Dockerfile** with `dumb-init` + `HEALTHCHECK`, drops to an unprivileged user, trims dev deps out of the final layer

## What changed in `www/now_showing.html`

The HTML now auto-detects server mode via a one-shot probe of `/api` on its own origin.

- **Server mode** → uses `/api/state` + `/api/media-info/:ratingKey`. No tokens in the browser.
- **Not server mode** → identical direct-to-HA path to what ships today. HACS-only installs behave exactly as before.

## Tests

30 offline tests (`node:test`), no network required:

```
tests 30
pass  30
fail  0
```

Coverage:
- `config.test.js` — mode detection, validation, trailing-slash handling, ALLOWED_ORIGINS parsing, TTL defaults
- `cache.test.js` — TTL expiry, invalidate all / by key
- `state.test.js` — plexPlayer pinning, user filtering, artwork rewrite (relative → proxy, absolute → untouched), defensive input handling
- `plex.test.js` — ratingKey parsing for all 4 input shapes, Plex metadata mapping, missing/non-ok fallback
- `routes.test.js` — end-to-end Express app with stub HA client; covers `/api/state`, `/healthz`, HA 502 handling, `PROXY_SECRET` middleware, `ALLOWED_ORIGINS` middleware

## Local dev

```bash
cd server
npm install
HA_URL=http://192.168.1.10:8123 HA_TOKEN=... npm run dev
# http://localhost:8099/now_showing.html
npm test
```

## Next

- #44 (addon-2): HA add-on wrapper (`config.yaml`, `Dockerfile`, `run.sh`) on top of this image
- #46 (addon-4): Docker Compose example publishing the same image to GHCR (#45)
