### PR TITLE
[addon-4] Docker Compose example for HA Container users

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ Thumbs.db
 node_modules/
 dist/
 server/node_modules/
+docker/.env

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -1,0 +1,45 @@
+# ==============================================================================
+# Plex Now Showing — environment for docker-compose.example.yml
+#
+# Copy this file to .env (same directory) and fill in the blanks. Never commit
+# your real .env — it holds tokens.
+# ==============================================================================
+
+# ---- Home Assistant (required) --------------------------------------------
+# e.g. http://192.168.1.10:8123 — no trailing slash needed.
+HA_URL=http://homeassistant.local:8123
+# Long-lived access token: HA profile → Security → Long-Lived Access Tokens.
+HA_TOKEN=
+
+# ---- Plex (optional; unlocks the codec / HDR info panel) ------------------
+# e.g. https://plex.example.com:32400
+PLEX_URL=
+# X-Plex-Token — see https://support.plex.tv/articles/204059436
+PLEX_TOKEN=
+# Filter which media_player.plex_* entities count as "yours".
+PLEX_USERNAME=
+# Or pin to one entity (takes priority over username filter).
+PLEX_PLAYER=
+
+# ---- Display / behaviour --------------------------------------------------
+LANDSCAPE=false
+THEME=classic-gold
+POLL=5000
+STATE_TTL_MS=3000
+MEDIA_INFO_TTL_MS=600000
+
+# ---- Optional hardening (set both if exposing the port beyond your LAN) ---
+# Every /api/* request must carry header X-Proxy-Secret: <value>.
+PROXY_SECRET=
+# Comma-separated allowlist for the Origin header on /api/*, e.g.
+# ALLOWED_ORIGINS=http://kiosk1.lan:8099,http://kiosk2.lan:8099
+ALLOWED_ORIGINS=
+
+# ---- Image selection ------------------------------------------------------
+# Override ARCH if you're on an aarch64 / armv7 / armhf / i386 host.
+ARCH=amd64
+# TAG=latest (stable release), :dev (rolling), or a pinned :X.Y.Z.
+TAG=latest
+
+# Host port to expose the kiosk on.
+HOST_PORT=8099

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,68 @@
+# Plex Now Showing — Docker Compose install
+
+For **HA Container** users (or anyone on plain Docker). Same image as the HA
+add-on, just self-hosted. If you're on HA OS or Supervised, use the add-on
+instead — it's one click and doesn't need an HA token.
+
+## Quick start
+
+```bash
+cd docker
+cp .env.example .env
+$EDITOR .env                             # fill HA_URL / HA_TOKEN
+docker compose -f docker-compose.example.yml up -d
+```
+
+Open <http://HOST:8099/now_showing.html>.
+
+## Checking health
+
+```bash
+curl http://localhost:8099/healthz        # liveness
+curl http://localhost:8099/api            # mode + version + endpoints
+curl http://localhost:8099/api/state      # current payload
+```
+
+## Updating
+
+```bash
+docker compose -f docker-compose.example.yml pull
+docker compose -f docker-compose.example.yml up -d
+```
+
+Pin `TAG=0.1.0` in `.env` to stay on a specific release instead of `latest`.
+
+## Colocating with Home Assistant Container
+
+If your HA Container runs on the same Docker host, join its network so the
+server can reach HA as `http://homeassistant:8123`:
+
+1. In `docker-compose.example.yml`, uncomment both the service-level
+   `networks:` and the top-level `networks:` block.
+2. Confirm your HA network is called `homeassistant` (or edit accordingly):
+   ```bash
+   docker network ls | grep home
+   ```
+3. In `.env`, set `HA_URL=http://homeassistant:8123`.
+
+## Exposing to the LAN
+
+The defaults bind `HOST_PORT=8099` on all interfaces. If you publish beyond
+your LAN, set **both**:
+
+- `PROXY_SECRET` → every `/api/*` request must carry `X-Proxy-Secret: <value>`.
+  The kiosk HTML injects it when running against the server.
+- `ALLOWED_ORIGINS` → comma-separated list of tablet origins, e.g.
+  `http://kiosk1.lan:8099,http://kiosk2.lan:8099`.
+
+## Why not run a separate reverse proxy?
+
+You can — any nginx/Caddy/Traefik in front of `8099` works. The server's
+built-in hardening (shared secret + origin allowlist) is there so the simple
+case stays simple; the reverse-proxy case still works the same way.
+
+## Where's the image published?
+
+`ghcr.io/rusty4444/plex-now-showing-{arch}` — same registry the HA add-on
+uses. See the [CI workflow](../.github/workflows/build-addon.yml) for the
+full tag matrix.

--- a/docker/docker-compose.example.yml
+++ b/docker/docker-compose.example.yml
@@ -1,0 +1,65 @@
+# =============================================================================
+# Plex Now Showing — Docker Compose example (install path B, HA Container).
+#
+# For folks running Home Assistant Container (plain Docker) rather than HA OS
+# or Supervised. Same image as the HA add-on, just without Supervisor; you
+# provide HA_URL + HA_TOKEN yourself.
+#
+# Quick start:
+#   cp .env.example .env
+#   $EDITOR .env                 # fill HA_URL / HA_TOKEN (and optionally PLEX_*)
+#   docker compose -f docker-compose.example.yml up -d
+#   open http://<this-host>:8099/now_showing.html
+#
+# The image comes from the same GHCR publish as the HA add-on (#45) so you're
+# never more than one `docker compose pull` behind.
+# =============================================================================
+
+services:
+  plex-now-showing:
+    image: ghcr.io/rusty4444/plex-now-showing-${ARCH:-amd64}:${TAG:-latest}
+    container_name: plex-now-showing
+    restart: unless-stopped
+
+    # If you want to colocate with HA Container on the same docker network
+    # and reach it as `http://homeassistant:8123`, uncomment and adjust:
+    # networks:
+    #   - homeassistant
+
+    ports:
+      - "${HOST_PORT:-8099}:8099"
+
+    environment:
+      # ---- Home Assistant (required) ----
+      HA_URL: "${HA_URL}"
+      HA_TOKEN: "${HA_TOKEN}"
+
+      # ---- Plex (optional; needed for codec/HDR info panel) ----
+      PLEX_URL: "${PLEX_URL:-}"
+      PLEX_TOKEN: "${PLEX_TOKEN:-}"
+      PLEX_USERNAME: "${PLEX_USERNAME:-}"
+      PLEX_PLAYER: "${PLEX_PLAYER:-}"
+
+      # ---- Display / behaviour ----
+      LANDSCAPE: "${LANDSCAPE:-false}"
+      THEME: "${THEME:-classic-gold}"
+      POLL: "${POLL:-5000}"
+      STATE_TTL_MS: "${STATE_TTL_MS:-3000}"
+      MEDIA_INFO_TTL_MS: "${MEDIA_INFO_TTL_MS:-600000}"
+
+      # ---- Optional hardening (recommended if exposed off-LAN) ----
+      PROXY_SECRET: "${PROXY_SECRET:-}"
+      ALLOWED_ORIGINS: "${ALLOWED_ORIGINS:-}"
+
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:8099/healthz >/dev/null || exit 1"]
+      interval: 30s
+      timeout: 5s
+      start_period: 15s
+      retries: 3
+
+# Uncomment alongside the `networks:` block on the service to join the HA
+# Container network.
+# networks:
+#   homeassistant:
+#     external: true


### PR DESCRIPTION
Closes #46 (addon-4). Docker Compose example for HA Container users, built on the same GHCR image the add-on uses.

> **Depends on #54** (publishes the image) and **#52** (the server inside the image). Merge order doesn't matter for code review — the compose file is just config and docs.

## Layout

```
docker/
  docker-compose.example.yml   <- single service, healthcheck, image + arch from .env
  .env.example                 <- every server env var documented
  README.md                    <- quick-start + update + colocation + hardening
```

## Quick start (after #54 publishes the image)

```bash
cd docker
cp .env.example .env
$EDITOR .env                   # HA_URL, HA_TOKEN, optionally PLEX_*
docker compose -f docker-compose.example.yml up -d
# http://<host>:8099/now_showing.html
```

## Highlights

- **Same image as the add-on** — `ghcr.io/rusty4444/plex-now-showing-{arch}`. HA Container users stay in lockstep with HA OS users; one `docker compose pull` upgrades.
- **Arch + tag override via `.env`** — `ARCH` defaults to `amd64`; change to `aarch64` / `armv7` / `armhf` / `i386` on other hosts. `TAG` defaults to `latest`; pin to a `:0.1.0` for reproducible installs.
- **Healthcheck** against `/healthz` so `docker compose ps` tells the truth.
- **Colocating with HA Container** — the README has a 3-step blurb for joining HA's Docker network so `HA_URL=http://homeassistant:8123` works.
- **Off-LAN hardening** — `PROXY_SECRET` + `ALLOWED_ORIGINS` are wired as optional env; the README explains when to set both.
- `.gitignore` updated so `docker/.env` never gets committed.

## Validation

- YAML parses; every env key expected by `server/src/config.js` is present in the compose file.
- No hardcoded secrets anywhere.

## What's next

- #48 addon-6 — built-in Fully Kiosk auto-switcher option inside the add-on
