### PR TITLE
[addon-2] Home Assistant add-on wrapper (ingress, bashio, multi-arch)

### DIFF
--- a/addons/plex-now-showing/CHANGELOG.md
+++ b/addons/plex-now-showing/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+All notable changes to the Plex Now Showing add-on will be documented here.
+The project follows [Semantic Versioning](https://semver.org/).
+
+## 0.1.0 — Unreleased
+
+### Added
+- Initial add-on wrapper for the unified Node 20 server (closes #44).
+- Ingress support (`ingress: true`, entry `/now_showing.html`).
+- User options for Plex URL/token/username/player, theme, landscape, poll
+  interval, cache TTLs, proxy secret, and origin allowlist.
+- Multi-arch Dockerfile (`amd64`, `aarch64`, `armv7`, `armhf`, `i386`).
+- s6-overlay service that forwards `/data/options.json` → env and runs
+  `node src/server.js`.
+- HEALTHCHECK against `/healthz` so Supervisor can detect a stuck process.

--- a/addons/plex-now-showing/DOCS.md
+++ b/addons/plex-now-showing/DOCS.md
@@ -1,0 +1,71 @@
+# Plex Now Showing — Add-on Documentation
+
+## How it runs
+
+This add-on runs the unified Node 20 server in **add-on mode**: it reads
+`SUPERVISOR_TOKEN` from the environment and talks to HA at
+`http://supervisor/core`. You don't need to create a long-lived access token.
+
+The kiosk HTML auto-detects it's running against the server (via a one-shot
+probe of `/api`) and switches to `/api/state` + `/api/media-info`, so Plex
+and HA tokens never leave the add-on.
+
+## How to open the kiosk
+
+- **Inside HA frontend** → click **Open Web UI** on the add-on page (Ingress).
+- **On a standalone tablet / Fully Kiosk** → `http://<ha-ip>:8099/now_showing.html`.
+  The `8099/tcp` port mapping is on by default; leave it empty in **Network**
+  if you only ever want Ingress.
+
+## Options
+
+| Option | Default | Purpose |
+|--------|---------|---------|
+| `plex_url` | _empty_ | e.g. `https://plex.example.com:32400`. Needed for the info panel. |
+| `plex_token` | _empty_ | Plex `X-Plex-Token`. Required together with `plex_url`. |
+| `plex_username` | _empty_ | Filter `media_player.plex_*` entities to your username. |
+| `plex_player` | _empty_ | Pin to one entity id, e.g. `media_player.plex_plex_for_lg_tv`. Takes priority over `plex_username`. |
+| `landscape` | `false` | Forces landscape layout on portrait tablets. |
+| `theme` | `classic-gold` | Visual theme. |
+| `poll_interval` | `5000` | Kiosk poll interval (ms). |
+| `state_ttl_ms` | `3000` | Server-side cache for `/api/state`. Smooths multi-tablet polls. |
+| `media_info_ttl_ms` | `600000` | Server-side cache for `/api/media-info/:ratingKey`. |
+| `proxy_secret` | _empty_ | If set, requests to `/api/*` must carry `X-Proxy-Secret`. |
+| `allowed_origins` | `[]` | Comma-joined allowlist for the `Origin` header on `/api/*`. Leave empty for Ingress-only. |
+| `log_level` | `info` | s6 / add-on log verbosity. |
+
+### Where to get `plex_token`
+
+Follow the [official Plex guide](https://support.plex.tv/articles/204059436-finding-an-authentication-token-x-plex-token/).
+It's stored only in the add-on's `/data/options.json` and never reaches the
+browser.
+
+### Multi-tablet installs
+
+Leave `proxy_secret` and `allowed_origins` empty for LAN-only use; Ingress
+already authenticates through HA. If you expose `8099/tcp` externally, set
+both — the server refuses non-matching requests.
+
+## Kiosk setup (Fully Kiosk)
+
+1. URL to load → `http://<ha-ip>:8099/now_showing.html`
+2. Enable "Keep screen on" + "Auto-reload on error"
+3. Optional: pair with the Blueprint (#47 / PR #51) or the built-in
+   Fully Kiosk auto-switcher (#48, landing in a later PR) so the tablet only
+   shows the UI when Plex is playing.
+
+## Troubleshooting
+
+- **Web UI is blank / `/api/state` returns 502** — HA API is unreachable.
+  Check the add-on log for `HA /api/states returned ...`. Supervisor sets
+  `SUPERVISOR_TOKEN` automatically; this usually only breaks if HA itself is
+  restarting.
+- **Info panel missing codec / HDR info** — `plex_url` + `plex_token` are
+  required. Without them the server returns `503 plex_not_configured` from
+  `/api/media-info/:ratingKey` and the HTML falls back to the bare player
+  attributes it already had.
+- **Artwork doesn't load** — check that the HA `media_player.plex_*` entity
+  has `entity_picture`. If it's a remote URL the server passes it through
+  untouched; if it's HA-relative the server serves it via `/api/artwork`.
+- **I want to use this without the add-on** — either run the Docker Compose
+  example (#46) or use the HACS frontend-only path (path C in `DEV_README.md`).

--- a/addons/plex-now-showing/Dockerfile
+++ b/addons/plex-now-showing/Dockerfile
@@ -1,0 +1,58 @@
+# Home Assistant add-on image for Plex Now Showing.
+#
+# Uses HA's official Alpine base so we inherit their s6-overlay, bashio, and
+# ffmpeg-free slim image. Node 20 is installed from Alpine's repository
+# (nodejs-current would be newer; nodejs 20.x is LTS and matches the server's
+# engines field).
+#
+# The build context is the REPO ROOT (not this directory) so we can COPY both
+# ../../server and ../../www in. The GitHub Actions workflow in #addon-3
+# invokes `docker build --file addons/plex-now-showing/Dockerfile .` from the
+# repo root; local builds should do the same.
+
+ARG BUILD_FROM=ghcr.io/hassio-addons/base:16.0.1
+FROM ${BUILD_FROM}
+
+ARG BUILD_ARCH
+ARG BUILD_VERSION
+
+ENV LANG=C.UTF-8 \
+    NODE_ENV=production \
+    PORT=8099 \
+    STATIC_DIR=/app/www
+
+# ---- Node 20 + tini (s6-overlay already runs PID 1, tini not needed) ----
+RUN apk add --no-cache nodejs=~20 npm=~10
+
+WORKDIR /app
+
+# ---- Install runtime deps only ----
+COPY server/package.json server/package-lock.json ./
+RUN npm ci --omit=dev --no-audit --no-fund \
+    && npm cache clean --force
+
+# ---- App code ----
+COPY server/src ./src
+COPY www ./www
+
+# ---- s6 service: run.sh is the long-running process ----
+COPY addons/plex-now-showing/rootfs/etc/services.d/plex-now-showing/run /etc/services.d/plex-now-showing/run
+COPY addons/plex-now-showing/rootfs/etc/services.d/plex-now-showing/finish /etc/services.d/plex-now-showing/finish
+RUN chmod +x /etc/services.d/plex-now-showing/run \
+             /etc/services.d/plex-now-showing/finish
+
+# ---- Labels (add-on store + OCI) ----
+LABEL \
+  io.hass.name="Plex Now Showing" \
+  io.hass.description="Cinema-style now-playing kiosk for Plex" \
+  io.hass.arch="${BUILD_ARCH}" \
+  io.hass.type="addon" \
+  io.hass.version="${BUILD_VERSION}" \
+  maintainer="rusty4444" \
+  org.opencontainers.image.title="Plex Now Showing add-on" \
+  org.opencontainers.image.description="HA add-on that serves the Plex Now Showing kiosk and proxies HA/Plex" \
+  org.opencontainers.image.source="https://github.com/rusty4444/plex-now-showing" \
+  org.opencontainers.image.licenses="MIT"
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=3 \
+  CMD wget -qO- http://127.0.0.1:8099/healthz >/dev/null || exit 1

--- a/addons/plex-now-showing/README.md
+++ b/addons/plex-now-showing/README.md
@@ -1,0 +1,33 @@
+# Plex Now Showing — Home Assistant Add-on
+
+Cinema-style now-playing kiosk for Plex, installed straight from the Home
+Assistant add-on store. One click, no long-lived access token, no Docker
+command line.
+
+## What this is
+
+This add-on wraps the unified Node 20 server (`../../server/`) and serves:
+
+- `/now_showing.html` — the kiosk UI (opens via Ingress or on port `8099`)
+- `/api/state` — normalised now-playing payload (no HA token in the browser)
+- `/api/media-info/:ratingKey` — Plex metadata proxy
+- `/api/artwork` — same-origin artwork proxy
+- `/healthz` — liveness probe
+
+Supervisor injects `SUPERVISOR_TOKEN`, so the add-on talks to Home Assistant
+at `http://supervisor/core` with **no user-created HA token required**.
+
+## Installation
+
+Once this repository is published as a Home Assistant add-on repository
+(tracked in #45), adding it is:
+
+1. Settings → Add-ons → Add-on store → **⋮** → **Repositories**
+2. Paste `https://github.com/rusty4444/plex-now-showing`
+3. Install **Plex Now Showing**
+4. Start it, then click **Open Web UI**
+
+## Documentation
+
+Full option reference lives in [`DOCS.md`](./DOCS.md). HA renders it on the
+add-on's **Documentation** tab.

--- a/addons/plex-now-showing/config.yaml
+++ b/addons/plex-now-showing/config.yaml
@@ -1,0 +1,69 @@
+---
+# Home Assistant add-on manifest for Plex Now Showing (V2).
+#
+# Wraps the unified Node 20 server (../server/) so HA OS / Supervised users
+# install this with one click from the add-on store. No user-created long-
+# lived access token is needed: Supervisor injects SUPERVISOR_TOKEN and the
+# HA API is reachable at http://supervisor/core.
+#
+# Docs on each field: https://developers.home-assistant.io/docs/add-ons/configuration
+
+name: Plex Now Showing
+version: "0.1.0"
+slug: plex_now_showing
+description: Cinema-style now-playing kiosk for Plex, served directly from Home Assistant.
+url: https://github.com/rusty4444/plex-now-showing
+arch:
+  - amd64
+  - aarch64
+  - armv7
+  - armhf
+  - i386
+startup: services
+boot: auto
+init: false
+hassio_api: true
+homeassistant_api: true
+auth_api: false
+ingress: true
+ingress_port: 8099
+ingress_entry: /now_showing.html
+panel_icon: mdi:theater
+panel_title: Now Showing
+ports:
+  # Direct access for Fully Kiosk / other tablets that can't use ingress.
+  # Leaving it empty in options.json disables the host port; users only need
+  # this exposed if they browse from outside the HA frontend.
+  8099/tcp: 8099
+ports_description:
+  8099/tcp: Direct HTTP access for external kiosks (leave empty to disable)
+map:
+  - ssl
+options:
+  plex_url: ""
+  plex_token: ""
+  plex_username: ""
+  plex_player: ""
+  landscape: false
+  theme: classic-gold
+  poll_interval: 5000
+  state_ttl_ms: 3000
+  media_info_ttl_ms: 600000
+  proxy_secret: ""
+  allowed_origins: []
+  log_level: info
+schema:
+  plex_url: "str?"
+  plex_token: "password?"
+  plex_username: "str?"
+  plex_player: "str?"
+  landscape: "bool"
+  theme: "list(classic-gold|midnight|neon|minimal|custom)?"
+  poll_interval: "int(1000,60000)"
+  state_ttl_ms: "int(500,30000)"
+  media_info_ttl_ms: "int(10000,3600000)"
+  proxy_secret: "password?"
+  allowed_origins:
+    - "url?"
+  log_level: "list(trace|debug|info|notice|warning|error|fatal)?"
+image: ghcr.io/rusty4444/plex-now-showing-{arch}

--- a/addons/plex-now-showing/rootfs/etc/services.d/plex-now-showing/finish
+++ b/addons/plex-now-showing/rootfs/etc/services.d/plex-now-showing/finish
@@ -1,0 +1,6 @@
+#!/command/execlineb -S0
+# ==============================================================================
+# If the Node server exits, bring the add-on down — Supervisor will restart
+# it. We don't want s6 to keep trying to relaunch a broken binary forever.
+# ==============================================================================
+s6-svscanctl -t /var/run/s6/services

--- a/addons/plex-now-showing/rootfs/etc/services.d/plex-now-showing/run
+++ b/addons/plex-now-showing/rootfs/etc/services.d/plex-now-showing/run
@@ -1,0 +1,61 @@
+#!/usr/bin/with-contenv bashio
+# shellcheck shell=bash
+# ==============================================================================
+# Plex Now Showing add-on — service runner.
+#
+# Reads /data/options.json via bashio and forwards each option into the
+# environment the Node server expects (see server/src/config.js for the
+# authoritative list).
+# ==============================================================================
+
+set -e
+
+bashio::log.info "Starting Plex Now Showing server..."
+
+# ---- Home Assistant API (add-on mode) ----
+# SUPERVISOR_TOKEN is injected by Supervisor when hassio_api / homeassistant_api
+# are true in config.yaml — the server will auto-detect add-on mode.
+export HA_URL="http://supervisor/core"
+export HA_TOKEN="${SUPERVISOR_TOKEN}"
+
+# Helper: export $1 from bashio config key $2. Assign then export (avoids
+# masking the return value, which "export FOO=$(cmd)" does silently).
+export_opt() {
+  local _val
+  _val="$(bashio::config "$2")"
+  export "$1=${_val}"
+}
+
+# ---- User options → env ----
+export_opt PLEX_URL          plex_url
+export_opt PLEX_TOKEN        plex_token
+export_opt PLEX_USERNAME     plex_username
+export_opt PLEX_PLAYER       plex_player
+export_opt LANDSCAPE         landscape
+export_opt THEME             theme
+export_opt POLL              poll_interval
+export_opt STATE_TTL_MS      state_ttl_ms
+export_opt MEDIA_INFO_TTL_MS media_info_ttl_ms
+export_opt PROXY_SECRET      proxy_secret
+
+# allowed_origins is a list → join with commas for the server's parser.
+if bashio::config.has_value 'allowed_origins'; then
+  ALLOWED_ORIGINS="$(bashio::config 'allowed_origins | join(",")')"
+  export ALLOWED_ORIGINS
+fi
+
+# ---- Diagnostics (no secrets) ----
+bashio::log.info "Plex URL configured:      $([[ -n "${PLEX_URL}"   ]] && echo yes || echo no)"
+bashio::log.info "Plex token configured:    $([[ -n "${PLEX_TOKEN}" ]] && echo yes || echo no)"
+bashio::log.info "Pinned player:            ${PLEX_PLAYER:-<none, using username filter>}"
+bashio::log.info "Plex username:            ${PLEX_USERNAME:-<none>}"
+bashio::log.info "Landscape mode:           ${LANDSCAPE}"
+bashio::log.info "Theme:                    ${THEME}"
+bashio::log.info "Poll interval (ms):       ${POLL}"
+bashio::log.info "State cache TTL (ms):     ${STATE_TTL_MS}"
+bashio::log.info "Media-info cache TTL (ms):${MEDIA_INFO_TTL_MS}"
+bashio::log.info "Proxy secret:             $([[ -n "${PROXY_SECRET}" ]] && echo set || echo unset)"
+bashio::log.info "Allowed origins:          ${ALLOWED_ORIGINS:-<any (ingress-only)>}"
+
+cd /app
+exec node src/server.js

--- a/addons/plex-now-showing/translations/en.yaml
+++ b/addons/plex-now-showing/translations/en.yaml
@@ -1,0 +1,55 @@
+---
+# Translations for the Options tab in the HA add-on UI.
+# Keys match fields in config.yaml's `options:` / `schema:` blocks.
+configuration:
+  plex_url:
+    name: Plex URL
+    description: >-
+      Base URL of your Plex server, e.g. https://plex.example.com:32400. Needed
+      for the info panel (resolution, HDR, codecs, audio). Leave empty to skip.
+  plex_token:
+    name: Plex token
+    description: >-
+      Plex X-Plex-Token. Stored only in the add-on; never sent to the browser.
+  plex_username:
+    name: Plex username
+    description: >-
+      Filters which media_player.plex_* entities count as "yours" when no
+      specific player is pinned.
+  plex_player:
+    name: Pinned Plex player
+    description: >-
+      Entity id to pin, e.g. media_player.plex_plex_for_lg_tv. Takes priority
+      over username filtering.
+  landscape:
+    name: Landscape mode
+    description: Force the kiosk layout into landscape regardless of orientation.
+  theme:
+    name: Theme
+    description: Visual theme. "custom" lets your own CSS overrides take over.
+  poll_interval:
+    name: Poll interval (ms)
+    description: How often each kiosk asks the server for updated state.
+  state_ttl_ms:
+    name: State cache TTL (ms)
+    description: >-
+      Server-side cache window for /api/state. Smooths bursty polling when
+      multiple kiosks are connected.
+  media_info_ttl_ms:
+    name: Media-info cache TTL (ms)
+    description: Server-side cache window for /api/media-info/:ratingKey.
+  proxy_secret:
+    name: Proxy secret (optional)
+    description: >-
+      If set, requests to /api/* must include the header X-Proxy-Secret with
+      this value. Leave empty for Ingress-only use.
+  allowed_origins:
+    name: Allowed origins (optional)
+    description: >-
+      Allowlist for the Origin header on /api/*. One URL per line, e.g.
+      http://tablet.lan:8099. Leave empty for Ingress-only use.
+  log_level:
+    name: Log level
+    description: Verbosity of the add-on log.
+network:
+  8099/tcp: Direct HTTP access for external kiosks. Leave empty to disable.

--- a/repository.yaml
+++ b/repository.yaml
@@ -1,0 +1,6 @@
+---
+# Home Assistant add-on repository manifest.
+# Users add this repo's URL in Settings → Add-ons → Add-on store → Repositories.
+name: Plex Now Showing
+url: https://github.com/rusty4444/plex-now-showing
+maintainer: rusty4444 <samrussellmobile@gmail.com>


### PR DESCRIPTION
Closes #44 (addon-2).

> **Depends on #52** — the Dockerfile `COPY`s from `server/` and `www/`. Either merge #52 first, or merge both together.

## Layout

Standard Home Assistant add-on repository layout:

```
repository.yaml                           <- HA custom-repo manifest (#45 prep)
addons/plex-now-showing/
  config.yaml                             <- add-on manifest
  Dockerfile                              <- builds on hassio-addons/base + node 20
  rootfs/etc/services.d/plex-now-showing/
    run                                   <- s6 service (bashio)
    finish                                <- brings the add-on down on crash
  translations/en.yaml                    <- labels for the Options tab
  README.md  DOCS.md  CHANGELOG.md
```

## Highlights

- **Ingress** is on (`ingress: true`, entry `/now_showing.html`, port `8099`). The **Open Web UI** button just works. `8099/tcp` is also mapped for Fully Kiosk / external tablets.
- **No user-created HA token**: `hassio_api: true` + `homeassistant_api: true` → Supervisor injects `SUPERVISOR_TOKEN`, and the server's `loadConfig()` (from #52) auto-detects add-on mode.
- **Options → env** via a small bashio helper. Every field in `options:` / `schema:` maps 1:1 to a documented server env var. `allowed_origins` is a list in the UI and gets joined to CSV on the way out so the server's existing parser sees it straight away.
- **`run` script is shellcheck-clean** (`SC2155`-safe via a local assign + export helper).
- **Multi-arch**: `amd64`, `aarch64`, `armv7`, `armhf`, `i386`. Actual multi-arch build + push to GHCR ships in #45.
- **HEALTHCHECK** against `/healthz` so Supervisor can restart a wedged process.

## Validation

- `config.yaml` parses as YAML; `options:` and `schema:` are balanced (same 12 keys on both sides).
- `translations/en.yaml` parses; top-level keys are `configuration` and `network`, matching schema fields.
- `run` passes `shellcheck --shell=bash` with no warnings.
- `repository.yaml` parses.
- Every `COPY` path in the Dockerfile (`server/package.json`, `server/package-lock.json`, `server/src`, `www`) exists on the #52 branch.

## Manual smoke test (after #52 merges)

```bash
# From repo root:
docker build \
  --build-arg BUILD_FROM=ghcr.io/hassio-addons/base:16.0.1 \
  --build-arg BUILD_ARCH=amd64 \
  --build-arg BUILD_VERSION=0.1.0 \
  -f addons/plex-now-showing/Dockerfile \
  -t plex-now-showing-addon:dev .
```

For a real HA test: copy `addons/plex-now-showing` into `/addons/plex_now_showing/` on an HA OS box, then **Local add-ons → Install**. Everything else (#45 GHCR publish, custom repository URL) is tracked separately.

## What's next on dev

- #45 addon-3 — GitHub Actions workflow to build + push to GHCR, wire up the HA custom repo
- #46 addon-4 — Docker Compose example on top of the same image
- #48 addon-6 — built-in Fully Kiosk switcher option inside the add-on
