### PR TITLE
[viz-4] Genre chips on info panel

### DIFF
--- a/addons/plex-now-showing/CHANGELOG.md
+++ b/addons/plex-now-showing/CHANGELOG.md
@@ -34,3 +34,9 @@ The project follows [Semantic Versioning](https://semver.org/).
   `on_tap` (default, current behaviour), `on_pause` (panel pinned open
   whenever the player is paused; tap-to-peek still works while playing),
   and `always` (panel pinned open the entire time media is active).
+- Genre chips (closes #20). Opt-in via `visual_genre_chips: true` — genre
+  pills (Action, Sci-Fi, …) appended to the content-rating row on the
+  info panel. Tags read from Plex metadata (`item.Genre[]`) via the
+  existing media-info pipeline; requires `plex_url` + `plex_token`. Capped
+  at 6 entries and deduped so a long sub-genre list can't blow out the
+  layout.

--- a/addons/plex-now-showing/DOCS.md
+++ b/addons/plex-now-showing/DOCS.md
@@ -37,6 +37,7 @@ and HA tokens never leave the add-on.
 | `fully_kiosks` | `[]` | List of tablets to drive. See below. |
 | `visual_progress_bar` | `false` | Slim gold progress bar along the bottom of the poster. See **Visual toggles** below. |
 | `visual_ratings_badges` | `false` | IMDb / Rotten Tomatoes / audience badges on the info panel. Needs `plex_url` + `plex_token`. |
+| `visual_genre_chips` | `false` | Genre pills (Action, Sci-Fi, …) next to the content rating in the info panel. Needs `plex_url` + `plex_token`. |
 | `visual_info_panel_mode` | `on_tap` | When to show the info panel. `on_tap` (default), `on_pause` (pinned while paused), `always` (pinned whenever media is active). |
 | `log_level` | `info` | s6 / add-on log verbosity. |
 
@@ -50,12 +51,14 @@ through to the browser automatically — no rebuild, no per-tablet config.
 |--------|--------------|
 | `visual_progress_bar` | Adds a slim gold playback bar along the bottom of the poster. Tracks HA's `media_position`, interpolated between polls so it moves smoothly. Dimmed while paused, hidden while idle. |
 | `visual_ratings_badges` | Adds IMDb, Rotten Tomatoes (fresh/rotten), and audience score chips on the info panel that slides up when you tap the kiosk. Scores are pulled server-side from Plex's `/library/metadata/{id}` via the existing `/api/media-info/:ratingKey` endpoint — requires `plex_url` + `plex_token` to be set. |
+| `visual_genre_chips` | Adds genre pills (Action, Sci-Fi, …) next to the content rating in the info panel. Tags are pulled from Plex metadata (`item.Genre[]`) via `/api/media-info/:ratingKey` — requires `plex_url` + `plex_token`. Personal media libraries without metadata agents will simply render nothing, which is fine. Capped at 6 chips to keep the meta row tidy. |
 | `visual_info_panel_mode` | Controls **when** the whole info panel appears. `on_tap` (default) matches v1 behaviour — hidden until you tap the poster, auto-hides after 8 s. `on_pause` pins the panel open whenever the player is paused (tap-to-peek still works during playback). `always` keeps the panel open the entire time media is active; tap is suppressed. Combine with `visual_ratings_badges` if you want ratings visible on pause or always. |
 
 HACS-only users (no add-on / server) can flip any visual toggle per tablet
 by setting `pns.visualProgressBar=true` / `pns.visualRatingsBadges=true` /
-`pns.visualInfoPanelMode=on_pause` in `localStorage` or adding
-`#visualProgressBar=true` / `#visualRatingsBadges=true` /
+`pns.visualGenreChips=true` / `pns.visualInfoPanelMode=on_pause` in
+`localStorage` or adding `#visualProgressBar=true` /
+`#visualRatingsBadges=true` / `#visualGenreChips=true` /
 `#visualInfoPanelMode=always` to the kiosk URL.
 
 ### Fully Kiosk auto-switcher (#48)

--- a/addons/plex-now-showing/config.yaml
+++ b/addons/plex-now-showing/config.yaml
@@ -60,6 +60,7 @@ options:
   # keep the original look until the user opts in.
   visual_progress_bar: false
   visual_ratings_badges: false
+  visual_genre_chips: false
   visual_info_panel_mode: on_tap
   log_level: info
 schema:
@@ -84,6 +85,7 @@ schema:
       stopped_url: "url?"
   visual_progress_bar: "bool"
   visual_ratings_badges: "bool"
+  visual_genre_chips: "bool"
   visual_info_panel_mode: "list(on_tap|on_pause|always)"
   log_level: "list(trace|debug|info|notice|warning|error|fatal)?"
 image: ghcr.io/rusty4444/plex-now-showing-{arch}

--- a/addons/plex-now-showing/rootfs/etc/services.d/plex-now-showing/run
+++ b/addons/plex-now-showing/rootfs/etc/services.d/plex-now-showing/run
@@ -59,6 +59,7 @@ fi
 # ---- Visual toggles (V2 visual sprint) ----
 export_opt VISUAL_PROGRESS_BAR     visual_progress_bar
 export_opt VISUAL_RATINGS_BADGES   visual_ratings_badges
+export_opt VISUAL_GENRE_CHIPS      visual_genre_chips
 export_opt VISUAL_INFO_PANEL_MODE  visual_info_panel_mode
 
 # ---- Diagnostics (no secrets) ----
@@ -75,6 +76,7 @@ bashio::log.info "Proxy secret:             $([[ -n "${PROXY_SECRET}" ]] && echo
 bashio::log.info "Allowed origins:          ${ALLOWED_ORIGINS:-<any (ingress-only)>}"
 bashio::log.info "Visual progress bar:      ${VISUAL_PROGRESS_BAR:-false}"
 bashio::log.info "Visual ratings badges:    ${VISUAL_RATINGS_BADGES:-false}"
+bashio::log.info "Visual genre chips:       ${VISUAL_GENRE_CHIPS:-false}"
 bashio::log.info "Info panel mode:          ${VISUAL_INFO_PANEL_MODE:-on_tap}"
 bashio::log.info "Switcher enabled:         ${SWITCHER_ENABLED:-false}"
 if bashio::var.true "${SWITCHER_ENABLED:-false}"; then

--- a/addons/plex-now-showing/translations/en.yaml
+++ b/addons/plex-now-showing/translations/en.yaml
@@ -76,6 +76,12 @@ configuration:
       Adds IMDb, Rotten Tomatoes, and audience score badges to the info
       panel (shown when you tap the kiosk). Requires plex_url + plex_token
       so the server can read ratings from /library/metadata. Off by default.
+  visual_genre_chips:
+    name: Show genre chips
+    description: >-
+      Adds genre pills (Action, Sci-Fi, …) next to the content rating in
+      the info panel. Populated from Plex metadata; requires plex_url +
+      plex_token. Off by default.
   visual_info_panel_mode:
     name: Info panel visibility
     description: >-

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -35,6 +35,10 @@ VISUAL_PROGRESS_BAR=false
 # IMDb / Rotten Tomatoes / audience score badges on the info panel.
 # Requires PLEX_URL + PLEX_TOKEN so the server can read /library/metadata.
 VISUAL_RATINGS_BADGES=false
+# Genre pills (Action, Sci-Fi, …) next to the content rating.
+# Same requirement: PLEX_URL + PLEX_TOKEN. Empty for personal media without
+# metadata agents; capped at 6 entries.
+VISUAL_GENRE_CHIPS=false
 # When to show the info panel (title, ratings, meta, tech tags).
 # One of: on_tap (default, tap-to-peek), on_pause, always.
 VISUAL_INFO_PANEL_MODE=on_tap

--- a/docker/docker-compose.example.yml
+++ b/docker/docker-compose.example.yml
@@ -50,6 +50,7 @@ services:
       # ---- Visual toggles (v2 visual sprint) ----
       VISUAL_PROGRESS_BAR: "${VISUAL_PROGRESS_BAR:-false}"
       VISUAL_RATINGS_BADGES: "${VISUAL_RATINGS_BADGES:-false}"
+      VISUAL_GENRE_CHIPS: "${VISUAL_GENRE_CHIPS:-false}"
       VISUAL_INFO_PANEL_MODE: "${VISUAL_INFO_PANEL_MODE:-on_tap}"
 
       # ---- Optional hardening (recommended if exposed off-LAN) ----

--- a/server/README.md
+++ b/server/README.md
@@ -61,6 +61,7 @@ For HA Container users running via Docker Compose. Set:
 | `FULLY_KIOSKS` | – | One kiosk per line: `host|password|playing_url[|stopped_url]` |
 | `VISUAL_PROGRESS_BAR` | `false` | Show a slim gold progress bar along the bottom of the poster |
 | `VISUAL_RATINGS_BADGES` | `false` | Show IMDb / Rotten Tomatoes / audience score badges in the info panel (needs `PLEX_URL` + `PLEX_TOKEN`) |
+| `VISUAL_GENRE_CHIPS` | `false` | Show genre pills next to the content rating in the info panel (needs `PLEX_URL` + `PLEX_TOKEN`) |
 | `VISUAL_INFO_PANEL_MODE` | `on_tap` | When to show the info panel: `on_tap`, `on_pause`, or `always` |
 | `STATIC_DIR` | `../www` | Override where `now_showing.html` is served from |
 

--- a/server/fixtures/plex_metadata_12345.json
+++ b/server/fixtures/plex_metadata_12345.json
@@ -53,6 +53,23 @@
             "value": 9.1,
             "type": "audience"
           }
+        ],
+        "Genre": [
+          {
+            "id": 1,
+            "filter": "genre=1",
+            "tag": "Action"
+          },
+          {
+            "id": 2,
+            "filter": "genre=2",
+            "tag": "Adventure"
+          },
+          {
+            "id": 3,
+            "filter": "genre=3",
+            "tag": "Science Fiction"
+          }
         ]
       }
     ]

--- a/server/src/config.js
+++ b/server/src/config.js
@@ -51,6 +51,9 @@ export function loadConfig(env = process.env) {
     visual: {
       progressBar: parseBool(env.VISUAL_PROGRESS_BAR, false),
       ratingsBadges: parseBool(env.VISUAL_RATINGS_BADGES, false),
+      // Render genre chips (Action, Sci-Fi, …) next to the content rating.
+      // Populated from Plex metadata (item.Genre[]); empty for personal media.
+      genreChips: parseBool(env.VISUAL_GENRE_CHIPS, false),
       // How the info panel (title + ratings + meta + tech) is revealed:
       //   'on_tap'   — default; hidden until the user taps the poster (8 s peek)
       //   'on_pause' — persistently shown while paused, still tappable when playing

--- a/server/src/plex.js
+++ b/server/src/plex.js
@@ -114,6 +114,34 @@ export function parseRatings(item) {
   return out;
 }
 
+// parseGenres — #20 Genre chips. Plex exposes genres via `item.Genre` when the
+// metadata agent has scraped them:
+//
+//   [ { id: 1, filter: 'genre=1', tag: 'Action' },
+//     { id: 2, filter: 'genre=2', tag: 'Adventure' }, ... ]
+//
+// Some libraries omit the array entirely (music, personal media); others have
+// duplicate tags from multiple agents. We normalise to a deduped array of
+// non-empty strings in original order, preserving Plex's ranking (the first
+// entry is typically the primary genre). Capped at 6 to stop a long metal
+// album's 17 sub-genres from wrapping onto three lines in the info panel.
+export function parseGenres(item, { max = 6 } = {}) {
+  if (!item || !Array.isArray(item.Genre)) return [];
+  const seen = new Set();
+  const out = [];
+  for (const g of item.Genre) {
+    if (!g || typeof g.tag !== 'string') continue;
+    const tag = g.tag.trim();
+    if (!tag) continue;
+    const key = tag.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(tag);
+    if (out.length >= max) break;
+  }
+  return out;
+}
+
 export async function fetchMediaInfo({ plexUrl, plexToken, ratingKey, fetchImpl = globalThis.fetch }) {
   if (!plexUrl || !plexToken || !ratingKey) return null;
 
@@ -149,5 +177,6 @@ export async function fetchMediaInfo({ plexUrl, plexToken, ratingKey, fetchImpl 
     width: media.width || 0,
     height: media.height || 0,
     ratings: parseRatings(item),
+    genres: parseGenres(item),
   };
 }

--- a/server/src/routes/config.js
+++ b/server/src/routes/config.js
@@ -17,6 +17,7 @@ export function configRoute({ config }) {
       visual: {
         progressBar: !!config.visual?.progressBar,
         ratingsBadges: !!config.visual?.ratingsBadges,
+        genreChips: !!config.visual?.genreChips,
         infoPanelMode: config.visual?.infoPanelMode || 'on_tap',
       },
     });

--- a/server/test/config.test.js
+++ b/server/test/config.test.js
@@ -51,6 +51,7 @@ test('visual toggles all default to false', () => {
   const { config } = loadConfig({ SUPERVISOR_TOKEN: 'x' });
   assert.equal(config.visual.progressBar, false);
   assert.equal(config.visual.ratingsBadges, false);
+  assert.equal(config.visual.genreChips, false);
 });
 
 test('VISUAL_PROGRESS_BAR=true flips the progress-bar toggle on', () => {
@@ -62,6 +63,13 @@ test('VISUAL_RATINGS_BADGES=true flips the ratings-badges toggle on', () => {
   const { config } = loadConfig({ SUPERVISOR_TOKEN: 'x', VISUAL_RATINGS_BADGES: 'true' });
   assert.equal(config.visual.ratingsBadges, true);
   assert.equal(config.visual.progressBar, false);
+});
+
+test('VISUAL_GENRE_CHIPS=true flips the genre-chips toggle on', () => {
+  const { config } = loadConfig({ SUPERVISOR_TOKEN: 'x', VISUAL_GENRE_CHIPS: 'true' });
+  assert.equal(config.visual.genreChips, true);
+  assert.equal(config.visual.progressBar, false);
+  assert.equal(config.visual.ratingsBadges, false);
 });
 
 test('VISUAL_INFO_PANEL_MODE defaults to on_tap', () => {

--- a/server/test/plex.test.js
+++ b/server/test/plex.test.js
@@ -4,7 +4,7 @@ import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
-import { parseRatingKey, fetchMediaInfo, parseRatings } from '../src/plex.js';
+import { parseRatingKey, fetchMediaInfo, parseRatings, parseGenres } from '../src/plex.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const metadata = JSON.parse(
@@ -163,4 +163,72 @@ test('fetchMediaInfo: surfaces ratings from the canned fixture', async () => {
   assert.equal(info.ratings.rottenTomatoes.value, 9.3);
   assert.equal(info.ratings.rottenTomatoes.fresh, true);
   assert.equal(info.ratings.audience.value, 9.1);
+});
+
+// ----- #20 parseGenres ---------------------------------------------------
+
+test('parseGenres: returns [] for falsy / missing input', () => {
+  assert.deepEqual(parseGenres(null), []);
+  assert.deepEqual(parseGenres(undefined), []);
+  assert.deepEqual(parseGenres({}), []);
+  assert.deepEqual(parseGenres({ Genre: null }), []);
+});
+
+test('parseGenres: returns tag strings in original order', () => {
+  const g = parseGenres({
+    Genre: [
+      { id: 1, tag: 'Action' },
+      { id: 2, tag: 'Adventure' },
+      { id: 3, tag: 'Science Fiction' },
+    ],
+  });
+  assert.deepEqual(g, ['Action', 'Adventure', 'Science Fiction']);
+});
+
+test('parseGenres: dedupes case-insensitively, keeps first casing', () => {
+  const g = parseGenres({
+    Genre: [
+      { tag: 'Sci-Fi' },
+      { tag: 'sci-fi' },      // duplicate
+      { tag: 'SCI-FI' },       // duplicate
+      { tag: 'Drama' },
+    ],
+  });
+  assert.deepEqual(g, ['Sci-Fi', 'Drama']);
+});
+
+test('parseGenres: skips entries without a non-empty string tag', () => {
+  const g = parseGenres({
+    Genre: [
+      { tag: 'Action' },
+      { tag: '' },
+      { tag: '   ' },
+      { id: 99 },
+      null,
+      { tag: 42 },
+      { tag: 'Thriller' },
+    ],
+  });
+  assert.deepEqual(g, ['Action', 'Thriller']);
+});
+
+test('parseGenres: caps output at the configurable max (default 6)', () => {
+  const many = Array.from({ length: 12 }, (_, i) => ({ tag: `Genre${i}` }));
+  assert.equal(parseGenres({ Genre: many }).length, 6);
+  assert.equal(parseGenres({ Genre: many }, { max: 3 }).length, 3);
+});
+
+test('parseGenres: trims surrounding whitespace on tags', () => {
+  const g = parseGenres({
+    Genre: [{ tag: '  Horror  ' }, { tag: 'Mystery' }],
+  });
+  assert.deepEqual(g, ['Horror', 'Mystery']);
+});
+
+test('fetchMediaInfo: surfaces genres from the canned fixture', async () => {
+  const fetchImpl = async () => ({ ok: true, async json() { return metadata; } });
+  const info = await fetchMediaInfo({
+    plexUrl: 'u', plexToken: 't', ratingKey: '12345', fetchImpl,
+  });
+  assert.deepEqual(info.genres, ['Action', 'Adventure', 'Science Fiction']);
 });

--- a/server/test/routes.test.js
+++ b/server/test/routes.test.js
@@ -31,7 +31,7 @@ function baseConfig(overrides = {}) {
     allowedOrigins: [],
     stateTtl: 3000,
     mediaInfoTtl: 600000,
-    visual: { progressBar: false, ratingsBadges: false, infoPanelMode: 'on_tap' },
+    visual: { progressBar: false, ratingsBadges: false, genreChips: false, infoPanelMode: 'on_tap' },
     staticDir: join(__dirname, '..', 'fixtures'),
     ...overrides,
   };
@@ -106,7 +106,7 @@ test('GET /api/config defaults every visual toggle off', async () => {
     assert.equal(resp.status, 200);
     assert.equal(resp.headers.get('cache-control'), 'no-store');
     const body = await resp.json();
-    assert.deepEqual(body, { visual: { progressBar: false, ratingsBadges: false, infoPanelMode: 'on_tap' } });
+    assert.deepEqual(body, { visual: { progressBar: false, ratingsBadges: false, genreChips: false, infoPanelMode: 'on_tap' } });
   } finally { server.close(); }
 });
 
@@ -144,6 +144,20 @@ test('GET /api/config surfaces ratingsBadges when enabled', async () => {
   try {
     const body = await fetch(`${url}/api/config`).then(r => r.json());
     assert.equal(body.visual.ratingsBadges, true);
+  } finally { server.close(); }
+});
+
+test('GET /api/config surfaces genreChips when enabled', async () => {
+  const haClient = { getStates: async () => haStates };
+  const { server, url } = await startApp(
+    baseConfig({ visual: { progressBar: false, ratingsBadges: false, genreChips: true } }),
+    haClient,
+  );
+  try {
+    const body = await fetch(`${url}/api/config`).then(r => r.json());
+    assert.equal(body.visual.genreChips, true);
+    assert.equal(body.visual.progressBar, false);
+    assert.equal(body.visual.ratingsBadges, false);
   } finally { server.close(); }
 });
 

--- a/www/now_showing.html
+++ b/www/now_showing.html
@@ -522,6 +522,30 @@
       text-transform: uppercase;
     }
 
+    /* ===== GENRE CHIPS (#20) =====
+       Shown inline in the same .info-meta row as the meta tags (Movie / PG-13 /
+       runtime / Paused). Hidden by default; body.visual-genre-chips toggles them
+       on. Chips use a cooler slate-blue tint so they read as a distinct
+       taxonomic axis from the gold meta tags without clashing with the classic
+       gold theme. Rounded pill shape distinguishes them at a glance. */
+    .info-panel .info-genre {
+      display: none;
+      font-family: 'Inter', sans-serif;
+      font-size: clamp(0.7rem, 1.7vw, 0.85rem);
+      font-weight: 500;
+      letter-spacing: 0.03em;
+      color: rgba(220, 230, 245, 0.92);
+      background: rgba(80, 110, 150, 0.25);
+      border: 1px solid rgba(140, 170, 200, 0.25);
+      padding: 3px 11px;
+      border-radius: 999px;
+      text-transform: none;
+      white-space: nowrap;
+    }
+    body.visual-genre-chips .info-panel .info-genre {
+      display: inline-block;
+    }
+
     /* ===== RATINGS BADGES (#18) =====
        Shown between subtitle and meta row inside .info-panel. Hidden by default;
        body.visual-ratings-badges toggles them on. Each provider renders as a
@@ -1054,7 +1078,7 @@
     // Server config wins so operators can ship a consistent look across the
     // fleet without touching every tablet.
     const INFO_PANEL_MODES = ['on_tap', 'on_pause', 'always'];
-    const VISUAL = { progressBar: false, ratingsBadges: false, infoPanelMode: 'on_tap' };
+    const VISUAL = { progressBar: false, ratingsBadges: false, genreChips: false, infoPanelMode: 'on_tap' };
 
     function readInfoPanelMode(defaultValue) {
       // Hash override takes precedence over localStorage so tablet operators can
@@ -1072,6 +1096,7 @@
       // the server is briefly unreachable.
       VISUAL.progressBar = readBool('visualProgressBar', false);
       VISUAL.ratingsBadges = readBool('visualRatingsBadges', false);
+      VISUAL.genreChips = readBool('visualGenreChips', false);
       VISUAL.infoPanelMode = readInfoPanelMode('on_tap');
 
       await serverModeReady;
@@ -1083,6 +1108,7 @@
         const v = body && body.visual;
         if (v && typeof v.progressBar === 'boolean') VISUAL.progressBar = v.progressBar;
         if (v && typeof v.ratingsBadges === 'boolean') VISUAL.ratingsBadges = v.ratingsBadges;
+        if (v && typeof v.genreChips === 'boolean') VISUAL.genreChips = v.genreChips;
         if (v && typeof v.infoPanelMode === 'string' && INFO_PANEL_MODES.includes(v.infoPanelMode)) {
           VISUAL.infoPanelMode = v.infoPanelMode;
         }
@@ -1094,6 +1120,7 @@
     function applyVisualToggles() {
       document.body.classList.toggle('visual-progress-bar', VISUAL.progressBar);
       document.body.classList.toggle('visual-ratings-badges', VISUAL.ratingsBadges);
+      document.body.classList.toggle('visual-genre-chips', VISUAL.genreChips);
       // Exactly one info-mode-* class is set so CSS / JS can branch without
       // juggling multiple booleans.
       document.body.classList.toggle('info-mode-on-tap', VISUAL.infoPanelMode === 'on_tap');
@@ -1471,6 +1498,31 @@
       infoRatings.classList.add('has-ratings');
     }
 
+    // ===== GENRE CHIPS (#20) =====
+    //
+    // Appends <span class="info-genre">…</span> chips into the meta row.
+    // `renderGenreChips(null)` clears any stale chips from the previous
+    // media before /api/media-info returns for the new one. When the
+    // visual-genre-chips toggle is off the CSS keeps the chips hidden even
+    // though the DOM is populated — same pattern as ratings-badges.
+    function renderGenreChips(genres) {
+      if (!infoMeta) return;
+      // Remove any existing genre chips from the row. We keep the info-tag
+      // spans intact (type / rating / runtime / paused) and only strip
+      // .info-genre so re-renders don't double up.
+      infoMeta.querySelectorAll('.info-genre').forEach(el => el.remove());
+      if (!Array.isArray(genres) || genres.length === 0) return;
+      const frag = document.createDocumentFragment();
+      for (const g of genres) {
+        if (typeof g !== 'string' || !g.trim()) continue;
+        const span = document.createElement('span');
+        span.className = 'info-genre';
+        span.textContent = g;
+        frag.appendChild(span);
+      }
+      infoMeta.appendChild(frag);
+    }
+
     async function showInfo() {
       if (!currentMediaData) return;
       const d = currentMediaData;
@@ -1507,6 +1559,12 @@
       }
       if (d.state === 'paused') tags.push('Paused');
       infoMeta.innerHTML = tags.map(t => `<span class="info-tag">${t}</span>`).join('');
+      // Genre chips (#20) append to the same row so they flow naturally on a
+      // single line when there's room and wrap when there isn't. Populated
+      // only once /api/media-info returns; until then the row just shows
+      // type / rating / runtime / paused. CSS gate (visual-genre-chips) keeps
+      // the chips hidden when the toggle is off even if the array is set.
+      renderGenreChips(null);
 
       // Synopsis
       if (d.summary) {
@@ -1525,6 +1583,7 @@
         const mi = await fetchPlexMediaInfo(d.ratingKey);
         if (mi) {
           renderRatingsBadges(mi.ratings);
+          renderGenreChips(mi.genres);
           let techTags = [];
           if (mi.width && mi.height) techTags.push(`${mi.width}×${mi.height}`);
           if (mi.videoCodec) {


### PR DESCRIPTION
Closes #20.

Adds opt-in genre chips next to the content-rating row on the info panel. Pulls genre tags from Plex's `item.Genre[]` via the existing `/api/media-info/:ratingKey` server pipeline — requires `plex_url` + `plex_token` like the ratings badges. Defaults off; enable with `visual_genre_chips: true` in add-on options or `VISUAL_GENRE_CHIPS=true` in Docker.

### Behaviour
- Slate-blue pill style so chips read as a distinct taxonomic axis from the gold meta tags.
- Deduped case-insensitively (some Plex agents emit duplicate tags).
- Capped at 6 entries so a 17-sub-genre metal album can't wrap onto three lines.
- Trimmed of surrounding whitespace. Empty/non-string tags silently dropped.
- Uses `textContent`, not `innerHTML` — Plex-sourced tags can't inject markup.
- Personal media libraries without metadata agents get an empty array, which renders nothing (no empty row).

### Screenshots
Toggle off → no chips in the meta row. Toggle on → chips appended on the same row, wrapping naturally.

### Tests
80/80 pass. Added: 6 `parseGenres` unit cases + 1 fixture-based integration case + 3 config/routes cases for the new toggle.