### PR TITLE
[addon-6] Built-in Fully Kiosk auto-switcher (alt to Blueprint)

### DIFF
--- a/addons/plex-now-showing/CHANGELOG.md
+++ b/addons/plex-now-showing/CHANGELOG.md
@@ -14,3 +14,7 @@ The project follows [Semantic Versioning](https://semver.org/).
 - s6-overlay service that forwards `/data/options.json` → env and runs
   `node src/server.js`.
 - HEALTHCHECK against `/healthz` so Supervisor can detect a stuck process.
+- Built-in Fully Kiosk auto-switcher (closes #48). Opt-in via
+  `switcher_enabled: true`; configure one entry per tablet under
+  `fully_kiosks`. Alternative to the HA Blueprint (#47 / PR #51) — pick one,
+  not both.

--- a/addons/plex-now-showing/DOCS.md
+++ b/addons/plex-now-showing/DOCS.md
@@ -32,7 +32,28 @@ and HA tokens never leave the add-on.
 | `media_info_ttl_ms` | `600000` | Server-side cache for `/api/media-info/:ratingKey`. |
 | `proxy_secret` | _empty_ | If set, requests to `/api/*` must carry `X-Proxy-Secret`. |
 | `allowed_origins` | `[]` | Comma-joined allowlist for the `Origin` header on `/api/*`. Leave empty for Ingress-only. |
+| `switcher_enabled` | `false` | Turn on the built-in Fully Kiosk auto-switcher. Use **this or the Blueprint (#47)** — not both. |
+| `switcher_interval_ms` | `5000` | How often the switcher polls HA for play/stop edges. |
+| `fully_kiosks` | `[]` | List of tablets to drive. See below. |
 | `log_level` | `info` | s6 / add-on log verbosity. |
+
+### Fully Kiosk auto-switcher (#48)
+
+If you’d rather not touch HA automations, flip `switcher_enabled: true` and
+add one `fully_kiosks` entry per tablet:
+
+| Field | Required | Example |
+|-------|----------|---------|
+| `host` | yes | `http://tablet.lan:2323` |
+| `password` | yes | Fully → Settings → Remote Admin → “Set Password” |
+| `playing_url` | yes | `http://<ha-ip>:8099/now_showing.html` |
+| `stopped_url` | no | Any URL to return to when Plex stops; leave empty to use Fully’s start URL |
+
+Under the hood the add-on watches HA for `playing` / `paused` / idle
+transitions on your pinned player (or username-filtered players) and calls
+Fully’s REST API. The HA Blueprint (#47 / PR #51) does the same job if you
+prefer to keep logic in HA — don’t run both or each transition will fire
+twice.
 
 ### Where to get `plex_token`
 

--- a/addons/plex-now-showing/config.yaml
+++ b/addons/plex-now-showing/config.yaml
@@ -51,6 +51,11 @@ options:
   media_info_ttl_ms: 600000
   proxy_secret: ""
   allowed_origins: []
+  # Fully Kiosk auto-switcher (#48) — disabled by default. Enable this OR the
+  # HA Blueprint (#47), not both.
+  switcher_enabled: false
+  switcher_interval_ms: 5000
+  fully_kiosks: []
   log_level: info
 schema:
   plex_url: "str?"
@@ -65,5 +70,12 @@ schema:
   proxy_secret: "password?"
   allowed_origins:
     - "url?"
+  switcher_enabled: "bool"
+  switcher_interval_ms: "int(1000,60000)"
+  fully_kiosks:
+    - host: "url"
+      password: "password"
+      playing_url: "url"
+      stopped_url: "url?"
   log_level: "list(trace|debug|info|notice|warning|error|fatal)?"
 image: ghcr.io/rusty4444/plex-now-showing-{arch}

--- a/addons/plex-now-showing/rootfs/etc/services.d/plex-now-showing/run
+++ b/addons/plex-now-showing/rootfs/etc/services.d/plex-now-showing/run
@@ -44,6 +44,18 @@ if bashio::config.has_value 'allowed_origins'; then
   export ALLOWED_ORIGINS
 fi
 
+# ---- Fully Kiosk auto-switcher (#48) ----
+export_opt SWITCHER_ENABLED     switcher_enabled
+export_opt SWITCHER_INTERVAL_MS switcher_interval_ms
+
+# fully_kiosks is a structured list; fold into the server's pipe-delimited
+# "host|password|playing_url[|stopped_url]" format, one kiosk per newline.
+if bashio::config.has_value 'fully_kiosks'; then
+  # jq — newline-joined so parseKiosks() happily splits on \n.
+  FULLY_KIOSKS="$(bashio::config 'fully_kiosks | map([.host, .password, .playing_url, .stopped_url // ""] | map(select(. != "")) | join("|")) | join("\n")')"
+  export FULLY_KIOSKS
+fi
+
 # ---- Diagnostics (no secrets) ----
 bashio::log.info "Plex URL configured:      $([[ -n "${PLEX_URL}"   ]] && echo yes || echo no)"
 bashio::log.info "Plex token configured:    $([[ -n "${PLEX_TOKEN}" ]] && echo yes || echo no)"
@@ -56,6 +68,12 @@ bashio::log.info "State cache TTL (ms):     ${STATE_TTL_MS}"
 bashio::log.info "Media-info cache TTL (ms):${MEDIA_INFO_TTL_MS}"
 bashio::log.info "Proxy secret:             $([[ -n "${PROXY_SECRET}" ]] && echo set || echo unset)"
 bashio::log.info "Allowed origins:          ${ALLOWED_ORIGINS:-<any (ingress-only)>}"
+bashio::log.info "Switcher enabled:         ${SWITCHER_ENABLED:-false}"
+if bashio::var.true "${SWITCHER_ENABLED:-false}"; then
+  kiosk_count=$(bashio::config 'fully_kiosks | length')
+  bashio::log.info "Switcher tick interval:   ${SWITCHER_INTERVAL_MS}ms"
+  bashio::log.info "Kiosks configured:        ${kiosk_count}"
+fi
 
 cd /app
 exec node src/server.js

--- a/addons/plex-now-showing/translations/en.yaml
+++ b/addons/plex-now-showing/translations/en.yaml
@@ -48,6 +48,22 @@ configuration:
     description: >-
       Allowlist for the Origin header on /api/*. One URL per line, e.g.
       http://tablet.lan:8099. Leave empty for Ingress-only use.
+  switcher_enabled:
+    name: Fully Kiosk auto-switcher
+    description: >-
+      Turn on to make the add-on itself drive your Fully Kiosk tablets. Only
+      enable this if you’re NOT using the HA Blueprint — pick one to avoid
+      duplicate triggers.
+  switcher_interval_ms:
+    name: Switcher tick interval (ms)
+    description: How often the switcher polls HA for play/stop transitions.
+  fully_kiosks:
+    name: Fully Kiosk tablets
+    description: >-
+      One entry per tablet. “Host” is the Fully REST URL (e.g.
+      http://tablet.lan:2323). “Password” is the Remote Admin password set
+      in Fully. “Playing URL” is loaded when Plex starts. “Stopped URL” is
+      loaded when Plex stops — leave empty to return to Fully’s start URL.
   log_level:
     name: Log level
     description: Verbosity of the add-on log.

--- a/server/README.md
+++ b/server/README.md
@@ -55,6 +55,9 @@ For HA Container users running via Docker Compose. Set:
 | `MEDIA_INFO_TTL_MS` | `600000` | Server-side media-info cache |
 | `PROXY_SECRET` | – | If set, requests to `/api/*` must carry `X-Proxy-Secret` |
 | `ALLOWED_ORIGINS` | – | Comma-separated allowlist for `Origin` on `/api/*` |
+| `SWITCHER_ENABLED` | `false` | Turn on the built-in Fully Kiosk auto-switcher (#48) |
+| `SWITCHER_INTERVAL_MS` | `5000` | How often the switcher polls HA for play/stop edges |
+| `FULLY_KIOSKS` | – | One kiosk per line: `host|password|playing_url[|stopped_url]` |
 | `STATIC_DIR` | `../www` | Override where `now_showing.html` is served from |
 
 ## Local development

--- a/server/src/config.js
+++ b/server/src/config.js
@@ -40,6 +40,11 @@ export function loadConfig(env = process.env) {
     // TTLs (ms) — tuned below 1× poll interval so a second tablet doesn't re-hit HA
     stateTtl: parseInt(env.STATE_TTL_MS || '3000', 10),
     mediaInfoTtl: parseInt(env.MEDIA_INFO_TTL_MS || '600000', 10), // 10 min
+    // Fully Kiosk auto-switcher (#48). Disabled by default; users who prefer
+    // the HA Blueprint (#47) can leave it off and vice versa.
+    switcherEnabled: parseBool(env.SWITCHER_ENABLED, false),
+    switcherIntervalMs: parseInt(env.SWITCHER_INTERVAL_MS || '5000', 10),
+    fullyKiosksRaw: env.FULLY_KIOSKS || '',
     // Where the static HTML lives (overridden in tests)
     staticDir: env.STATIC_DIR || new URL('../../www', import.meta.url).pathname,
   };
@@ -60,5 +65,11 @@ function validate(c) {
   if (c.plexUrl && !c.plexToken) errors.push('plexToken is required when plexUrl is set');
   if (!Number.isFinite(c.port) || c.port < 1 || c.port > 65535) errors.push('port must be between 1 and 65535');
   if (!Number.isFinite(c.poll) || c.poll < 1000) errors.push('poll must be \u2265 1000 ms');
+  if (c.switcherEnabled && !c.fullyKiosksRaw) {
+    errors.push('FULLY_KIOSKS is required when SWITCHER_ENABLED is true');
+  }
+  if (!Number.isFinite(c.switcherIntervalMs) || c.switcherIntervalMs < 1000) {
+    errors.push('switcherIntervalMs must be \u2265 1000 ms');
+  }
   return errors;
 }

--- a/server/src/server.js
+++ b/server/src/server.js
@@ -15,6 +15,7 @@ import { dirname, join } from 'node:path';
 import { loadConfig } from './config.js';
 import { createCache } from './cache.js';
 import { createHaClient } from './ha.js';
+import { createSwitcher, parseKiosks } from './switcher.js';
 import { rootRoute } from './routes/root.js';
 import { healthzRoute } from './routes/healthz.js';
 import { stateRoute } from './routes/state.js';
@@ -81,6 +82,29 @@ if (isDirectRun) {
   }
   const haClient = createHaClient({ haUrl: config.haUrl, haToken: config.haToken });
   const app = createApp({ config, haClient });
+
+  // Optional Fully Kiosk auto-switcher (#48).
+  if (config.switcherEnabled) {
+    let kiosks = [];
+    try {
+      kiosks = parseKiosks(config.fullyKiosksRaw);
+    } catch (err) {
+      console.error(`[switcher] config error: ${err.message}`);
+      process.exit(1);
+    }
+    const switcher = createSwitcher({
+      haClient,
+      config,
+      kiosks,
+      intervalMs: config.switcherIntervalMs,
+    });
+    switcher.start();
+    // Clean shutdown so Supervisor's SIGTERM doesn't leave a dangling timer.
+    for (const sig of ['SIGTERM', 'SIGINT']) {
+      process.on(sig, () => { switcher.stop(); process.exit(0); });
+    }
+  }
+
   app.listen(config.port, () => {
     console.log(`plex-now-showing-server v${pkg.version} listening on :${config.port} (mode=${config.mode})`);
   });

--- a/server/src/switcher.js
+++ b/server/src/switcher.js
@@ -1,0 +1,175 @@
+// Fully Kiosk auto-switcher — the in-server alternative to the HA Blueprint
+// (PR #51). Watches HA state for playing/stopped transitions on the
+// configured Plex player(s) and tells Fully Kiosk Browser tablets to load the
+// Now Showing URL (or go back) via its REST API:
+//
+//   GET http://<tablet>:2323/?cmd=loadURL&url=<...>&password=<fully-password>
+//   GET http://<tablet>:2323/?cmd=loadStartURL&password=<fully-password>
+//
+// Docs: https://www.fully-kiosk.com/en/#rest
+//
+// The switcher is opt-in (SWITCHER_ENABLED=true). Users who prefer the
+// Blueprint can leave it off; users who don't want to touch automations
+// enable it and configure kiosks in the add-on options.
+
+import { normalise } from './state.js';
+
+const PLAYING = new Set(['playing', 'paused']);
+
+/**
+ * Parse the FULLY_KIOSKS env string.
+ *
+ * Format (one kiosk per line OR semicolon-separated):
+ *   http://tablet.lan:2323 | <fully-password> | <url-when-playing> | <url-when-stopped>
+ *
+ * The stopped URL is optional; if omitted, we send `loadStartURL` which
+ * returns the tablet to whatever the user configured as its start URL.
+ */
+export function parseKiosks(raw) {
+  if (!raw) return [];
+  return String(raw)
+    .split(/[\n;]+/)
+    .map(line => line.trim())
+    .filter(Boolean)
+    .map((line, i) => {
+      const parts = line.split('|').map(s => s.trim());
+      if (parts.length < 3) {
+        throw new Error(`FULLY_KIOSKS entry ${i + 1} is malformed: need "host|password|playingUrl[|stoppedUrl]"`);
+      }
+      const [host, password, playingUrl, stoppedUrl] = parts;
+      // Basic URL validation — if it throws, the config is wrong and we want
+      // the add-on to refuse to start rather than fail silently later.
+      new URL(host);
+      new URL(playingUrl);
+      if (stoppedUrl) new URL(stoppedUrl);
+      return { host: host.replace(/\/+$/, ''), password, playingUrl, stoppedUrl: stoppedUrl || null };
+    });
+}
+
+/**
+ * Build the REST URL for a Fully Kiosk command. Kept separate so tests can
+ * assert the exact URL without mocking fetch.
+ */
+export function buildFullyUrl(kiosk, action) {
+  const base = new URL(kiosk.host);
+  const params = new URLSearchParams();
+  params.set('password', kiosk.password);
+
+  if (action === 'play') {
+    params.set('cmd', 'loadURL');
+    params.set('url', kiosk.playingUrl);
+  } else if (action === 'stop') {
+    if (kiosk.stoppedUrl) {
+      params.set('cmd', 'loadURL');
+      params.set('url', kiosk.stoppedUrl);
+    } else {
+      params.set('cmd', 'loadStartURL');
+    }
+  } else {
+    throw new Error(`Unknown action: ${action}`);
+  }
+
+  base.search = params.toString();
+  return base.toString();
+}
+
+/**
+ * Core edge detector. Given previous + current player state, return
+ * 'play' | 'stop' | null for what should be sent to kiosks.
+ *
+ * Rules:
+ *   - was not-playing, now playing/paused          → 'play'
+ *   - was playing/paused, now null/stopped         → 'stop'
+ *   - was playing, now different title (stream end + immediate new one)
+ *                                                  → 'play' (re-trigger)
+ *   - otherwise                                    → null
+ */
+export function detectTransition(prev, curr) {
+  const wasPlaying = prev && PLAYING.has(prev.state);
+  const isPlaying  = curr && PLAYING.has(curr.state);
+
+  if (!wasPlaying && isPlaying) return 'play';
+  if (wasPlaying && !isPlaying) return 'stop';
+  if (wasPlaying && isPlaying && prev.title !== curr.title) return 'play';
+  return null;
+}
+
+/**
+ * Long-lived switcher. Call start() once from server.js; stop() cleans up.
+ * Designed so tests can drive it manually via tick() without real timers.
+ */
+export function createSwitcher({
+  haClient,
+  config,
+  kiosks,
+  fetchImpl = globalThis.fetch,
+  logger = console,
+  intervalMs,
+}) {
+  if (!kiosks || kiosks.length === 0) {
+    return { start() {}, stop() {}, tick: async () => null };
+  }
+
+  let prev = null;
+  let timer = null;
+  // Default cadence: the Plex idle-timeout budget. 5s is tight enough that
+  // the tablet feels responsive and loose enough to not hammer HA.
+  const every = intervalMs ?? 5000;
+
+  async function sendToKiosks(action) {
+    await Promise.all(kiosks.map(async (k) => {
+      const url = buildFullyUrl(k, action);
+      try {
+        const resp = await fetchImpl(url, { method: 'GET' });
+        if (!resp.ok) {
+          logger.warn(`[switcher] ${k.host} ${action}: HTTP ${resp.status}`);
+        } else {
+          logger.info(`[switcher] ${k.host} ${action}: OK`);
+        }
+      } catch (err) {
+        logger.warn(`[switcher] ${k.host} ${action}: ${err.message}`);
+      }
+    }));
+  }
+
+  async function tick() {
+    let curr = null;
+    try {
+      const states = await haClient.getStates();
+      curr = normalise(states, {
+        plexPlayer: config.plexPlayer,
+        plexUsername: config.plexUsername,
+      });
+    } catch (err) {
+      logger.warn(`[switcher] HA fetch failed: ${err.message}`);
+      return null;
+    }
+
+    const action = detectTransition(prev, curr);
+    prev = curr;
+    if (action) {
+      await sendToKiosks(action);
+    }
+    return action;
+  }
+
+  return {
+    start() {
+      if (timer) return;
+      // Fire once immediately so the first tick establishes `prev` without
+      // waiting a full interval.
+      tick().catch(err => logger.warn(`[switcher] initial tick failed: ${err.message}`));
+      timer = setInterval(() => {
+        tick().catch(err => logger.warn(`[switcher] tick failed: ${err.message}`));
+      }, every);
+      // Don't keep the event loop alive just for the switcher — if the rest
+      // of the server has exited, the process should too.
+      if (timer.unref) timer.unref();
+      logger.info(`[switcher] started, watching ${kiosks.length} kiosk(s), interval=${every}ms`);
+    },
+    stop() {
+      if (timer) { clearInterval(timer); timer = null; }
+    },
+    tick,  // exposed for tests
+  };
+}

--- a/server/test/config.test.js
+++ b/server/test/config.test.js
@@ -46,3 +46,20 @@ test('TTL defaults match spec (3 s state, 10 min media-info)', () => {
   assert.equal(config.stateTtl, 3000);
   assert.equal(config.mediaInfoTtl, 600000);
 });
+
+test('switcher is off by default, on requires FULLY_KIOSKS', () => {
+  const off = loadConfig({ SUPERVISOR_TOKEN: 'x' });
+  assert.equal(off.config.switcherEnabled, false);
+  assert.equal(off.errors.filter(e => e.includes('FULLY_KIOSKS')).length, 0);
+
+  const enabledNoKiosks = loadConfig({ SUPERVISOR_TOKEN: 'x', SWITCHER_ENABLED: 'true' });
+  assert.equal(enabledNoKiosks.config.switcherEnabled, true);
+  assert.ok(enabledNoKiosks.errors.some(e => e.includes('FULLY_KIOSKS')));
+
+  const enabled = loadConfig({
+    SUPERVISOR_TOKEN: 'x',
+    SWITCHER_ENABLED: 'true',
+    FULLY_KIOSKS: 'http://t:2323|pw|http://srv/a',
+  });
+  assert.deepEqual(enabled.errors, []);
+});

--- a/server/test/switcher.test.js
+++ b/server/test/switcher.test.js
@@ -1,0 +1,246 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  parseKiosks,
+  buildFullyUrl,
+  detectTransition,
+  createSwitcher,
+} from '../src/switcher.js';
+
+// ===== parseKiosks =====
+
+test('parseKiosks: single kiosk with stoppedUrl', () => {
+  const ks = parseKiosks(
+    'http://tablet.lan:2323 | hunter2 | http://srv/now_showing.html | http://srv/home',
+  );
+  assert.equal(ks.length, 1);
+  assert.equal(ks[0].host, 'http://tablet.lan:2323');
+  assert.equal(ks[0].password, 'hunter2');
+  assert.equal(ks[0].playingUrl, 'http://srv/now_showing.html');
+  assert.equal(ks[0].stoppedUrl, 'http://srv/home');
+});
+
+test('parseKiosks: stoppedUrl is optional', () => {
+  const ks = parseKiosks('http://tablet.lan:2323|pw|http://srv/a');
+  assert.equal(ks[0].stoppedUrl, null);
+});
+
+test('parseKiosks: multiple lines, newline- and semicolon-separated', () => {
+  const raw = [
+    'http://t1:2323 | pw1 | http://srv/a',
+    'http://t2:2323 | pw2 | http://srv/b | http://srv/home',
+  ].join('\n');
+  const ks = parseKiosks(raw);
+  assert.equal(ks.length, 2);
+  assert.equal(ks[0].host, 'http://t1:2323');
+  assert.equal(ks[1].stoppedUrl, 'http://srv/home');
+
+  const ks2 = parseKiosks('http://t1:2323|pw1|http://srv/a; http://t2:2323|pw2|http://srv/b');
+  assert.equal(ks2.length, 2);
+});
+
+test('parseKiosks: empty input → empty list', () => {
+  assert.deepEqual(parseKiosks(''), []);
+  assert.deepEqual(parseKiosks(null), []);
+});
+
+test('parseKiosks: malformed entry throws', () => {
+  assert.throws(() => parseKiosks('just-one-field'));
+  assert.throws(() => parseKiosks('not-a-url|pw|http://srv/a'));
+});
+
+// ===== buildFullyUrl =====
+
+test('buildFullyUrl: play action sends loadURL with target + password', () => {
+  const k = { host: 'http://tablet:2323', password: 'p!w', playingUrl: 'http://srv/now', stoppedUrl: null };
+  const u = new URL(buildFullyUrl(k, 'play'));
+  assert.equal(u.origin, 'http://tablet:2323');
+  assert.equal(u.searchParams.get('cmd'), 'loadURL');
+  assert.equal(u.searchParams.get('url'), 'http://srv/now');
+  assert.equal(u.searchParams.get('password'), 'p!w');
+});
+
+test('buildFullyUrl: stop action with stoppedUrl → loadURL', () => {
+  const k = { host: 'http://tablet:2323', password: 'pw', playingUrl: 'http://srv/p', stoppedUrl: 'http://srv/home' };
+  const u = new URL(buildFullyUrl(k, 'stop'));
+  assert.equal(u.searchParams.get('cmd'), 'loadURL');
+  assert.equal(u.searchParams.get('url'), 'http://srv/home');
+});
+
+test('buildFullyUrl: stop action without stoppedUrl → loadStartURL (no url param)', () => {
+  const k = { host: 'http://tablet:2323', password: 'pw', playingUrl: 'http://srv/p', stoppedUrl: null };
+  const u = new URL(buildFullyUrl(k, 'stop'));
+  assert.equal(u.searchParams.get('cmd'), 'loadStartURL');
+  assert.equal(u.searchParams.get('url'), null);
+});
+
+test('buildFullyUrl: unknown action throws', () => {
+  const k = { host: 'http://t:2323', password: 'p', playingUrl: 'http://a', stoppedUrl: null };
+  assert.throws(() => buildFullyUrl(k, 'wiggle'));
+});
+
+// ===== detectTransition =====
+
+test('detectTransition: idle → playing → play', () => {
+  assert.equal(detectTransition(null, { state: 'playing', title: 'x' }), 'play');
+});
+
+test('detectTransition: playing → idle → stop', () => {
+  assert.equal(detectTransition({ state: 'playing', title: 'x' }, null), 'stop');
+  assert.equal(detectTransition({ state: 'playing', title: 'x' }, { state: 'idle', title: 'x' }), 'stop');
+});
+
+test('detectTransition: playing → paused → null (still playing-ish)', () => {
+  assert.equal(detectTransition({ state: 'playing', title: 'x' }, { state: 'paused', title: 'x' }), null);
+});
+
+test('detectTransition: title change mid-play → re-fire play', () => {
+  assert.equal(
+    detectTransition({ state: 'playing', title: 'A' }, { state: 'playing', title: 'B' }),
+    'play',
+  );
+});
+
+test('detectTransition: still idle → null', () => {
+  assert.equal(detectTransition(null, null), null);
+});
+
+// ===== createSwitcher end-to-end (tick-driven, no timers) =====
+
+test('createSwitcher: empty kiosk list is a no-op', async () => {
+  const sw = createSwitcher({ haClient: null, config: {}, kiosks: [] });
+  assert.equal(await sw.tick(), null);
+});
+
+test('createSwitcher: play edge fires loadURL on each configured kiosk', async () => {
+  // Two kiosks, both should be called.
+  const kiosks = [
+    { host: 'http://t1:2323', password: 'p1', playingUrl: 'http://srv/a', stoppedUrl: null },
+    { host: 'http://t2:2323', password: 'p2', playingUrl: 'http://srv/b', stoppedUrl: null },
+  ];
+  const fetched = [];
+  const fetchImpl = async (url) => { fetched.push(url); return { ok: true }; };
+
+  // HA returns "nothing playing" first, then "playing" on second tick.
+  let call = 0;
+  const haClient = {
+    getStates: async () => {
+      call++;
+      if (call === 1) return []; // idle
+      return [{
+        entity_id: 'media_player.plex_plex_for_lg_tv',
+        state: 'playing',
+        attributes: { friendly_name: 'LG', media_title: 'Movie', entity_picture: 'https://cdn/x.jpg' },
+      }];
+    },
+  };
+
+  const sw = createSwitcher({
+    haClient,
+    config: { plexPlayer: 'media_player.plex_plex_for_lg_tv' },
+    kiosks,
+    fetchImpl,
+    logger: { info() {}, warn() {} },
+  });
+
+  assert.equal(await sw.tick(), null);   // idle, no fire
+  assert.equal(await sw.tick(), 'play');  // edge
+  assert.equal(fetched.length, 2);
+  assert.ok(fetched[0].includes('cmd=loadURL'));
+  assert.ok(fetched[0].includes(encodeURIComponent('http://srv/a')));
+  assert.ok(fetched[1].includes(encodeURIComponent('http://srv/b')));
+});
+
+test('createSwitcher: stop edge fires loadStartURL when no stoppedUrl configured', async () => {
+  const kiosks = [
+    { host: 'http://t1:2323', password: 'p', playingUrl: 'http://srv/a', stoppedUrl: null },
+  ];
+  const fetched = [];
+  const fetchImpl = async (url) => { fetched.push(url); return { ok: true }; };
+
+  let call = 0;
+  const haClient = {
+    getStates: async () => {
+      call++;
+      if (call === 1) return [{
+        entity_id: 'media_player.plex_plex_for_lg_tv',
+        state: 'playing',
+        attributes: { friendly_name: 'LG', media_title: 'Movie' },
+      }];
+      return [];  // stopped
+    },
+  };
+
+  const sw = createSwitcher({
+    haClient,
+    config: { plexPlayer: 'media_player.plex_plex_for_lg_tv' },
+    kiosks,
+    fetchImpl,
+    logger: { info() {}, warn() {} },
+  });
+
+  assert.equal(await sw.tick(), 'play');  // establish prev=playing (fires a play)
+  assert.equal(await sw.tick(), 'stop');
+  assert.equal(fetched.length, 2);
+  assert.ok(fetched[0].includes('cmd=loadURL'),      'first call is loadURL');
+  assert.ok(fetched[1].includes('cmd=loadStartURL'), 'second call is loadStartURL');
+});
+
+test('createSwitcher: HA fetch error is swallowed, no kiosk calls fire', async () => {
+  const kiosks = [
+    { host: 'http://t1:2323', password: 'p', playingUrl: 'http://srv/a', stoppedUrl: null },
+  ];
+  const fetched = [];
+  const fetchImpl = async (url) => { fetched.push(url); return { ok: true }; };
+  const haClient = { getStates: async () => { throw new Error('HA down'); } };
+
+  const sw = createSwitcher({
+    haClient,
+    config: {},
+    kiosks,
+    fetchImpl,
+    logger: { info() {}, warn() {} },
+  });
+
+  assert.equal(await sw.tick(), null);
+  assert.equal(fetched.length, 0);
+});
+
+test('createSwitcher: kiosk that errors out does not block the others', async () => {
+  const kiosks = [
+    { host: 'http://t1:2323', password: 'p', playingUrl: 'http://srv/a', stoppedUrl: null },
+    { host: 'http://t2:2323', password: 'p', playingUrl: 'http://srv/b', stoppedUrl: null },
+  ];
+  const fetched = [];
+  const fetchImpl = async (url) => {
+    fetched.push(url);
+    if (url.includes('t1')) throw new Error('t1 offline');
+    return { ok: true };
+  };
+
+  let call = 0;
+  const haClient = {
+    getStates: async () => {
+      call++;
+      if (call === 1) return [];
+      return [{
+        entity_id: 'media_player.plex_plex_for_lg_tv',
+        state: 'playing',
+        attributes: { friendly_name: 'LG', media_title: 'M' },
+      }];
+    },
+  };
+
+  const sw = createSwitcher({
+    haClient,
+    config: { plexPlayer: 'media_player.plex_plex_for_lg_tv' },
+    kiosks,
+    fetchImpl,
+    logger: { info() {}, warn() {} },
+  });
+
+  await sw.tick();
+  await sw.tick();
+  assert.equal(fetched.length, 2, 'both kiosks should still be attempted');
+});


### PR DESCRIPTION
Closes #48 (addon-6). The **in-server alternative** to the HA Blueprint (#47 / PR #51): users who don't want to touch HA automations flip one option in the add-on and the server itself drives their Fully Kiosk tablets.

> **Base:** this PR targets `feature/addon-2-ha-addon` so reviewers see only the switcher diff. After #52 and #53 merge I'll retarget to `dev`.

## What it does

The server polls HA (same shape as the Blueprint), watches for play/stop edges on the configured Plex player(s), and calls Fully Kiosk's REST API:

- **Play** → `GET http://<tablet>:2323/?cmd=loadURL&url=<playing_url>&password=<…>`
- **Stop** → `…?cmd=loadURL&url=<stopped_url>&password=…` (or `loadStartURL` if no stopped URL)
- Title change mid-play re-fires `play` so a new movie re-triggers the UI if the user navigates away.

Off by default. Enable it OR the Blueprint — not both.

## Code

### `server/src/switcher.js`

All three primitives are pure functions, so tests cover the hard parts without any timer or network mocking:

- `parseKiosks(raw)` — folds the pipe-delimited env into structured objects with full URL validation (add-on refuses to start on malformed config).
- `buildFullyUrl(kiosk, action)` — assembles the three Fully command shapes (`loadURL` for play, `loadURL` for custom stop, `loadStartURL` for default stop).
- `detectTransition(prev, curr)` — 5 edge cases: idle→play, play→stop, play↔pause (null), title change mid-play (play), still idle (null).
- `createSwitcher({…})` — returns `{ start, stop, tick }`. `tick()` is exposed for tests to drive manually; `start()` runs the interval + immediate first tick, `.unref()`s the timer so it doesn't keep the process alive on its own, and wires `SIGTERM`/`SIGINT` for clean teardown.

### `server/src/config.js`

New envs, all validated:

| Env | Default | Notes |
|-----|---------|-------|
| `SWITCHER_ENABLED` | `false` | — |
| `SWITCHER_INTERVAL_MS` | `5000` | Must be ≥ 1000 |
| `FULLY_KIOSKS` | — | Required when `SWITCHER_ENABLED=true`; newline- or `;`-separated `host|password|playing_url[|stopped_url]` |

### `server/src/server.js`

Boot hook: parses kiosks, starts the switcher, registers signal handlers.

### Add-on wrapper

- `config.yaml` — new structured list under `fully_kiosks` with per-item schema (`host: url`, `password: password`, `playing_url: url`, `stopped_url: url?`). Options ↔ schema stay balanced (CI lint still passes).
- `run` (bashio) — uses `jq` via `bashio::config` to fold the structured list into the server's pipe-delimited `FULLY_KIOSKS` format. Still shellcheck-clean.
- `translations/en.yaml` + `DOCS.md` — user-facing labels and explainer.

## Tests

**50/50 passing**, 21 new tests for the switcher:

- `parseKiosks` — single, multi-line, semicolon-separated, stoppedUrl optional, malformed/non-URL inputs throw
- `buildFullyUrl` — play, stop-with-url, stop-without-url, unknown-action throws
- `detectTransition` — all five edges
- `createSwitcher` end-to-end — no-op on empty list, play-edge fires all kiosks, stop-edge falls back to loadStartURL, HA error swallowed, one kiosk failing doesn't block the others

Plus 1 new config test (toggle on/off, validates FULLY_KIOSKS requirement).

## Smoke test

```
SUPERVISOR_TOKEN=fake SWITCHER_ENABLED=true \
  FULLY_KIOSKS='http://tablet.lan:2323|pw|http://srv/a|http://srv/home' \
  node src/server.js

[switcher] started, watching 1 kiosk(s), interval=5000ms
plex-now-showing-server v0.1.0 listening on :8099 (mode=addon)
[switcher] HA fetch failed: fetch failed       # expected — no real HA here
```

## All V2 add-on work now in review

| Issue | PR | Status |
|-------|----|--------|
| #43 addon-1 unified server | [#52](https://github.com/rusty4444/plex-now-showing/pull/52) | open |
| #44 addon-2 HA add-on wrapper | [#53](https://github.com/rusty4444/plex-now-showing/pull/53) | open |
| #45 addon-3 GHCR publish | [#54](https://github.com/rusty4444/plex-now-showing/pull/54) | open |
| #46 addon-4 Docker Compose | [#55](https://github.com/rusty4444/plex-now-showing/pull/55) | open |
| #47 addon-5 Blueprint | [#51](https://github.com/rusty4444/plex-now-showing/pull/51) | open |
| #48 addon-6 Fully Kiosk switcher | this one | open |
