### PR TITLE
[viz-1] Playback progress bar + visual toggle scaffolding

### DIFF
--- a/addons/plex-now-showing/CHANGELOG.md
+++ b/addons/plex-now-showing/CHANGELOG.md
@@ -18,3 +18,10 @@ The project follows [Semantic Versioning](https://semver.org/).
   `switcher_enabled: true`; configure one entry per tablet under
   `fully_kiosks`. Alternative to the HA Blueprint (#47 / PR #51) — pick one,
   not both.
+- Playback progress bar (closes #17). Opt-in via `visual_progress_bar: true`
+  — a slim gold bar along the bottom of the poster that tracks HA's
+  `media_position`, interpolated between polls for smooth motion. Freezes
+  while paused, hides when idle. Off by default; every other v2 visual
+  feature will follow the same toggle pattern.
+- Server now exposes `GET /api/config` so the browser can read runtime
+  visual toggles without a rebuild.

--- a/addons/plex-now-showing/DOCS.md
+++ b/addons/plex-now-showing/DOCS.md
@@ -35,7 +35,22 @@ and HA tokens never leave the add-on.
 | `switcher_enabled` | `false` | Turn on the built-in Fully Kiosk auto-switcher. Use **this or the Blueprint (#47)** — not both. |
 | `switcher_interval_ms` | `5000` | How often the switcher polls HA for play/stop edges. |
 | `fully_kiosks` | `[]` | List of tablets to drive. See below. |
+| `visual_progress_bar` | `false` | Slim gold progress bar along the bottom of the poster. See **Visual toggles** below. |
 | `log_level` | `info` | s6 / add-on log verbosity. |
+
+### Visual toggles (V2)
+
+Every new visual feature is **opt-in** so existing installs keep the
+original look until you choose otherwise. Toggles flow from add-on options
+through to the browser automatically — no rebuild, no per-tablet config.
+
+| Toggle | What it does |
+|--------|--------------|
+| `visual_progress_bar` | Adds a slim gold playback bar along the bottom of the poster. Tracks HA's `media_position`, interpolated between polls so it moves smoothly. Dimmed while paused, hidden while idle. |
+
+HACS-only users (no add-on / server) can flip any visual toggle per tablet
+by setting `pns.visualProgressBar=true` in `localStorage` or adding
+`#visualProgressBar=true` to the kiosk URL.
 
 ### Fully Kiosk auto-switcher (#48)
 

--- a/addons/plex-now-showing/config.yaml
+++ b/addons/plex-now-showing/config.yaml
@@ -56,6 +56,9 @@ options:
   switcher_enabled: false
   switcher_interval_ms: 5000
   fully_kiosks: []
+  # Visual toggles (V2 visual sprint). All default OFF so existing installs
+  # keep the original look until the user opts in.
+  visual_progress_bar: false
   log_level: info
 schema:
   plex_url: "str?"
@@ -77,5 +80,6 @@ schema:
       password: "password"
       playing_url: "url"
       stopped_url: "url?"
+  visual_progress_bar: "bool"
   log_level: "list(trace|debug|info|notice|warning|error|fatal)?"
 image: ghcr.io/rusty4444/plex-now-showing-{arch}

--- a/addons/plex-now-showing/rootfs/etc/services.d/plex-now-showing/run
+++ b/addons/plex-now-showing/rootfs/etc/services.d/plex-now-showing/run
@@ -56,6 +56,9 @@ if bashio::config.has_value 'fully_kiosks'; then
   export FULLY_KIOSKS
 fi
 
+# ---- Visual toggles (V2 visual sprint) ----
+export_opt VISUAL_PROGRESS_BAR visual_progress_bar
+
 # ---- Diagnostics (no secrets) ----
 bashio::log.info "Plex URL configured:      $([[ -n "${PLEX_URL}"   ]] && echo yes || echo no)"
 bashio::log.info "Plex token configured:    $([[ -n "${PLEX_TOKEN}" ]] && echo yes || echo no)"
@@ -68,6 +71,7 @@ bashio::log.info "State cache TTL (ms):     ${STATE_TTL_MS}"
 bashio::log.info "Media-info cache TTL (ms):${MEDIA_INFO_TTL_MS}"
 bashio::log.info "Proxy secret:             $([[ -n "${PROXY_SECRET}" ]] && echo set || echo unset)"
 bashio::log.info "Allowed origins:          ${ALLOWED_ORIGINS:-<any (ingress-only)>}"
+bashio::log.info "Visual progress bar:      ${VISUAL_PROGRESS_BAR:-false}"
 bashio::log.info "Switcher enabled:         ${SWITCHER_ENABLED:-false}"
 if bashio::var.true "${SWITCHER_ENABLED:-false}"; then
   kiosk_count=$(bashio::config 'fully_kiosks | length')

--- a/addons/plex-now-showing/translations/en.yaml
+++ b/addons/plex-now-showing/translations/en.yaml
@@ -64,6 +64,12 @@ configuration:
       http://tablet.lan:2323). “Password” is the Remote Admin password set
       in Fully. “Playing URL” is loaded when Plex starts. “Stopped URL” is
       loaded when Plex stops — leave empty to return to Fully’s start URL.
+  visual_progress_bar:
+    name: Show playback progress bar
+    description: >-
+      Adds a slim gold progress bar along the bottom of the poster while
+      something is playing. Freezes while paused, disappears when idle.
+      Off by default; flip on to enable.
   log_level:
     name: Log level
     description: Verbosity of the add-on log.

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -28,6 +28,11 @@ POLL=5000
 STATE_TTL_MS=3000
 MEDIA_INFO_TTL_MS=600000
 
+# ---- Visual toggles (V2 visual sprint) ------------------------------------
+# Each visual feature is opt-in. Defaults preserve the v1 look.
+# Slim gold progress bar along the bottom of the poster.
+VISUAL_PROGRESS_BAR=false
+
 # ---- Optional hardening (set both if exposing the port beyond your LAN) ---
 # Every /api/* request must carry header X-Proxy-Secret: <value>.
 PROXY_SECRET=

--- a/docker/docker-compose.example.yml
+++ b/docker/docker-compose.example.yml
@@ -47,6 +47,9 @@ services:
       STATE_TTL_MS: "${STATE_TTL_MS:-3000}"
       MEDIA_INFO_TTL_MS: "${MEDIA_INFO_TTL_MS:-600000}"
 
+      # ---- Visual toggles (v2 visual sprint) ----
+      VISUAL_PROGRESS_BAR: "${VISUAL_PROGRESS_BAR:-false}"
+
       # ---- Optional hardening (recommended if exposed off-LAN) ----
       PROXY_SECRET: "${PROXY_SECRET:-}"
       ALLOWED_ORIGINS: "${ALLOWED_ORIGINS:-}"

--- a/server/README.md
+++ b/server/README.md
@@ -17,6 +17,7 @@ Standalone (HACS-only) installs continue to work against the unmodified
 | GET    | `/now_showing.html`               | The kiosk UI (served from `STATIC_DIR`, default `../www`) |
 | GET    | `/api`                            | Version + mode + endpoint listing                        |
 | GET    | `/api/state`                      | Normalised now-playing payload (3 s TTL cache)          |
+| GET    | `/api/config`                     | Browser-safe runtime flags (visual toggles)              |
 | GET    | `/api/media-info/:ratingKey`      | Plex metadata for the info panel (10 min TTL cache)      |
 | GET    | `/healthz`                        | Liveness probe (doesn't call upstream)                   |
 
@@ -58,6 +59,7 @@ For HA Container users running via Docker Compose. Set:
 | `SWITCHER_ENABLED` | `false` | Turn on the built-in Fully Kiosk auto-switcher (#48) |
 | `SWITCHER_INTERVAL_MS` | `5000` | How often the switcher polls HA for play/stop edges |
 | `FULLY_KIOSKS` | – | One kiosk per line: `host|password|playing_url[|stopped_url]` |
+| `VISUAL_PROGRESS_BAR` | `false` | Show a slim gold progress bar along the bottom of the poster |
 | `STATIC_DIR` | `../www` | Override where `now_showing.html` is served from |
 
 ## Local development

--- a/server/fixtures/ha_states.json
+++ b/server/fixtures/ha_states.json
@@ -16,6 +16,8 @@
       "media_episode": 1,
       "media_content_rating": "TV-MA",
       "media_duration": 3120,
+      "media_position": 842,
+      "media_position_updated_at": "2026-04-24T12:00:00.000000+00:00",
       "media_summary": "Mark leads a team of office workers whose memories have been surgically divided.",
       "media_content_id": "12345",
       "entity_picture": "/api/media_player_proxy/media_player.plex_plex_for_lg_tv",
@@ -40,6 +42,8 @@
       "media_content_type": "movie",
       "media_content_rating": "PG-13",
       "media_duration": 9900,
+      "media_position": 1234,
+      "media_position_updated_at": "2026-04-24T11:30:00.000000+00:00",
       "media_content_id": "plex://movie/5e161e4c8f3f5a00401b5af1",
       "entity_picture": "/api/media_player_proxy/media_player.plex_plex_for_android_tv",
       "username": "rusty"

--- a/server/src/config.js
+++ b/server/src/config.js
@@ -45,6 +45,12 @@ export function loadConfig(env = process.env) {
     switcherEnabled: parseBool(env.SWITCHER_ENABLED, false),
     switcherIntervalMs: parseInt(env.SWITCHER_INTERVAL_MS || '5000', 10),
     fullyKiosksRaw: env.FULLY_KIOSKS || '',
+    // Visual toggles (v2 visual sprint). All default OFF so existing installs
+    // keep the original look until the user opts in. Exposed to the browser
+    // via GET /api/config.
+    visual: {
+      progressBar: parseBool(env.VISUAL_PROGRESS_BAR, false),
+    },
     // Where the static HTML lives (overridden in tests)
     staticDir: env.STATIC_DIR || new URL('../../www', import.meta.url).pathname,
   };

--- a/server/src/routes/config.js
+++ b/server/src/routes/config.js
@@ -1,0 +1,24 @@
+// GET /api/config — exposes browser-safe runtime flags.
+//
+// Only ships non-sensitive values. Tokens and internal settings (TTLs, cache,
+// kiosk URLs) are deliberately excluded. Visual toggles let the frontend
+// conditionally render new v2 UI without a rebuild.
+
+import { Router } from 'express';
+
+export function configRoute({ config }) {
+  const r = Router();
+
+  r.get('/api/config', (_req, res) => {
+    // No-cache: flipping a toggle in the add-on UI restarts the server, but
+    // browsers on the wall might live for days. Let them re-read on reload.
+    res.set('Cache-Control', 'no-store');
+    res.json({
+      visual: {
+        progressBar: !!config.visual?.progressBar,
+      },
+    });
+  });
+
+  return r;
+}

--- a/server/src/routes/root.js
+++ b/server/src/routes/root.js
@@ -13,6 +13,7 @@ export function rootRoute({ config, version }) {
       mode: config.mode,
       endpoints: {
         state: '/api/state',
+        config: '/api/config',
         mediaInfo: '/api/media-info/:ratingKey',
         healthz: '/healthz',
         html: '/now_showing.html',

--- a/server/src/server.js
+++ b/server/src/server.js
@@ -19,6 +19,7 @@ import { createSwitcher, parseKiosks } from './switcher.js';
 import { rootRoute } from './routes/root.js';
 import { healthzRoute } from './routes/healthz.js';
 import { stateRoute } from './routes/state.js';
+import { configRoute } from './routes/config.js';
 import { mediaInfoRoute } from './routes/mediaInfo.js';
 import { artworkRoute } from './routes/artwork.js';
 
@@ -58,6 +59,7 @@ export function createApp({ config, haClient }) {
 
   app.use(rootRoute({ config, version: pkg.version }));
   app.use(healthzRoute({ config, version: pkg.version }));
+  app.use(configRoute({ config }));
   app.use(stateRoute({ haClient, cache: stateCache, config }));
   app.use(mediaInfoRoute({ cache: mediaInfoCache, config }));
   app.use(artworkRoute({ config }));

--- a/server/src/state.js
+++ b/server/src/state.js
@@ -46,6 +46,13 @@ function shape(playerState) {
   const artwork = rawArt && !/^https?:\/\//i.test(rawArt)
     ? `/api/artwork?path=${encodeURIComponent(rawArt)}`
     : rawArt;
+  // Progress bar (#17) needs both current position and the timestamp HA last
+  // updated it, so the browser can interpolate smoothly between polls when
+  // playing. positionUpdatedAt is an ISO8601 string in HA state JSON.
+  const position = Number.isFinite(attrs.media_position)
+    ? attrs.media_position
+    : 0;
+  const positionUpdatedAt = attrs.media_position_updated_at || '';
   return {
     title: attrs.media_title || 'Unknown Title',
     seriesTitle: attrs.media_series_title || '',
@@ -57,6 +64,8 @@ function shape(playerState) {
     episode: attrs.media_episode || '',
     contentRating: attrs.media_content_rating || '',
     duration: attrs.media_duration || 0,
+    position,
+    positionUpdatedAt,
     summary: attrs.media_summary || '',
     ratingKey: attrs.media_content_id || '',
   };

--- a/server/test/config.test.js
+++ b/server/test/config.test.js
@@ -47,6 +47,16 @@ test('TTL defaults match spec (3 s state, 10 min media-info)', () => {
   assert.equal(config.mediaInfoTtl, 600000);
 });
 
+test('visual toggles all default to false', () => {
+  const { config } = loadConfig({ SUPERVISOR_TOKEN: 'x' });
+  assert.equal(config.visual.progressBar, false);
+});
+
+test('VISUAL_PROGRESS_BAR=true flips the progress-bar toggle on', () => {
+  const { config } = loadConfig({ SUPERVISOR_TOKEN: 'x', VISUAL_PROGRESS_BAR: 'true' });
+  assert.equal(config.visual.progressBar, true);
+});
+
 test('switcher is off by default, on requires FULLY_KIOSKS', () => {
   const off = loadConfig({ SUPERVISOR_TOKEN: 'x' });
   assert.equal(off.config.switcherEnabled, false);

--- a/server/test/routes.test.js
+++ b/server/test/routes.test.js
@@ -31,6 +31,7 @@ function baseConfig(overrides = {}) {
     allowedOrigins: [],
     stateTtl: 3000,
     mediaInfoTtl: 600000,
+    visual: { progressBar: false },
     staticDir: join(__dirname, '..', 'fixtures'),
     ...overrides,
   };
@@ -94,6 +95,30 @@ test('PROXY_SECRET middleware blocks requests without the header', async () => {
     assert.equal(blocked.status, 401);
     const ok = await fetch(`${url}/api/state`, { headers: { 'x-proxy-secret': 'sekret' } });
     assert.equal(ok.status, 200);
+  } finally { server.close(); }
+});
+
+test('GET /api/config defaults every visual toggle off', async () => {
+  const haClient = { getStates: async () => haStates };
+  const { server, url } = await startApp(baseConfig(), haClient);
+  try {
+    const resp = await fetch(`${url}/api/config`);
+    assert.equal(resp.status, 200);
+    assert.equal(resp.headers.get('cache-control'), 'no-store');
+    const body = await resp.json();
+    assert.deepEqual(body, { visual: { progressBar: false } });
+  } finally { server.close(); }
+});
+
+test('GET /api/config reflects server-side visual toggle state', async () => {
+  const haClient = { getStates: async () => haStates };
+  const { server, url } = await startApp(
+    baseConfig({ visual: { progressBar: true } }),
+    haClient,
+  );
+  try {
+    const body = await fetch(`${url}/api/config`).then(r => r.json());
+    assert.equal(body.visual.progressBar, true);
   } finally { server.close(); }
 });
 

--- a/server/test/state.test.js
+++ b/server/test/state.test.js
@@ -27,6 +27,24 @@ test('pins to plexPlayer when configured', () => {
   assert.ok(r.artwork.includes(encodeURIComponent('/api/media_player_proxy/media_player.plex_plex_for_lg_tv')));
 });
 
+test('includes position + positionUpdatedAt for the progress bar', () => {
+  const r = normalise(states, { plexPlayer: 'media_player.plex_plex_for_lg_tv' });
+  assert.equal(r.duration, 3120);
+  assert.equal(r.position, 842);
+  assert.equal(r.positionUpdatedAt, '2026-04-24T12:00:00.000000+00:00');
+});
+
+test('position defaults to 0 and positionUpdatedAt to empty when missing', () => {
+  const withoutPos = [{
+    entity_id: 'media_player.plex_plex_for_lg_tv',
+    state: 'playing',
+    attributes: { media_title: 'x', media_duration: 120 },
+  }];
+  const r = normalise(withoutPos, { plexPlayer: 'media_player.plex_plex_for_lg_tv' });
+  assert.equal(r.position, 0);
+  assert.equal(r.positionUpdatedAt, '');
+});
+
 test('absolute artwork URLs are left alone', () => {
   const withAbs = [{
     entity_id: 'media_player.plex_plex_for_lg_tv',

--- a/www/now_showing.html
+++ b/www/now_showing.html
@@ -173,6 +173,66 @@
       background: var(--bg-marquee);
     }
 
+    /* ===== PLAYBACK PROGRESS BAR (#17) ===== */
+    /* Hidden by default. Shown only when body.visual-progress-bar is set by
+       the runtime-config loader. Matches the classic-gold theme: a gold
+       gradient with a soft glow, pinned near the bottom of the poster so it
+       reads like cinema film-strip trim without clashing with the bulb frame. */
+    .progress-bar {
+      position: absolute;
+      left: 6%;
+      right: 6%;
+      bottom: 2.8vh; /* lifted above the outer bulb string so it doesn't fuse with it */
+      height: 8px;
+      background: rgba(0, 0, 0, 0.7);
+      border: 1px solid rgba(0, 0, 0, 0.85);
+      border-radius: 4px;
+      overflow: hidden;
+      z-index: 6;
+      opacity: 0;
+      transition: opacity 0.4s ease;
+      pointer-events: none;
+      display: none;
+      box-shadow:
+        0 0 0 1px rgba(200, 160, 50, 0.35),
+        0 2px 6px rgba(0, 0, 0, 0.6);
+    }
+    body.visual-progress-bar .progress-bar { display: block; }
+    .progress-bar.visible { opacity: 1; }
+
+    .progress-bar-fill {
+      position: absolute;
+      top: 0;
+      left: 0;
+      bottom: 0;
+      width: 0%;
+      background: linear-gradient(90deg,
+        var(--gold-dark) 0%,
+        var(--gold-mid) 40%,
+        var(--gold-light) 70%,
+        var(--gold-glow) 100%);
+      box-shadow:
+        0 0 10px rgba(255, 215, 94, 0.55),
+        0 0 22px rgba(255, 215, 94, 0.3);
+      will-change: width;
+    }
+    /* Soft leading edge so the bar feels like a spotlight sweep */
+    .progress-bar-fill::after {
+      content: '';
+      position: absolute;
+      top: 0;
+      right: -5px;
+      bottom: 0;
+      width: 10px;
+      background: radial-gradient(ellipse at left center,
+        rgba(255, 230, 156, 0.95) 0%, transparent 70%);
+    }
+    /* Dimmed fill while paused */
+    .progress-bar.paused .progress-bar-fill {
+      filter: brightness(0.55) saturate(0.7);
+      box-shadow: none;
+    }
+
     /* Inner gold trim on poster section */
     .poster-section::after {
       content: '';
@@ -255,6 +315,13 @@
       left: 20px;
       right: 20px;
       z-index: 2;
+      transition: bottom 0.4s ease;
+    }
+    /* Lift the title above the playback progress bar when the toggle is on
+       so the bar doesn't clip the bottom of the movie name. The bar itself
+       sits at 2.8vh with 8px height + glow — give it ~18px of breathing room. */
+    body.visual-progress-bar .poster-title {
+      bottom: calc(2.8vh + 8px + 18px);
     }
 
     .poster-title h2 {
@@ -283,8 +350,12 @@
       right: 20px;
       text-align: right;
       opacity: 0;
-      transition: opacity 0.6s ease;
+      transition: opacity 0.6s ease, bottom 0.4s ease;
       z-index: 6;
+    }
+    /* Keep the player-name/media-type block clear of the progress bar too. */
+    body.visual-progress-bar .media-info {
+      bottom: calc(2.8vh + 8px + 18px);
     }
 
     .media-info.visible { opacity: 1; }
@@ -734,6 +805,11 @@
         <div class="player-name" id="playerName"></div>
       </div>
 
+      <!-- PLAYBACK PROGRESS BAR (#17) — opt-in via VISUAL_PROGRESS_BAR env -->
+      <div class="progress-bar" id="progressBar" aria-hidden="true">
+        <div class="progress-bar-fill" id="progressBarFill"></div>
+      </div>
+
       <!-- INFO OVERLAY (tap to show) -->
       <div class="info-overlay" id="infoOverlay">
         <div class="info-panel">
@@ -869,6 +945,44 @@
         return false;
       }
     })();
+
+    // ===== VISUAL TOGGLES (V2 visual sprint) =====
+    //
+    // Every visual feature is opt-in. Defaults preserve the original v1 look.
+    //
+    // Resolution order (same as other settings):
+    //   1. /api/config          — unified-server mode; driven by env vars /
+    //                             add-on options (e.g. VISUAL_PROGRESS_BAR).
+    //   2. readBool('visualProgressBar', …)
+    //                           — HACS-only users can flip it per-tablet via
+    //                             localStorage ('pns.visualProgressBar') or
+    //                             the URL hash (#visualProgressBar=true).
+    //
+    // Server config wins so operators can ship a consistent look across the
+    // fleet without touching every tablet.
+    const VISUAL = { progressBar: false };
+
+    async function loadVisualConfig() {
+      // Local overrides apply first so the tablet still looks right even if
+      // the server is briefly unreachable.
+      VISUAL.progressBar = readBool('visualProgressBar', false);
+
+      await serverModeReady;
+      if (!SERVER_MODE) return;
+      try {
+        const resp = await fetch('/api/config', { cache: 'no-store' });
+        if (!resp.ok) return;
+        const body = await resp.json();
+        const v = body && body.visual;
+        if (v && typeof v.progressBar === 'boolean') VISUAL.progressBar = v.progressBar;
+      } catch (err) {
+        console.warn('[plex-now-showing] /api/config fetch failed — using local defaults.', err);
+      }
+    }
+
+    function applyVisualToggles() {
+      document.body.classList.toggle('visual-progress-bar', VISUAL.progressBar);
+    }
 
     // ===== SETUP PAGE CONTROLLER (#setup) =====
     //
@@ -1329,6 +1443,8 @@
             episode: attrs.media_episode || '',
             contentRating: attrs.media_content_rating || '',
             duration: attrs.media_duration || 0,
+            position: Number.isFinite(attrs.media_position) ? attrs.media_position : 0,
+            positionUpdatedAt: attrs.media_position_updated_at || '',
             summary: attrs.media_summary || '',
             ratingKey: attrs.media_content_id || ''
           };
@@ -1369,6 +1485,8 @@
           episode: attrs.media_episode || '',
           contentRating: attrs.media_content_rating || '',
           duration: attrs.media_duration || 0,
+          position: Number.isFinite(attrs.media_position) ? attrs.media_position : 0,
+          positionUpdatedAt: attrs.media_position_updated_at || '',
           summary: attrs.media_summary || '',
           ratingKey: attrs.media_content_id || ''
         };
@@ -1376,6 +1494,53 @@
         console.warn('Fetch error:', err);
         return null;
       }
+    }
+
+    // ===== PROGRESS BAR CONTROLLER (#17) =====
+    //
+    // Plays well with the 5 s poll: we store the latest {duration, position,
+    // positionUpdatedAt, state} from HA and interpolate "now" against the
+    // server clock in a requestAnimationFrame loop. When paused or idle the
+    // bar freezes at the last known position. When nothing is playing the bar
+    // is hidden with a fade.
+    const progressBar = document.getElementById('progressBar');
+    const progressBarFill = document.getElementById('progressBarFill');
+    let progressState = null; // { duration, basePosition, baseAt, playing }
+    let progressRafId = null;
+
+    function setProgressFromState(data) {
+      if (!VISUAL.progressBar) return;
+      const duration = Number(data && data.duration) || 0;
+      if (duration <= 0) { hideProgressBar(); return; }
+      const basePosition = Number(data.position) || 0;
+      // positionUpdatedAt is HA's ISO8601 string; fall back to "now" so a
+      // missing field still produces a monotonic bar.
+      const parsed = data.positionUpdatedAt ? Date.parse(data.positionUpdatedAt) : NaN;
+      const baseAt = Number.isFinite(parsed) ? parsed : Date.now();
+      progressState = { duration, basePosition, baseAt, playing: data.state === 'playing' };
+      progressBar.classList.toggle('paused', data.state !== 'playing');
+      progressBar.classList.add('visible');
+      if (progressRafId == null) tickProgressBar();
+    }
+
+    function tickProgressBar() {
+      progressRafId = null;
+      if (!progressState) return;
+      const { duration, basePosition, baseAt, playing } = progressState;
+      const elapsedSec = playing ? Math.max(0, (Date.now() - baseAt) / 1000) : 0;
+      const pos = Math.min(duration, basePosition + elapsedSec);
+      const pct = duration > 0 ? (pos / duration) * 100 : 0;
+      progressBarFill.style.width = pct.toFixed(3) + '%';
+      // Only keep the RAF loop alive while playing; when paused the width is
+      // already correct and we don't need to burn cycles.
+      if (playing) progressRafId = requestAnimationFrame(tickProgressBar);
+    }
+
+    function hideProgressBar() {
+      progressState = null;
+      if (progressRafId != null) { cancelAnimationFrame(progressRafId); progressRafId = null; }
+      progressBar.classList.remove('visible');
+      progressBar.classList.remove('paused');
     }
 
     // ===== UPDATE DISPLAY =====
@@ -1444,6 +1609,9 @@
       // Ambient glow
       ambientGlow.style.background = `radial-gradient(ellipse at 50% 40%, rgba(200, 160, 50, 0.08) 0%, transparent 70%)`;
       ambientGlow.classList.add('active');
+
+      // Progress bar — updated every poll; no-ops when toggle is off.
+      setProgressFromState(data);
     }
 
     function showIdle() {
@@ -1463,6 +1631,7 @@
       mediaInfo.classList.remove('visible');
       idleContent.classList.add('visible');
       ambientGlow.classList.remove('active');
+      hideProgressBar();
     }
 
     // ===== POLLING LOOP =====
@@ -1476,9 +1645,13 @@
     }
 
     // ===== INIT =====
-    function init() {
+    async function init() {
       createOuterBulbs();
       setInterval(animateChase, 500);
+      // Runtime visual config must resolve before the first render so we don't
+      // flash the default UI and then repaint.
+      await loadVisualConfig();
+      applyVisualToggles();
       poll();
       setInterval(poll, POLL_INTERVAL);
     }


### PR DESCRIPTION
First PR of V2 Visual Sprint 1. Ships the playback progress bar (#17) on top of a reusable toggle scaffold so every upcoming visual tweak (#18, #20, #21, #28) can be opted into without disturbing v1 look.

## Toggle scaffolding (reusable)

- **Server**: `visual.*` namespace in `config.js`, parsed from `VISUAL_*` env vars
- **Server**: new `GET /api/config` returns `{ visual: { ... } }` with `Cache-Control: no-store`
- **Frontend**: `loadVisualConfig()` fetches `/api/config` at boot; falls back to `localStorage` (`pns.visual*`) / URL hash (`#visual*=true`) for HACS-only users
- **Frontend**: `applyVisualToggles()` sets body classes (`visual-<name>`) that each feature's CSS gates on
- **Add-on**: matching `visual_*` boolean options + run-script `export_opt` lines

All flags default OFF so existing v1 installs look identical after upgrade.

## Progress bar (#17)

- Server `shape()` surfaces `position` + `positionUpdatedAt` from HA (`media_position`, `media_position_updated_at`), null-safe
- Widget: pinned at `bottom: 2.8vh`, `left/right: 6%`, 8px tall, gold trim on black, glow, gradient fill
- `.paused` class dims + desaturates; `requestAnimationFrame` loop interpolates `basePosition + elapsedSec` while playing, freezes on pause, hidden when idle or toggle is off

## Tests

- `state.test.js`: position fields included; defaults when HA omits them
- `config.test.js`: visual defaults off; `VISUAL_PROGRESS_BAR=true` flips on
- `routes.test.js`: `GET /api/config` defaults off; reflects toggle state
- 50 → 56 passing, shellcheck clean

## Docs

- `server/README.md`: `/api/config` + `VISUAL_PROGRESS_BAR` rows
- add-on `DOCS.md`: new "Visual toggles (V2)" section with HACS override instructions
- add-on `CHANGELOG.md`: entry for progress bar + `/api/config`
- `docker-compose.example.yml` + `.env.example` updated

## Enablement

- HA add-on: set `visual_progress_bar: true` in add-on config
- Docker: `VISUAL_PROGRESS_BAR=true` in env
- HACS-only: `localStorage.setItem('pns.visualProgressBar','true')` or append `#visualProgressBar=true` to the kiosk URL

Closes #17