### PR TITLE
[viz-2] Ratings badges + info panel visibility mode

### DIFF
--- a/addons/plex-now-showing/CHANGELOG.md
+++ b/addons/plex-now-showing/CHANGELOG.md
@@ -25,3 +25,12 @@ The project follows [Semantic Versioning](https://semver.org/).
   feature will follow the same toggle pattern.
 - Server now exposes `GET /api/config` so the browser can read runtime
   visual toggles without a rebuild.
+- Ratings badges (closes #18). Opt-in via `visual_ratings_badges: true` —
+  IMDb, Rotten Tomatoes (fresh/rotten critic), and audience (RT upright/
+  spilled or TMDB fallback) chips on the info panel. Scores are pulled
+  server-side from `/library/metadata` and cached with the existing
+  media-info TTL. Requires `plex_url` + `plex_token`.
+- Info panel visibility mode (`visual_info_panel_mode`). Three choices:
+  `on_tap` (default, current behaviour), `on_pause` (panel pinned open
+  whenever the player is paused; tap-to-peek still works while playing),
+  and `always` (panel pinned open the entire time media is active).

--- a/addons/plex-now-showing/DOCS.md
+++ b/addons/plex-now-showing/DOCS.md
@@ -36,6 +36,8 @@ and HA tokens never leave the add-on.
 | `switcher_interval_ms` | `5000` | How often the switcher polls HA for play/stop edges. |
 | `fully_kiosks` | `[]` | List of tablets to drive. See below. |
 | `visual_progress_bar` | `false` | Slim gold progress bar along the bottom of the poster. See **Visual toggles** below. |
+| `visual_ratings_badges` | `false` | IMDb / Rotten Tomatoes / audience badges on the info panel. Needs `plex_url` + `plex_token`. |
+| `visual_info_panel_mode` | `on_tap` | When to show the info panel. `on_tap` (default), `on_pause` (pinned while paused), `always` (pinned whenever media is active). |
 | `log_level` | `info` | s6 / add-on log verbosity. |
 
 ### Visual toggles (V2)
@@ -47,10 +49,14 @@ through to the browser automatically — no rebuild, no per-tablet config.
 | Toggle | What it does |
 |--------|--------------|
 | `visual_progress_bar` | Adds a slim gold playback bar along the bottom of the poster. Tracks HA's `media_position`, interpolated between polls so it moves smoothly. Dimmed while paused, hidden while idle. |
+| `visual_ratings_badges` | Adds IMDb, Rotten Tomatoes (fresh/rotten), and audience score chips on the info panel that slides up when you tap the kiosk. Scores are pulled server-side from Plex's `/library/metadata/{id}` via the existing `/api/media-info/:ratingKey` endpoint — requires `plex_url` + `plex_token` to be set. |
+| `visual_info_panel_mode` | Controls **when** the whole info panel appears. `on_tap` (default) matches v1 behaviour — hidden until you tap the poster, auto-hides after 8 s. `on_pause` pins the panel open whenever the player is paused (tap-to-peek still works during playback). `always` keeps the panel open the entire time media is active; tap is suppressed. Combine with `visual_ratings_badges` if you want ratings visible on pause or always. |
 
 HACS-only users (no add-on / server) can flip any visual toggle per tablet
-by setting `pns.visualProgressBar=true` in `localStorage` or adding
-`#visualProgressBar=true` to the kiosk URL.
+by setting `pns.visualProgressBar=true` / `pns.visualRatingsBadges=true` /
+`pns.visualInfoPanelMode=on_pause` in `localStorage` or adding
+`#visualProgressBar=true` / `#visualRatingsBadges=true` /
+`#visualInfoPanelMode=always` to the kiosk URL.
 
 ### Fully Kiosk auto-switcher (#48)
 

--- a/addons/plex-now-showing/config.yaml
+++ b/addons/plex-now-showing/config.yaml
@@ -59,6 +59,8 @@ options:
   # Visual toggles (V2 visual sprint). All default OFF so existing installs
   # keep the original look until the user opts in.
   visual_progress_bar: false
+  visual_ratings_badges: false
+  visual_info_panel_mode: on_tap
   log_level: info
 schema:
   plex_url: "str?"
@@ -81,5 +83,7 @@ schema:
       playing_url: "url"
       stopped_url: "url?"
   visual_progress_bar: "bool"
+  visual_ratings_badges: "bool"
+  visual_info_panel_mode: "list(on_tap|on_pause|always)"
   log_level: "list(trace|debug|info|notice|warning|error|fatal)?"
 image: ghcr.io/rusty4444/plex-now-showing-{arch}

--- a/addons/plex-now-showing/rootfs/etc/services.d/plex-now-showing/run
+++ b/addons/plex-now-showing/rootfs/etc/services.d/plex-now-showing/run
@@ -57,7 +57,9 @@ if bashio::config.has_value 'fully_kiosks'; then
 fi
 
 # ---- Visual toggles (V2 visual sprint) ----
-export_opt VISUAL_PROGRESS_BAR visual_progress_bar
+export_opt VISUAL_PROGRESS_BAR     visual_progress_bar
+export_opt VISUAL_RATINGS_BADGES   visual_ratings_badges
+export_opt VISUAL_INFO_PANEL_MODE  visual_info_panel_mode
 
 # ---- Diagnostics (no secrets) ----
 bashio::log.info "Plex URL configured:      $([[ -n "${PLEX_URL}"   ]] && echo yes || echo no)"
@@ -72,6 +74,8 @@ bashio::log.info "Media-info cache TTL (ms):${MEDIA_INFO_TTL_MS}"
 bashio::log.info "Proxy secret:             $([[ -n "${PROXY_SECRET}" ]] && echo set || echo unset)"
 bashio::log.info "Allowed origins:          ${ALLOWED_ORIGINS:-<any (ingress-only)>}"
 bashio::log.info "Visual progress bar:      ${VISUAL_PROGRESS_BAR:-false}"
+bashio::log.info "Visual ratings badges:    ${VISUAL_RATINGS_BADGES:-false}"
+bashio::log.info "Info panel mode:          ${VISUAL_INFO_PANEL_MODE:-on_tap}"
 bashio::log.info "Switcher enabled:         ${SWITCHER_ENABLED:-false}"
 if bashio::var.true "${SWITCHER_ENABLED:-false}"; then
   kiosk_count=$(bashio::config 'fully_kiosks | length')

--- a/addons/plex-now-showing/translations/en.yaml
+++ b/addons/plex-now-showing/translations/en.yaml
@@ -70,6 +70,20 @@ configuration:
       Adds a slim gold progress bar along the bottom of the poster while
       something is playing. Freezes while paused, disappears when idle.
       Off by default; flip on to enable.
+  visual_ratings_badges:
+    name: Show ratings badges
+    description: >-
+      Adds IMDb, Rotten Tomatoes, and audience score badges to the info
+      panel (shown when you tap the kiosk). Requires plex_url + plex_token
+      so the server can read ratings from /library/metadata. Off by default.
+  visual_info_panel_mode:
+    name: Info panel visibility
+    description: >-
+      When to show the info panel (title, ratings, meta, tech tags).
+      "on_tap" (default) — hidden until the user taps the poster, auto-hides
+      after 8 s. "on_pause" — shows persistently whenever the player is
+      paused; tap-to-peek still works while playing. "always" — pinned open
+      the entire time media is active.
   log_level:
     name: Log level
     description: Verbosity of the add-on log.

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -32,6 +32,12 @@ MEDIA_INFO_TTL_MS=600000
 # Each visual feature is opt-in. Defaults preserve the v1 look.
 # Slim gold progress bar along the bottom of the poster.
 VISUAL_PROGRESS_BAR=false
+# IMDb / Rotten Tomatoes / audience score badges on the info panel.
+# Requires PLEX_URL + PLEX_TOKEN so the server can read /library/metadata.
+VISUAL_RATINGS_BADGES=false
+# When to show the info panel (title, ratings, meta, tech tags).
+# One of: on_tap (default, tap-to-peek), on_pause, always.
+VISUAL_INFO_PANEL_MODE=on_tap
 
 # ---- Optional hardening (set both if exposing the port beyond your LAN) ---
 # Every /api/* request must carry header X-Proxy-Secret: <value>.

--- a/docker/docker-compose.example.yml
+++ b/docker/docker-compose.example.yml
@@ -49,6 +49,8 @@ services:
 
       # ---- Visual toggles (v2 visual sprint) ----
       VISUAL_PROGRESS_BAR: "${VISUAL_PROGRESS_BAR:-false}"
+      VISUAL_RATINGS_BADGES: "${VISUAL_RATINGS_BADGES:-false}"
+      VISUAL_INFO_PANEL_MODE: "${VISUAL_INFO_PANEL_MODE:-on_tap}"
 
       # ---- Optional hardening (recommended if exposed off-LAN) ----
       PROXY_SECRET: "${PROXY_SECRET:-}"

--- a/server/README.md
+++ b/server/README.md
@@ -60,6 +60,8 @@ For HA Container users running via Docker Compose. Set:
 | `SWITCHER_INTERVAL_MS` | `5000` | How often the switcher polls HA for play/stop edges |
 | `FULLY_KIOSKS` | – | One kiosk per line: `host|password|playing_url[|stopped_url]` |
 | `VISUAL_PROGRESS_BAR` | `false` | Show a slim gold progress bar along the bottom of the poster |
+| `VISUAL_RATINGS_BADGES` | `false` | Show IMDb / Rotten Tomatoes / audience score badges in the info panel (needs `PLEX_URL` + `PLEX_TOKEN`) |
+| `VISUAL_INFO_PANEL_MODE` | `on_tap` | When to show the info panel: `on_tap`, `on_pause`, or `always` |
 | `STATIC_DIR` | `../www` | Override where `now_showing.html` is served from |
 
 ## Local development

--- a/server/fixtures/plex_metadata_12345.json
+++ b/server/fixtures/plex_metadata_12345.json
@@ -34,6 +34,25 @@
               }
             ]
           }
+        ],
+        "rating": 8.4,
+        "audienceRating": 9.1,
+        "Rating": [
+          {
+            "image": "imdb://image.rating",
+            "value": 8.4,
+            "type": "audience"
+          },
+          {
+            "image": "rottentomatoes://image.rating.ripe",
+            "value": 9.3,
+            "type": "critic"
+          },
+          {
+            "image": "rottentomatoes://image.rating.upright",
+            "value": 9.1,
+            "type": "audience"
+          }
         ]
       }
     ]

--- a/server/src/config.js
+++ b/server/src/config.js
@@ -50,6 +50,13 @@ export function loadConfig(env = process.env) {
     // via GET /api/config.
     visual: {
       progressBar: parseBool(env.VISUAL_PROGRESS_BAR, false),
+      ratingsBadges: parseBool(env.VISUAL_RATINGS_BADGES, false),
+      // How the info panel (title + ratings + meta + tech) is revealed:
+      //   'on_tap'   — default; hidden until the user taps the poster (8 s peek)
+      //   'on_pause' — persistently shown while paused, still tappable when playing
+      //   'always'   — persistently shown whenever media is playing
+      infoPanelMode: parseEnum(env.VISUAL_INFO_PANEL_MODE,
+        ['on_tap', 'on_pause', 'always'], 'on_tap'),
     },
     // Where the static HTML lives (overridden in tests)
     staticDir: env.STATIC_DIR || new URL('../../www', import.meta.url).pathname,
@@ -62,6 +69,12 @@ export function loadConfig(env = process.env) {
 function parseBool(v, defaultValue) {
   if (v == null || v === '') return defaultValue;
   return /^(1|true|yes|on)$/i.test(String(v));
+}
+
+function parseEnum(v, allowed, defaultValue) {
+  if (v == null || v === '') return defaultValue;
+  const s = String(v).trim().toLowerCase();
+  return allowed.includes(s) ? s : defaultValue;
 }
 
 function validate(c) {

--- a/server/src/plex.js
+++ b/server/src/plex.js
@@ -37,6 +37,83 @@ export function parseRatingKey(raw) {
   return tail ? tail[1] : null;
 }
 
+// parseRatings  — #18 Ratings badges. Plex exposes ratings two ways:
+//
+//   1. Legacy scalars on the Metadata item:
+//        - `rating`          critic score (usually IMDb-sourced, 0–10)
+//        - `audienceRating`  audience score (0–10)
+//
+//   2. A `Rating` array when the Plex agent supplies multi-provider data:
+//        [ { image: 'imdb://image.rating',                value: 7.8, type: 'audience'|'critic' },
+//          { image: 'rottentomatoes://image.rating.ripe', value: 8.5, type: 'critic' },
+//          { image: 'rottentomatoes://image.rating.rotten', value: 3.2, type: 'critic' },
+//          { image: 'rottentomatoes://image.rating.upright', value: 8.9, type: 'audience' },
+//          { image: 'rottentomatoes://image.rating.spilled', value: 4.5, type: 'audience' },
+//          { image: 'themoviedb://image.rating',          value: 7.6, type: 'audience' } ]
+//
+// We prefer the Rating[] array (it's unambiguous) and fall back to the legacy
+// scalars. Each slot is null when unavailable so the frontend can skip the
+// widget cleanly.
+export function parseRatings(item) {
+  if (!item || typeof item !== 'object') return { imdb: null, rottenTomatoes: null, audience: null };
+
+  const out = { imdb: null, rottenTomatoes: null, audience: null };
+  const ratings = Array.isArray(item.Rating) ? item.Rating : [];
+
+  for (const r of ratings) {
+    if (!r || typeof r.image !== 'string') continue;
+    const img = r.image.toLowerCase();
+    const val = Number(r.value);
+    // Treat missing / non-numeric / zero values as unknown so we don't render
+    // a "0.0" badge when Plex simply hasn't fetched a score yet.
+    if (!Number.isFinite(val) || val <= 0) continue;
+    const type = (r.type || '').toLowerCase();
+
+    if (img.startsWith('imdb://')) {
+      // IMDb scores are on a 0–10 scale.
+      if (out.imdb == null) out.imdb = { value: val, scale: 10, source: 'imdb' };
+    } else if (img.startsWith('rottentomatoes://')) {
+      // RT publishes on 0–10 in Plex's feed. Map the badge variant so the
+      // frontend can pick the right icon (fresh vs rotten, upright vs spilled).
+      const fresh = img.includes('ripe') || img.includes('upright');
+      const rotten = img.includes('rotten') || img.includes('spilled');
+      const isAudience = type === 'audience' || img.includes('upright') || img.includes('spilled');
+      const slot = isAudience ? 'audience' : 'rottenTomatoes';
+      if (out[slot] == null) {
+        out[slot] = {
+          value: val,
+          scale: 10,
+          source: isAudience ? 'rt_audience' : 'rt_critic',
+          fresh: fresh || (!rotten && val >= 6),
+        };
+      }
+    } else if (img.startsWith('themoviedb://')) {
+      // TMDB is primarily audience-sourced — only use as an audience fallback.
+      if (out.audience == null) {
+        out.audience = { value: val, scale: 10, source: 'tmdb' };
+      }
+    }
+  }
+
+  // Legacy fallbacks. `item.rating` is typically the IMDb-sourced critic score
+  // when the Plex agent is the default IMDb/TMDB combo, so use it to fill the
+  // IMDb slot if the Rating[] array didn't already populate it.
+  if (out.imdb == null) {
+    const legacy = Number(item.rating);
+    if (Number.isFinite(legacy) && legacy > 0) {
+      out.imdb = { value: legacy, scale: 10, source: 'legacy_rating' };
+    }
+  }
+  if (out.audience == null) {
+    const legacyAud = Number(item.audienceRating);
+    if (Number.isFinite(legacyAud) && legacyAud > 0) {
+      out.audience = { value: legacyAud, scale: 10, source: 'legacy_audience_rating' };
+    }
+  }
+
+  return out;
+}
+
 export async function fetchMediaInfo({ plexUrl, plexToken, ratingKey, fetchImpl = globalThis.fetch }) {
   if (!plexUrl || !plexToken || !ratingKey) return null;
 
@@ -71,5 +148,6 @@ export async function fetchMediaInfo({ plexUrl, plexToken, ratingKey, fetchImpl 
     fileSize: part?.size || 0,
     width: media.width || 0,
     height: media.height || 0,
+    ratings: parseRatings(item),
   };
 }

--- a/server/src/routes/config.js
+++ b/server/src/routes/config.js
@@ -16,6 +16,8 @@ export function configRoute({ config }) {
     res.json({
       visual: {
         progressBar: !!config.visual?.progressBar,
+        ratingsBadges: !!config.visual?.ratingsBadges,
+        infoPanelMode: config.visual?.infoPanelMode || 'on_tap',
       },
     });
   });

--- a/server/test/config.test.js
+++ b/server/test/config.test.js
@@ -50,11 +50,40 @@ test('TTL defaults match spec (3 s state, 10 min media-info)', () => {
 test('visual toggles all default to false', () => {
   const { config } = loadConfig({ SUPERVISOR_TOKEN: 'x' });
   assert.equal(config.visual.progressBar, false);
+  assert.equal(config.visual.ratingsBadges, false);
 });
 
 test('VISUAL_PROGRESS_BAR=true flips the progress-bar toggle on', () => {
   const { config } = loadConfig({ SUPERVISOR_TOKEN: 'x', VISUAL_PROGRESS_BAR: 'true' });
   assert.equal(config.visual.progressBar, true);
+});
+
+test('VISUAL_RATINGS_BADGES=true flips the ratings-badges toggle on', () => {
+  const { config } = loadConfig({ SUPERVISOR_TOKEN: 'x', VISUAL_RATINGS_BADGES: 'true' });
+  assert.equal(config.visual.ratingsBadges, true);
+  assert.equal(config.visual.progressBar, false);
+});
+
+test('VISUAL_INFO_PANEL_MODE defaults to on_tap', () => {
+  const { config } = loadConfig({ SUPERVISOR_TOKEN: 'x' });
+  assert.equal(config.visual.infoPanelMode, 'on_tap');
+});
+
+test('VISUAL_INFO_PANEL_MODE accepts on_pause and always', () => {
+  const pause = loadConfig({ SUPERVISOR_TOKEN: 'x', VISUAL_INFO_PANEL_MODE: 'on_pause' });
+  assert.equal(pause.config.visual.infoPanelMode, 'on_pause');
+  const always = loadConfig({ SUPERVISOR_TOKEN: 'x', VISUAL_INFO_PANEL_MODE: 'always' });
+  assert.equal(always.config.visual.infoPanelMode, 'always');
+});
+
+test('VISUAL_INFO_PANEL_MODE falls back to on_tap on unknown values', () => {
+  const { config } = loadConfig({ SUPERVISOR_TOKEN: 'x', VISUAL_INFO_PANEL_MODE: 'bogus' });
+  assert.equal(config.visual.infoPanelMode, 'on_tap');
+});
+
+test('VISUAL_INFO_PANEL_MODE is case-insensitive', () => {
+  const { config } = loadConfig({ SUPERVISOR_TOKEN: 'x', VISUAL_INFO_PANEL_MODE: 'ON_PAUSE' });
+  assert.equal(config.visual.infoPanelMode, 'on_pause');
 });
 
 test('switcher is off by default, on requires FULLY_KIOSKS', () => {

--- a/server/test/plex.test.js
+++ b/server/test/plex.test.js
@@ -4,7 +4,7 @@ import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
-import { parseRatingKey, fetchMediaInfo } from '../src/plex.js';
+import { parseRatingKey, fetchMediaInfo, parseRatings } from '../src/plex.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const metadata = JSON.parse(
@@ -76,4 +76,91 @@ test('fetchMediaInfo: returns null on non-ok response', async () => {
     plexUrl: 'u', plexToken: 't', ratingKey: '1', fetchImpl,
   });
   assert.equal(info, null);
+});
+
+// ----- #18 parseRatings ---------------------------------------------------
+
+test('parseRatings: returns all-null for falsy input', () => {
+  assert.deepEqual(parseRatings(null), { imdb: null, rottenTomatoes: null, audience: null });
+  assert.deepEqual(parseRatings(undefined), { imdb: null, rottenTomatoes: null, audience: null });
+  assert.deepEqual(parseRatings({}), { imdb: null, rottenTomatoes: null, audience: null });
+});
+
+test('parseRatings: pulls imdb + RT critic + RT audience from Rating[]', () => {
+  const r = parseRatings({
+    Rating: [
+      { image: 'imdb://image.rating', value: 7.8, type: 'audience' },
+      { image: 'rottentomatoes://image.rating.ripe', value: 8.5, type: 'critic' },
+      { image: 'rottentomatoes://image.rating.upright', value: 9.1, type: 'audience' },
+    ],
+  });
+  assert.equal(r.imdb.value, 7.8);
+  assert.equal(r.imdb.source, 'imdb');
+  assert.equal(r.rottenTomatoes.value, 8.5);
+  assert.equal(r.rottenTomatoes.fresh, true);
+  assert.equal(r.audience.value, 9.1);
+  assert.equal(r.audience.source, 'rt_audience');
+});
+
+test('parseRatings: RT rotten/spilled mark fresh=false', () => {
+  const r = parseRatings({
+    Rating: [
+      { image: 'rottentomatoes://image.rating.rotten', value: 3.2, type: 'critic' },
+      { image: 'rottentomatoes://image.rating.spilled', value: 4.1, type: 'audience' },
+    ],
+  });
+  assert.equal(r.rottenTomatoes.fresh, false);
+  assert.equal(r.audience.fresh, false);
+});
+
+test('parseRatings: falls back to legacy scalars when Rating[] missing', () => {
+  const r = parseRatings({ rating: 7.3, audienceRating: 8.2 });
+  assert.equal(r.imdb.value, 7.3);
+  assert.equal(r.imdb.source, 'legacy_rating');
+  assert.equal(r.audience.value, 8.2);
+  assert.equal(r.audience.source, 'legacy_audience_rating');
+  assert.equal(r.rottenTomatoes, null);
+});
+
+test('parseRatings: Rating[] wins over legacy scalars for imdb slot', () => {
+  const r = parseRatings({
+    rating: 5.0,
+    Rating: [{ image: 'imdb://image.rating', value: 8.9 }],
+  });
+  assert.equal(r.imdb.value, 8.9);
+  assert.equal(r.imdb.source, 'imdb');
+});
+
+test('parseRatings: TMDB fills audience slot only when empty', () => {
+  const r = parseRatings({
+    Rating: [{ image: 'themoviedb://image.rating', value: 7.6 }],
+  });
+  assert.equal(r.audience.source, 'tmdb');
+  assert.equal(r.audience.value, 7.6);
+});
+
+test('parseRatings: ignores entries with bad/missing values', () => {
+  const r = parseRatings({
+    Rating: [
+      { image: 'imdb://image.rating' },
+      { image: 'imdb://image.rating', value: 'abc' },
+      { image: 'imdb://image.rating', value: 0 },
+      { value: 5, type: 'critic' }, // no image
+    ],
+    rating: 0,          // 0 is treated as "unknown"
+    audienceRating: 0,
+  });
+  assert.deepEqual(r, { imdb: null, rottenTomatoes: null, audience: null });
+});
+
+test('fetchMediaInfo: surfaces ratings from the canned fixture', async () => {
+  const fetchImpl = async () => ({ ok: true, async json() { return metadata; } });
+  const info = await fetchMediaInfo({
+    plexUrl: 'u', plexToken: 't', ratingKey: '12345', fetchImpl,
+  });
+  assert.ok(info.ratings);
+  assert.equal(info.ratings.imdb.value, 8.4);
+  assert.equal(info.ratings.rottenTomatoes.value, 9.3);
+  assert.equal(info.ratings.rottenTomatoes.fresh, true);
+  assert.equal(info.ratings.audience.value, 9.1);
 });

--- a/server/test/routes.test.js
+++ b/server/test/routes.test.js
@@ -31,7 +31,7 @@ function baseConfig(overrides = {}) {
     allowedOrigins: [],
     stateTtl: 3000,
     mediaInfoTtl: 600000,
-    visual: { progressBar: false },
+    visual: { progressBar: false, ratingsBadges: false, infoPanelMode: 'on_tap' },
     staticDir: join(__dirname, '..', 'fixtures'),
     ...overrides,
   };
@@ -106,19 +106,44 @@ test('GET /api/config defaults every visual toggle off', async () => {
     assert.equal(resp.status, 200);
     assert.equal(resp.headers.get('cache-control'), 'no-store');
     const body = await resp.json();
-    assert.deepEqual(body, { visual: { progressBar: false } });
+    assert.deepEqual(body, { visual: { progressBar: false, ratingsBadges: false, infoPanelMode: 'on_tap' } });
   } finally { server.close(); }
 });
 
 test('GET /api/config reflects server-side visual toggle state', async () => {
   const haClient = { getStates: async () => haStates };
   const { server, url } = await startApp(
-    baseConfig({ visual: { progressBar: true } }),
+    baseConfig({ visual: { progressBar: true, ratingsBadges: false } }),
     haClient,
   );
   try {
     const body = await fetch(`${url}/api/config`).then(r => r.json());
     assert.equal(body.visual.progressBar, true);
+    assert.equal(body.visual.ratingsBadges, false);
+  } finally { server.close(); }
+});
+
+test('GET /api/config surfaces infoPanelMode when set', async () => {
+  const haClient = { getStates: async () => haStates };
+  const { server, url } = await startApp(
+    baseConfig({ visual: { progressBar: false, ratingsBadges: false, infoPanelMode: 'on_pause' } }),
+    haClient,
+  );
+  try {
+    const body = await fetch(`${url}/api/config`).then(r => r.json());
+    assert.equal(body.visual.infoPanelMode, 'on_pause');
+  } finally { server.close(); }
+});
+
+test('GET /api/config surfaces ratingsBadges when enabled', async () => {
+  const haClient = { getStates: async () => haStates };
+  const { server, url } = await startApp(
+    baseConfig({ visual: { progressBar: false, ratingsBadges: true } }),
+    haClient,
+  );
+  try {
+    const body = await fetch(`${url}/api/config`).then(r => r.json());
+    assert.equal(body.visual.ratingsBadges, true);
   } finally { server.close(); }
 });
 

--- a/www/now_showing.html
+++ b/www/now_showing.html
@@ -470,6 +470,23 @@
       transform: translateY(0);
     }
 
+    /* ===== Pinned info-panel styling =====
+       When the panel is pinned open by the active mode — rather than a user
+       tap — we drop the full-screen dim so the poster artwork stays vibrant,
+       and paint a bottom-up gradient behind just the panel so text remains
+       legible against the poster. Tap-driven reveals (on_tap, and the
+       tap-to-peek path in on_pause) keep today's 85 % black overlay. */
+    body.info-pinned .info-overlay {
+      background: transparent;
+    }
+    body.info-pinned .info-overlay .info-panel {
+      background: linear-gradient(to top,
+        rgba(0, 0, 0, 0.92) 0%,
+        rgba(0, 0, 0, 0.78) 55%,
+        rgba(0, 0, 0, 0.00) 100%);
+      padding-top: 120px;
+    }
+
     .info-panel .info-title {
       font-family: 'Playfair Display', serif;
       font-weight: 900;
@@ -503,6 +520,76 @@
       padding: 4px 12px;
       border-radius: 4px;
       text-transform: uppercase;
+    }
+
+    /* ===== RATINGS BADGES (#18) =====
+       Shown between subtitle and meta row inside .info-panel. Hidden by default;
+       body.visual-ratings-badges toggles them on. Each provider renders as a
+       small chip with an inline SVG mark + the score. Colours map to the
+       provider's brand (yellow for IMDb, tomato-red for RT critic, popcorn-gold
+       for RT audience). Dimensions are tuned to line up visually with
+       .info-tag so the two rows read as a single badge stack. */
+    .info-panel .info-ratings {
+      display: none;
+      flex-wrap: wrap;
+      gap: 8px;
+      margin-bottom: 14px;
+    }
+    body.visual-ratings-badges .info-panel .info-ratings.has-ratings {
+      display: flex;
+    }
+    .rating-badge {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      padding: 4px 10px 4px 8px;
+      border-radius: 6px;
+      font-family: 'Inter', sans-serif;
+      font-weight: 700;
+      font-size: clamp(0.8rem, 1.9vw, 1rem);
+      line-height: 1;
+      background: rgba(0, 0, 0, 0.55);
+      border: 1px solid rgba(255, 255, 255, 0.06);
+      color: var(--text-light);
+      text-shadow: 0 1px 2px rgba(0, 0, 0, 0.8);
+    }
+    .rating-badge .rating-mark {
+      display: inline-flex;
+      width: 20px;
+      height: 20px;
+      align-items: center;
+      justify-content: center;
+      border-radius: 3px;
+      font-family: 'Bebas Neue', sans-serif;
+      letter-spacing: 0.02em;
+      font-size: 0.72rem;
+      font-weight: 700;
+    }
+    .rating-badge .rating-mark svg { width: 16px; height: 16px; display: block; }
+    .rating-badge .rating-value { font-variant-numeric: tabular-nums; }
+    .rating-badge .rating-suffix {
+      font-size: 0.72em;
+      color: var(--text-dim);
+      margin-left: 2px;
+    }
+    /* Provider variants */
+    .rating-badge.imdb .rating-mark {
+      background: #f5c518;                   /* IMDb yellow */
+      color: #000;
+    }
+    .rating-badge.rt-critic .rating-mark {
+      background: #fa320a;                   /* Tomato red */
+      color: #fff;
+    }
+    .rating-badge.rt-critic.rotten .rating-mark { background: #6b7f2e; }
+    .rating-badge.rt-audience .rating-mark {
+      background: #faca15;                   /* Popcorn gold */
+      color: #3d2a0a;
+    }
+    .rating-badge.rt-audience.spilled .rating-mark { background: #5a7139; color: #fff; }
+    .rating-badge.tmdb .rating-mark {
+      background: linear-gradient(90deg, #01d277, #0d253f);
+      color: #fff;
     }
 
     .info-panel .info-summary {
@@ -551,6 +638,11 @@
       margin-top: 16px;
       text-align: center;
     }
+
+    /* "always" mode suppresses the tap-to-dismiss handler, so hide the hint
+       that advertises it. on_pause keeps tap working while playing so the
+       hint is still accurate there. */
+    body.info-mode-always .info-panel .info-hint { display: none; }
 
     /* ===== SETUP PAGE (#setup) ===== */
     .setup-overlay {
@@ -815,6 +907,7 @@
         <div class="info-panel">
           <div class="info-title" id="infoTitle"></div>
           <div class="info-subtitle" id="infoSubtitle"></div>
+          <div class="info-ratings" id="infoRatings" aria-label="Ratings"></div>
           <div class="info-meta" id="infoMeta"></div>
           <div class="info-summary" id="infoSummary"></div>
           <div class="info-techbox" id="infoTech"></div>
@@ -960,12 +1053,26 @@
     //
     // Server config wins so operators can ship a consistent look across the
     // fleet without touching every tablet.
-    const VISUAL = { progressBar: false };
+    const INFO_PANEL_MODES = ['on_tap', 'on_pause', 'always'];
+    const VISUAL = { progressBar: false, ratingsBadges: false, infoPanelMode: 'on_tap' };
+
+    function readInfoPanelMode(defaultValue) {
+      // Hash override takes precedence over localStorage so tablet operators can
+      // test modes without clearing storage — same pattern as readBool().
+      const hash = new URLSearchParams(location.hash.replace(/^#/, ''));
+      const fromHash = hash.get('visualInfoPanelMode');
+      if (fromHash && INFO_PANEL_MODES.includes(fromHash)) return fromHash;
+      const fromStorage = localStorage.getItem('pns.visualInfoPanelMode');
+      if (fromStorage && INFO_PANEL_MODES.includes(fromStorage)) return fromStorage;
+      return defaultValue;
+    }
 
     async function loadVisualConfig() {
       // Local overrides apply first so the tablet still looks right even if
       // the server is briefly unreachable.
       VISUAL.progressBar = readBool('visualProgressBar', false);
+      VISUAL.ratingsBadges = readBool('visualRatingsBadges', false);
+      VISUAL.infoPanelMode = readInfoPanelMode('on_tap');
 
       await serverModeReady;
       if (!SERVER_MODE) return;
@@ -975,6 +1082,10 @@
         const body = await resp.json();
         const v = body && body.visual;
         if (v && typeof v.progressBar === 'boolean') VISUAL.progressBar = v.progressBar;
+        if (v && typeof v.ratingsBadges === 'boolean') VISUAL.ratingsBadges = v.ratingsBadges;
+        if (v && typeof v.infoPanelMode === 'string' && INFO_PANEL_MODES.includes(v.infoPanelMode)) {
+          VISUAL.infoPanelMode = v.infoPanelMode;
+        }
       } catch (err) {
         console.warn('[plex-now-showing] /api/config fetch failed — using local defaults.', err);
       }
@@ -982,6 +1093,12 @@
 
     function applyVisualToggles() {
       document.body.classList.toggle('visual-progress-bar', VISUAL.progressBar);
+      document.body.classList.toggle('visual-ratings-badges', VISUAL.ratingsBadges);
+      // Exactly one info-mode-* class is set so CSS / JS can branch without
+      // juggling multiple booleans.
+      document.body.classList.toggle('info-mode-on-tap', VISUAL.infoPanelMode === 'on_tap');
+      document.body.classList.toggle('info-mode-on-pause', VISUAL.infoPanelMode === 'on_pause');
+      document.body.classList.toggle('info-mode-always', VISUAL.infoPanelMode === 'always');
     }
 
     // ===== SETUP PAGE CONTROLLER (#setup) =====
@@ -1162,6 +1279,7 @@
     const infoTitle = document.getElementById('infoTitle');
     const infoSubtitle = document.getElementById('infoSubtitle');
     const infoMeta = document.getElementById('infoMeta');
+    const infoRatings = document.getElementById('infoRatings');
     const infoSummary = document.getElementById('infoSummary');
     const infoTech = document.getElementById('infoTech');
     const infoPlayer = document.getElementById('infoPlayer');
@@ -1172,17 +1290,64 @@
       document.getElementById('frameWrapper').classList.add('landscape-mode');
     }
 
-    // Tap to show/hide info
+    // Tap to show/hide info.
+    //
+    // In always mode the panel is pinned open by syncInfoPanelForMode(); a tap
+    // that tried to hide it would just be re-opened on the next poll, so we
+    // suppress it entirely. on_tap and on_pause behave the same way on tap —
+    // on_pause also keeps honouring the tap-to-peek behaviour consistent with
+    // users' muscle memory. A tap also *unpins* the panel so the full-screen
+    // dim returns for the peek (pinned modes use the lighter gradient skin).
     posterSection.addEventListener('click', (e) => {
       if (!isShowingMedia || !currentMediaData) return;
+      if (VISUAL.infoPanelMode === 'always') return;
       if (infoOverlay.classList.contains('visible')) {
         hideInfo();
       } else {
+        document.body.classList.remove('info-pinned');
         showInfo();
       }
     });
 
     // Fetch media file info from Plex API
+    // HACS-direct-path only: client-side mirror of server parseRatings().
+    // The unified-server path gets ratings pre-parsed by the backend.
+    function parseRatingsClient(item) {
+      const out = { imdb: null, rottenTomatoes: null, audience: null };
+      const ratings = Array.isArray(item?.Rating) ? item.Rating : [];
+      for (const r of ratings) {
+        if (!r || typeof r.image !== 'string') continue;
+        const val = Number(r.value);
+        if (!Number.isFinite(val) || val <= 0) continue;
+        const img = r.image.toLowerCase();
+        const type = (r.type || '').toLowerCase();
+        if (img.startsWith('imdb://')) {
+          if (!out.imdb) out.imdb = { value: val, scale: 10, source: 'imdb' };
+        } else if (img.startsWith('rottentomatoes://')) {
+          const fresh = img.includes('ripe') || img.includes('upright');
+          const rotten = img.includes('rotten') || img.includes('spilled');
+          const isAudience = type === 'audience' || img.includes('upright') || img.includes('spilled');
+          const slot = isAudience ? 'audience' : 'rottenTomatoes';
+          if (!out[slot]) out[slot] = {
+            value: val, scale: 10,
+            source: isAudience ? 'rt_audience' : 'rt_critic',
+            fresh: fresh || (!rotten && val >= 6),
+          };
+        } else if (img.startsWith('themoviedb://')) {
+          if (!out.audience) out.audience = { value: val, scale: 10, source: 'tmdb' };
+        }
+      }
+      if (!out.imdb) {
+        const l = Number(item?.rating);
+        if (Number.isFinite(l) && l > 0) out.imdb = { value: l, scale: 10, source: 'legacy_rating' };
+      }
+      if (!out.audience) {
+        const l = Number(item?.audienceRating);
+        if (Number.isFinite(l) && l > 0) out.audience = { value: l, scale: 10, source: 'legacy_audience_rating' };
+      }
+      return out;
+    }
+
     async function fetchPlexMediaInfo(ratingKey) {
       if (!ratingKey) return null;
       if (cachedMediaInfo[ratingKey]) return cachedMediaInfo[ratingKey];
@@ -1230,7 +1395,8 @@
           container: (media.container || '').toUpperCase(),
           fileSize: part?.size || 0,
           width: media.width || 0,
-          height: media.height || 0
+          height: media.height || 0,
+          ratings: parseRatingsClient(item),
         };
         cachedMediaInfo[ratingKey] = info;
         return info;
@@ -1238,6 +1404,71 @@
         console.warn('Plex media info fetch error:', err);
         return null;
       }
+    }
+
+    // ===== RATINGS BADGES (#18) =====
+    //
+    // Renders whatever providers the server returned into small themed chips.
+    // Called by showInfo() with the full ratings object or null (to clear).
+    // The body.visual-ratings-badges class gates visibility — when the toggle
+    // is off, innerHTML is still populated but CSS keeps the row hidden. This
+    // way flipping the toggle at runtime doesn't need a re-fetch.
+    const RT_FRESH_SVG = '<svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 2C9 6 7 7 4 8c3 3 3 9 8 12 5-3 5-9 8-12-3-1-5-2-8-6z"/></svg>';
+    const RT_ROTTEN_SVG = '<svg viewBox="0 0 24 24" fill="currentColor"><circle cx="12" cy="12" r="9"/><path d="M8 9l1.5-1 1 1.5M14 10l1-1.5 1.5 1" stroke="#2a1a05" stroke-width="1.3" fill="none" stroke-linecap="round"/></svg>';
+    const AUD_UPRIGHT_SVG = '<svg viewBox="0 0 24 24" fill="currentColor"><path d="M5 9h14l-1 11H6zM7 9V7a5 5 0 0110 0v2"/></svg>';
+    const AUD_SPILLED_SVG = '<svg viewBox="0 0 24 24" fill="currentColor"><path d="M4 11h16l-3 10H7zM6 11l2-5 3 1 2-3 3 2 2 5"/></svg>';
+
+    function formatRatingValue(r) {
+      // Plex reports 0–10 across every provider we care about, so render that
+      // directly (one decimal). If something out-of-band arrives (>10), fall
+      // back to a percentage so it still reads as a meaningful score.
+      if (!r || !Number.isFinite(r.value)) return '';
+      const v = r.value;
+      if (v > 10) return `${Math.round(v)}%`;
+      return v.toFixed(1);
+    }
+
+    function renderRatingsBadges(ratings) {
+      if (!infoRatings) return;
+      infoRatings.classList.remove('has-ratings');
+      infoRatings.innerHTML = '';
+      if (!ratings) return;
+
+      const chips = [];
+
+      if (ratings.imdb) {
+        chips.push(
+          `<span class="rating-badge imdb" title="IMDb">`
+          + `<span class="rating-mark">IMDb</span>`
+          + `<span class="rating-value">${formatRatingValue(ratings.imdb)}</span>`
+          + `<span class="rating-suffix">/10</span>`
+          + `</span>`
+        );
+      }
+      if (ratings.rottenTomatoes) {
+        const fresh = ratings.rottenTomatoes.fresh;
+        chips.push(
+          `<span class="rating-badge rt-critic ${fresh ? 'fresh' : 'rotten'}" title="Rotten Tomatoes — Critics">`
+          + `<span class="rating-mark">${fresh ? RT_FRESH_SVG : RT_ROTTEN_SVG}</span>`
+          + `<span class="rating-value">${Math.round(ratings.rottenTomatoes.value * 10)}%</span>`
+          + `</span>`
+        );
+      }
+      if (ratings.audience) {
+        const isRt = ratings.audience.source === 'rt_audience' || ratings.audience.source === 'legacy_audience_rating';
+        const fresh = ratings.audience.fresh !== false;
+        chips.push(
+          `<span class="rating-badge ${isRt ? 'rt-audience' : 'tmdb'} ${fresh ? 'upright' : 'spilled'}" title="Audience score">`
+          + `<span class="rating-mark">${isRt ? (fresh ? AUD_UPRIGHT_SVG : AUD_SPILLED_SVG) : 'TMDB'}</span>`
+          + `<span class="rating-value">${formatRatingValue(ratings.audience)}</span>`
+          + `<span class="rating-suffix">/10</span>`
+          + `</span>`
+        );
+      }
+
+      if (chips.length === 0) return;
+      infoRatings.innerHTML = chips.join('');
+      infoRatings.classList.add('has-ratings');
     }
 
     async function showInfo() {
@@ -1285,11 +1516,15 @@
         infoSummary.style.display = 'none';
       }
 
-      // Media file info from Plex API
+      // Media file info from Plex API. In SERVER_MODE the server proxies the
+      // Plex request (so the browser doesn't need PLEX_URL); in HACS-only mode
+      // we fall through to the direct fetch which requires the URL + token.
       infoTech.innerHTML = '';
-      if (d.ratingKey && PLEX_URL) {
+      renderRatingsBadges(null); // reset
+      if (d.ratingKey && (SERVER_MODE || PLEX_URL)) {
         const mi = await fetchPlexMediaInfo(d.ratingKey);
         if (mi) {
+          renderRatingsBadges(mi.ratings);
           let techTags = [];
           if (mi.width && mi.height) techTags.push(`${mi.width}×${mi.height}`);
           if (mi.videoCodec) {
@@ -1321,14 +1556,57 @@
 
       infoOverlay.classList.add('visible');
 
-      // Auto-hide after 8 seconds
+      // Auto-hide after 8 seconds — but only in on_tap mode. on_pause and
+      // always keep the panel up until the state changes (pause → play, or
+      // media ends).
       clearTimeout(infoTimeout);
-      infoTimeout = setTimeout(hideInfo, 8000);
+      if (VISUAL.infoPanelMode === 'on_tap') {
+        infoTimeout = setTimeout(hideInfo, 8000);
+      }
     }
 
     function hideInfo() {
       infoOverlay.classList.remove('visible');
+      document.body.classList.remove('info-pinned');
       clearTimeout(infoTimeout);
+    }
+
+    // Called from showMedia() on every poll so the info panel reflects the
+    // current playback state for the active mode. Tap-driven visibility in
+    // on_tap and on_pause is preserved; showInfo() is only *forced* when the
+    // mode demands persistence. Returns true if the panel is now being forced
+    // open by the mode so the caller can skip conflicting hide() calls.
+    function syncInfoPanelForMode(data) {
+      if (!data) {
+        hideInfo();
+        return false;
+      }
+      if (VISUAL.infoPanelMode === 'always') {
+        // Panel is shown whenever media is active, paused or playing.
+        // Mark as mode-pinned so CSS drops the full-screen 85 % dim and
+        // uses a bottom-up gradient behind just the panel instead.
+        document.body.classList.add('info-pinned');
+        showInfo();
+        return true;
+      }
+      if (VISUAL.infoPanelMode === 'on_pause') {
+        if (data.state === 'paused') {
+          // Pinned-by-mode: no dim, just the gradient under the panel.
+          // A subsequent tap clears info-pinned so the user gets the full
+          // dim as a peek affordance.
+          document.body.classList.add('info-pinned');
+          showInfo();
+          return true;
+        }
+        // Play resumed — if the panel was pinned open by the previous pause
+        // cycle (no 8 s timer was set), retract it. If the user had opened it
+        // via tap, a timer is ticking and will hide it shortly; leaving it
+        // visible until the timer fires matches on_tap behaviour.
+        if (!infoTimeout) hideInfo();
+        return false;
+      }
+      // on_tap: fully user-driven, nothing to sync.
+      return false;
     }
 
     // ===== OUTER BULB LIGHTS (around screen edge) =====
@@ -1550,11 +1828,25 @@
         : `${HA_URL}${data.artwork}`;
 
       const mediaKey = `${data.title}_${data.seriesTitle}_${artworkUrl}`;
+      const isSameMedia = mediaKey === currentMediaKey && isShowingMedia;
 
-      if (mediaKey === currentMediaKey && isShowingMedia) return;
+      // Always keep currentMediaData fresh so syncInfoPanelForMode() sees the
+      // latest state (play vs. paused) even when the media itself hasn't
+      // changed — otherwise on_pause couldn't react to a pause event on the
+      // same movie.
+      currentMediaData = data;
+
+      if (isSameMedia) {
+        // Same media, but playback state may have flipped (play ↔ pause).
+        // Let the active info-panel mode decide whether to show/hide, refresh
+        // the progress bar's paused class, then bail out of the full re-render.
+        syncInfoPanelForMode(data);
+        setProgressFromState(data);
+        return;
+      }
+
       currentMediaKey = mediaKey;
       isShowingMedia = true;
-      currentMediaData = data;
       hideInfo();
 
       // Update poster background image
@@ -1612,6 +1904,10 @@
 
       // Progress bar — updated every poll; no-ops when toggle is off.
       setProgressFromState(data);
+
+      // Info-panel mode may need the panel to appear on first frame of new
+      // media (always), on pause state (on_pause), or not at all (on_tap).
+      syncInfoPanelForMode(data);
     }
 
     function showIdle() {


### PR DESCRIPTION
Closes #18.

Ships two companion features behind the same visual-toggle pattern from #17:

1. **Ratings badges** (IMDb / RT critic / audience) on the info panel
2. **Info panel visibility mode** so the panel (and the new chips) can be pinned open

## Ratings badges

- `server/src/plex.js`: new `parseRatings(item)` export. Handles the modern `Rating[]` shape from `/library/metadata/{id}` via `image` URIs:
  - `imdb://image.rating` → `imdb`
  - `rottentomatoes://image.rating.ripe|rotten` → `rottenTomatoes` critic (with `fresh` flag)
  - `rottentomatoes://image.rating.upright|spilled` → `audience` (RT audience, `fresh` flag)
  - `themoviedb://image.rating` → `audience` fallback only if no RT audience
  - Legacy `rating` / `audienceRating` scalar fallback when `Rating[]` is absent
  - `0` or non-finite values treated as unknown so empty Plex entries don't render `0.0/10`
- `fetchMediaInfo()` now includes a `ratings: { imdb, rottenTomatoes, audience }` block
- Frontend widget with inline SVG marks for RT fresh/rotten and audience upright/spilled
- `parseRatingsClient(item)` mirrors the server parser for the HACS direct-to-Plex path
- `VISUAL_RATINGS_BADGES` env / `visual_ratings_badges` option (default false)

### Drive-by fix

`if (d.ratingKey && PLEX_URL)` → `if (d.ratingKey && (SERVER_MODE || PLEX_URL))` — browsers in server/add-on mode don't see `PLEX_URL`, so `/api/media-info/{id}` was never called. Unblocks ratings *and* the tech tags from #16 for ingress users.

## Info panel visibility mode

New `VISUAL_INFO_PANEL_MODE` env / `visual_info_panel_mode` add-on option with three values:

| Mode | Behaviour |
|------|-----------|
| `on_tap` (default) | Panel hidden until the user taps the poster, auto-hides after 8 s. Matches v1. |
| `on_pause` | Panel pinned open whenever the player is paused. Tap-to-peek still works while playing. |
| `always` | Panel pinned open the entire time media is active. Tap is suppressed so the UI can't be accidentally hidden. |

Implementation:
- String enum validated by a new `parseEnum()` helper in `config.js`
- Surfaced via `/api/config` → `body.info-mode-{on-tap,on-pause,always}` classes
- `syncInfoPanelForMode(data)` called from `showMedia()` on every poll so pause ↔ play flips on the same media are honoured without waiting for a media change
- `showInfo()` only arms the 8 s auto-hide timer in `on_tap`
- Tap handler suppressed in `always` mode (tapping would just be re-opened on the next poll)
- Hint text "Tap anywhere to dismiss" is hidden in `always` mode (inaccurate there)

## Plumbing (both features)

- `addons/plex-now-showing/config.yaml` — both options + schema (`bool` and `list(on_tap|on_pause|always)`)
- `rootfs/etc/services.d/plex-now-showing/run` — `export_opt` + diagnostic log lines
- `translations/en.yaml`, `CHANGELOG.md`, `DOCS.md`
- `docker/docker-compose.example.yml` + `docker/.env.example`
- `server/README.md`

## Tests

56 → 71 passing:
- `server/test/plex.test.js`: +10 — falsy input, Rating[] parsing, fresh/rotten flags, legacy scalar fallback, precedence, TMDB audience fallback, invalid values, fixture integration
- `server/test/config.test.js`: +5 — `VISUAL_RATINGS_BADGES`, `VISUAL_INFO_PANEL_MODE` default + accepted values + invalid fallback + case-insensitive
- `server/test/routes.test.js`: `/api/config` asserts all three flags, plus new `surfaces infoPanelMode when set` + `surfaces ratingsBadges when enabled` cases
- Fixture `plex_metadata_12345.json` extended with `rating`, `audienceRating`, and a `Rating[]` covering imdb + RT ripe + RT upright

## Preview

Captured with a patched harness (`PREVIEW_INFO_PANEL_MODE` / `PREVIEW_PAUSED` / `PREVIEW_RATINGS_BADGES` envs) that serves canned `/api/media-info`:

- **on_tap + playing** → panel hidden (today's look)
- **on_pause + playing** → panel hidden, tap opens it with the 8 s timer
- **on_pause + paused** → panel auto-opens persistently, `PAUSED` chip in meta row
- **always + playing** → panel pinned open, hint hidden