### PR TITLE
[viz-5] Backdrop art on pause (#21)

### DIFF
--- a/addons/plex-now-showing/CHANGELOG.md
+++ b/addons/plex-now-showing/CHANGELOG.md
@@ -40,3 +40,13 @@ The project follows [Semantic Versioning](https://semver.org/).
   existing media-info pipeline; requires `plex_url` + `plex_token`. Capped
   at 6 entries and deduped so a long sub-genre list can't blow out the
   layout.
+- Backdrop art on pause (closes #21). Opt-in via `visual_use_backdrops:
+  true`. Two styles: `fullscreen` (default) crossfades the poster view to
+  the Plex fanart after `visual_backdrop_delay_ms` of sustained pause on
+  landscape devices; `ambient` replaces the yellow bulb-lit background
+  with a blurred and darkened copy of the fanart whenever media is active,
+  and works in both orientations because the blur makes aspect ratio moot.
+  Fanart is proxied through a new `/api/plex-art?path=…` endpoint so the
+  Plex token never reaches the browser; the proxy rejects any path that
+  doesn't start with `/library/` to block SSRF-style abuse. Requires
+  `plex_url` + `plex_token`.

--- a/addons/plex-now-showing/DOCS.md
+++ b/addons/plex-now-showing/DOCS.md
@@ -39,6 +39,9 @@ and HA tokens never leave the add-on.
 | `visual_ratings_badges` | `false` | IMDb / Rotten Tomatoes / audience badges on the info panel. Needs `plex_url` + `plex_token`. |
 | `visual_genre_chips` | `false` | Genre pills (Action, Sci-Fi, …) next to the content rating in the info panel. Needs `plex_url` + `plex_token`. |
 | `visual_info_panel_mode` | `on_tap` | When to show the info panel. `on_tap` (default), `on_pause` (pinned while paused), `always` (pinned whenever media is active). |
+| `visual_use_backdrops` | `false` | Master switch for the backdrop-art feature. Needs `plex_url` + `plex_token`. |
+| `visual_backdrop_style` | `fullscreen` | `fullscreen` (landscape-only crossfade after `visual_backdrop_delay_ms`) or `ambient` (blurred fanart behind the poster, both orientations). |
+| `visual_backdrop_delay_ms` | `10000` | Pause threshold before the fullscreen backdrop fades in (ms, clamped 1000–600000). |
 | `log_level` | `info` | s6 / add-on log verbosity. |
 
 ### Visual toggles (V2)
@@ -53,13 +56,17 @@ through to the browser automatically — no rebuild, no per-tablet config.
 | `visual_ratings_badges` | Adds IMDb, Rotten Tomatoes (fresh/rotten), and audience score chips on the info panel that slides up when you tap the kiosk. Scores are pulled server-side from Plex's `/library/metadata/{id}` via the existing `/api/media-info/:ratingKey` endpoint — requires `plex_url` + `plex_token` to be set. |
 | `visual_genre_chips` | Adds genre pills (Action, Sci-Fi, …) next to the content rating in the info panel. Tags are pulled from Plex metadata (`item.Genre[]`) via `/api/media-info/:ratingKey` — requires `plex_url` + `plex_token`. Personal media libraries without metadata agents will simply render nothing, which is fine. Capped at 6 chips to keep the meta row tidy. |
 | `visual_info_panel_mode` | Controls **when** the whole info panel appears. `on_tap` (default) matches v1 behaviour — hidden until you tap the poster, auto-hides after 8 s. `on_pause` pins the panel open whenever the player is paused (tap-to-peek still works during playback). `always` keeps the panel open the entire time media is active; tap is suppressed. Combine with `visual_ratings_badges` if you want ratings visible on pause or always. |
+| `visual_use_backdrops` / `visual_backdrop_style` / `visual_backdrop_delay_ms` | Backdrop art on pause (#21). **Master switch** is `visual_use_backdrops`. **Style** picks between `fullscreen` (after the item has been paused for `visual_backdrop_delay_ms`, the poster view crossfades to the Plex fanart — landscape orientations only, portrait is silently skipped because fanart crops look bad there) and `ambient` (a blurred + darkened copy of the fanart replaces the yellow bulb-lit background whenever media is active; works on both orientations because the blur makes aspect ratio moot). Images are proxied through the server at `/api/plex-art?path=…` so the Plex token never leaves the server. Requires `plex_url` + `plex_token`. |
 
 HACS-only users (no add-on / server) can flip any visual toggle per tablet
 by setting `pns.visualProgressBar=true` / `pns.visualRatingsBadges=true` /
-`pns.visualGenreChips=true` / `pns.visualInfoPanelMode=on_pause` in
-`localStorage` or adding `#visualProgressBar=true` /
-`#visualRatingsBadges=true` / `#visualGenreChips=true` /
-`#visualInfoPanelMode=always` to the kiosk URL.
+`pns.visualGenreChips=true` / `pns.visualInfoPanelMode=on_pause` /
+`pns.visualUseBackdrops=true` / `pns.visualBackdropStyle=ambient` in
+`localStorage`, or adding the matching
+`#visualProgressBar=true` / `#visualRatingsBadges=true` /
+`#visualGenreChips=true` / `#visualInfoPanelMode=always` /
+`#visualUseBackdrops=true` / `#visualBackdropStyle=ambient`
+to the kiosk URL hash.
 
 ### Fully Kiosk auto-switcher (#48)
 

--- a/addons/plex-now-showing/config.yaml
+++ b/addons/plex-now-showing/config.yaml
@@ -62,6 +62,13 @@ options:
   visual_ratings_badges: false
   visual_genre_chips: false
   visual_info_panel_mode: on_tap
+  # Backdrop art on pause (#21). Master switch is off; backdrop_style picks
+  # fullscreen (landscape-only crossfade, default) vs ambient (blurred
+  # fanart behind the poster on every orientation). Delay is the pause
+  # threshold for the fullscreen swap — >10 s by spec.
+  visual_use_backdrops: false
+  visual_backdrop_style: fullscreen
+  visual_backdrop_delay_ms: 10000
   log_level: info
 schema:
   plex_url: "str?"
@@ -87,5 +94,8 @@ schema:
   visual_ratings_badges: "bool"
   visual_genre_chips: "bool"
   visual_info_panel_mode: "list(on_tap|on_pause|always)"
+  visual_use_backdrops: "bool"
+  visual_backdrop_style: "list(fullscreen|ambient)"
+  visual_backdrop_delay_ms: "int(1000,600000)"
   log_level: "list(trace|debug|info|notice|warning|error|fatal)?"
 image: ghcr.io/rusty4444/plex-now-showing-{arch}

--- a/addons/plex-now-showing/rootfs/etc/services.d/plex-now-showing/run
+++ b/addons/plex-now-showing/rootfs/etc/services.d/plex-now-showing/run
@@ -57,10 +57,13 @@ if bashio::config.has_value 'fully_kiosks'; then
 fi
 
 # ---- Visual toggles (V2 visual sprint) ----
-export_opt VISUAL_PROGRESS_BAR     visual_progress_bar
-export_opt VISUAL_RATINGS_BADGES   visual_ratings_badges
-export_opt VISUAL_GENRE_CHIPS      visual_genre_chips
-export_opt VISUAL_INFO_PANEL_MODE  visual_info_panel_mode
+export_opt VISUAL_PROGRESS_BAR        visual_progress_bar
+export_opt VISUAL_RATINGS_BADGES      visual_ratings_badges
+export_opt VISUAL_GENRE_CHIPS         visual_genre_chips
+export_opt VISUAL_INFO_PANEL_MODE     visual_info_panel_mode
+export_opt VISUAL_USE_BACKDROPS       visual_use_backdrops
+export_opt VISUAL_BACKDROP_STYLE      visual_backdrop_style
+export_opt VISUAL_BACKDROP_DELAY_MS   visual_backdrop_delay_ms
 
 # ---- Diagnostics (no secrets) ----
 bashio::log.info "Plex URL configured:      $([[ -n "${PLEX_URL}"   ]] && echo yes || echo no)"
@@ -78,6 +81,7 @@ bashio::log.info "Visual progress bar:      ${VISUAL_PROGRESS_BAR:-false}"
 bashio::log.info "Visual ratings badges:    ${VISUAL_RATINGS_BADGES:-false}"
 bashio::log.info "Visual genre chips:       ${VISUAL_GENRE_CHIPS:-false}"
 bashio::log.info "Info panel mode:          ${VISUAL_INFO_PANEL_MODE:-on_tap}"
+bashio::log.info "Backdrop art:             ${VISUAL_USE_BACKDROPS:-false} (${VISUAL_BACKDROP_STYLE:-fullscreen}, delay ${VISUAL_BACKDROP_DELAY_MS:-10000}ms)"
 bashio::log.info "Switcher enabled:         ${SWITCHER_ENABLED:-false}"
 if bashio::var.true "${SWITCHER_ENABLED:-false}"; then
   kiosk_count=$(bashio::config 'fully_kiosks | length')

--- a/addons/plex-now-showing/translations/en.yaml
+++ b/addons/plex-now-showing/translations/en.yaml
@@ -90,6 +90,25 @@ configuration:
       after 8 s. "on_pause" — shows persistently whenever the player is
       paused; tap-to-peek still works while playing. "always" — pinned open
       the entire time media is active.
+  visual_use_backdrops:
+    name: Show backdrop art on pause
+    description: >-
+      Master switch for the backdrop-art feature. Requires plex_url +
+      plex_token. Pair with Backdrop style below. Off by default.
+  visual_backdrop_style:
+    name: Backdrop style
+    description: >-
+      "fullscreen" (default) — on landscape devices, after a sustained
+      pause, crossfade to the movie/show fanart. Portrait devices are
+      silently skipped since the crop looks bad there. "ambient" — replaces
+      the yellow bulb-lit background with a blurred and darkened copy of
+      the fanart whenever media is active. Works on both orientations.
+  visual_backdrop_delay_ms:
+    name: Backdrop pause delay (ms)
+    description: >-
+      How long the player must stay paused before the fullscreen backdrop
+      fades in. Defaults to 10000 (10 s) per spec; skip-intros / quick
+      seeks shouldn't trigger the swap.
   log_level:
     name: Log level
     description: Verbosity of the add-on log.

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -42,6 +42,15 @@ VISUAL_GENRE_CHIPS=false
 # When to show the info panel (title, ratings, meta, tech tags).
 # One of: on_tap (default, tap-to-peek), on_pause, always.
 VISUAL_INFO_PANEL_MODE=on_tap
+# Backdrop art on pause (#21). Master switch; requires PLEX_URL + PLEX_TOKEN
+# so /api/plex-art can proxy fanart with the token server-side.
+VISUAL_USE_BACKDROPS=false
+# fullscreen — landscape-only crossfade after >VISUAL_BACKDROP_DELAY_MS paused.
+# ambient    — blurred darkened fanart replaces the bulb-lit background.
+VISUAL_BACKDROP_STYLE=fullscreen
+# Clamped to [1000, 600000]. Default 10 s matches the spec — avoids firing
+# on skip-intro / short-seek pauses.
+VISUAL_BACKDROP_DELAY_MS=10000
 
 # ---- Optional hardening (set both if exposing the port beyond your LAN) ---
 # Every /api/* request must carry header X-Proxy-Secret: <value>.

--- a/docker/docker-compose.example.yml
+++ b/docker/docker-compose.example.yml
@@ -52,6 +52,9 @@ services:
       VISUAL_RATINGS_BADGES: "${VISUAL_RATINGS_BADGES:-false}"
       VISUAL_GENRE_CHIPS: "${VISUAL_GENRE_CHIPS:-false}"
       VISUAL_INFO_PANEL_MODE: "${VISUAL_INFO_PANEL_MODE:-on_tap}"
+      VISUAL_USE_BACKDROPS: "${VISUAL_USE_BACKDROPS:-false}"
+      VISUAL_BACKDROP_STYLE: "${VISUAL_BACKDROP_STYLE:-fullscreen}"
+      VISUAL_BACKDROP_DELAY_MS: "${VISUAL_BACKDROP_DELAY_MS:-10000}"
 
       # ---- Optional hardening (recommended if exposed off-LAN) ----
       PROXY_SECRET: "${PROXY_SECRET:-}"

--- a/server/README.md
+++ b/server/README.md
@@ -63,6 +63,9 @@ For HA Container users running via Docker Compose. Set:
 | `VISUAL_RATINGS_BADGES` | `false` | Show IMDb / Rotten Tomatoes / audience score badges in the info panel (needs `PLEX_URL` + `PLEX_TOKEN`) |
 | `VISUAL_GENRE_CHIPS` | `false` | Show genre pills next to the content rating in the info panel (needs `PLEX_URL` + `PLEX_TOKEN`) |
 | `VISUAL_INFO_PANEL_MODE` | `on_tap` | When to show the info panel: `on_tap`, `on_pause`, or `always` |
+| `VISUAL_USE_BACKDROPS` | `false` | Master switch for backdrop art on pause (#21). Needs `PLEX_URL` + `PLEX_TOKEN` |
+| `VISUAL_BACKDROP_STYLE` | `fullscreen` | `fullscreen` (landscape-only crossfade) or `ambient` (blurred fanart behind the poster, all orientations) |
+| `VISUAL_BACKDROP_DELAY_MS` | `10000` | Pause threshold for the fullscreen fade-in (ms, clamped 1000–600000) |
 | `STATIC_DIR` | `../www` | Override where `now_showing.html` is served from |
 
 ## Local development

--- a/server/fixtures/plex_metadata_12345.json
+++ b/server/fixtures/plex_metadata_12345.json
@@ -37,6 +37,7 @@
         ],
         "rating": 8.4,
         "audienceRating": 9.1,
+        "art": "/library/metadata/12345/art/1700000000",
         "Rating": [
           {
             "image": "imdb://image.rating",

--- a/server/src/config.js
+++ b/server/src/config.js
@@ -60,6 +60,24 @@ export function loadConfig(env = process.env) {
       //   'always'   — persistently shown whenever media is playing
       infoPanelMode: parseEnum(env.VISUAL_INFO_PANEL_MODE,
         ['on_tap', 'on_pause', 'always'], 'on_tap'),
+      // Backdrop art on pause (#21). Master switch; off keeps the original
+      // poster-only look.
+      useBackdrops: parseBool(env.VISUAL_USE_BACKDROPS, false),
+      // Two presentation styles:
+      //   'fullscreen' — landscape only; after backdropDelayMs of pause,
+      //                   crossfade the poster view to the Plex fanart.
+      //                   On portrait devices the fanart crop is always bad,
+      //                   so this mode silently no-ops there.
+      //   'ambient'    — replaces the yellow bulb-lit background with a
+      //                   heavily blurred and darkened copy of the fanart at
+      //                   all times (not just on pause). Works on both
+      //                   orientations because the image is blurred to the
+      //                   point where aspect ratio doesn't matter.
+      backdropStyle: parseEnum(env.VISUAL_BACKDROP_STYLE,
+        ['fullscreen', 'ambient'], 'fullscreen'),
+      // Delay (ms) before the fullscreen backdrop fades in on pause. Spec
+      // calls for >10 s so quick seeks / skip-intros don't trigger the swap.
+      backdropDelayMs: parseIntClamped(env.VISUAL_BACKDROP_DELAY_MS, 10000, 1000, 600000),
     },
     // Where the static HTML lives (overridden in tests)
     staticDir: env.STATIC_DIR || new URL('../../www', import.meta.url).pathname,
@@ -72,6 +90,15 @@ export function loadConfig(env = process.env) {
 function parseBool(v, defaultValue) {
   if (v == null || v === '') return defaultValue;
   return /^(1|true|yes|on)$/i.test(String(v));
+}
+
+function parseIntClamped(v, defaultValue, min, max) {
+  if (v == null || v === '') return defaultValue;
+  const n = parseInt(String(v), 10);
+  if (!Number.isFinite(n)) return defaultValue;
+  if (n < min) return min;
+  if (n > max) return max;
+  return n;
 }
 
 function parseEnum(v, allowed, defaultValue) {

--- a/server/src/plex.js
+++ b/server/src/plex.js
@@ -178,5 +178,37 @@ export async function fetchMediaInfo({ plexUrl, plexToken, ratingKey, fetchImpl 
     height: media.height || 0,
     ratings: parseRatings(item),
     genres: parseGenres(item),
+    // #21 backdrop art. Plex stores fanart on the item as `art` — a path
+    // like '/library/metadata/12345/art/1700000000'. The browser never sees
+    // this directly; it goes through /api/plex-art?path=… so the token stays
+    // server-side. Empty string when the item has no fanart (e.g. personal
+    // media) so the frontend can gate rendering cleanly.
+    art: typeof item.art === 'string' ? item.art : '',
   };
+}
+
+// fetchArts — #21 backdrop cycling. Plex exposes the full collection of
+// fanart for an item at /library/metadata/{id}/arts. Returns a `Photo[]`
+// shape under MediaContainer.Metadata; each photo has a `key` that can be
+// proxied the same way as `item.art`. Returns [] on any failure so callers
+// can always render something (the primary `art` is still usable).
+export async function fetchArts({ plexUrl, plexToken, ratingKey, fetchImpl = globalThis.fetch }) {
+  if (!plexUrl || !plexToken || !ratingKey) return [];
+  const url = `${plexUrl}/library/metadata/${encodeURIComponent(ratingKey)}/arts?X-Plex-Token=${encodeURIComponent(plexToken)}`;
+  try {
+    const resp = await fetchImpl(url, { headers: { Accept: 'application/json' } });
+    if (!resp.ok) return [];
+    const data = await resp.json();
+    const photos = data?.MediaContainer?.Metadata ?? data?.MediaContainer?.Photo ?? [];
+    if (!Array.isArray(photos)) return [];
+    const out = [];
+    for (const p of photos) {
+      if (p && typeof p.key === 'string' && p.key.startsWith('/library/')) {
+        out.push(p.key);
+      }
+    }
+    return out;
+  } catch {
+    return [];
+  }
 }

--- a/server/src/routes/config.js
+++ b/server/src/routes/config.js
@@ -19,6 +19,10 @@ export function configRoute({ config }) {
         ratingsBadges: !!config.visual?.ratingsBadges,
         genreChips: !!config.visual?.genreChips,
         infoPanelMode: config.visual?.infoPanelMode || 'on_tap',
+        useBackdrops: !!config.visual?.useBackdrops,
+        backdropStyle: config.visual?.backdropStyle || 'fullscreen',
+        backdropDelayMs: Number.isFinite(config.visual?.backdropDelayMs)
+          ? config.visual.backdropDelayMs : 10000,
       },
     });
   });

--- a/server/src/routes/plexArt.js
+++ b/server/src/routes/plexArt.js
@@ -1,0 +1,44 @@
+// GET /api/plex-art?path=<plex-path>
+//
+// Proxies Plex fanart/backdrop images so the browser can render them
+// same-origin without ever seeing the Plex token. Used by the #21 backdrop
+// feature. Path validation is strict: only paths beginning with '/library/'
+// are accepted, which is what Plex emits for `art`/`thumb`/`arts` entries.
+// Anything else is rejected to prevent SSRF-style abuse of the proxy.
+
+import { Router } from 'express';
+
+export function plexArtRoute({ config, fetchImpl = globalThis.fetch }) {
+  const r = Router();
+
+  r.get('/api/plex-art', async (req, res) => {
+    if (!config.plexUrl || !config.plexToken) {
+      return res.status(503).json({ error: 'plex_not_configured' });
+    }
+
+    const path = String(req.query.path || '');
+    if (!path.startsWith('/library/')) {
+      return res.status(400).json({ error: 'path_must_be_library_relative' });
+    }
+
+    try {
+      const sep = path.includes('?') ? '&' : '?';
+      const url = `${config.plexUrl}${path}${sep}X-Plex-Token=${encodeURIComponent(config.plexToken)}`;
+      const upstream = await fetchImpl(url);
+      if (!upstream.ok) return res.status(upstream.status).end();
+
+      const ct = upstream.headers.get('content-type') || 'image/jpeg';
+      res.setHeader('Content-Type', ct);
+      // Backdrops change rarely per item — cache aggressively so crossfades
+      // don't re-download the same jpg every pause cycle.
+      res.setHeader('Cache-Control', 'public, max-age=3600');
+
+      const buf = Buffer.from(await upstream.arrayBuffer());
+      res.end(buf);
+    } catch (err) {
+      res.status(502).json({ error: 'plex_unreachable', message: err.message });
+    }
+  });
+
+  return r;
+}

--- a/server/src/server.js
+++ b/server/src/server.js
@@ -22,6 +22,7 @@ import { stateRoute } from './routes/state.js';
 import { configRoute } from './routes/config.js';
 import { mediaInfoRoute } from './routes/mediaInfo.js';
 import { artworkRoute } from './routes/artwork.js';
+import { plexArtRoute } from './routes/plexArt.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const pkg = JSON.parse(readFileSync(join(__dirname, '..', 'package.json'), 'utf8'));
@@ -63,6 +64,7 @@ export function createApp({ config, haClient }) {
   app.use(stateRoute({ haClient, cache: stateCache, config }));
   app.use(mediaInfoRoute({ cache: mediaInfoCache, config }));
   app.use(artworkRoute({ config }));
+  app.use(plexArtRoute({ config }));
 
   // Static HTML last so /api/* wins on overlap.
   app.use(express.static(config.staticDir, {

--- a/server/test/config.test.js
+++ b/server/test/config.test.js
@@ -94,6 +94,40 @@ test('VISUAL_INFO_PANEL_MODE is case-insensitive', () => {
   assert.equal(config.visual.infoPanelMode, 'on_pause');
 });
 
+// ===== #21 backdrop config =====
+
+test('backdrop config defaults — off, fullscreen, 10 s', () => {
+  const { config } = loadConfig({ SUPERVISOR_TOKEN: 'x' });
+  assert.equal(config.visual.useBackdrops, false);
+  assert.equal(config.visual.backdropStyle, 'fullscreen');
+  assert.equal(config.visual.backdropDelayMs, 10000);
+});
+
+test('VISUAL_USE_BACKDROPS=true flips the master switch on', () => {
+  const { config } = loadConfig({ SUPERVISOR_TOKEN: 'x', VISUAL_USE_BACKDROPS: 'true' });
+  assert.equal(config.visual.useBackdrops, true);
+});
+
+test('VISUAL_BACKDROP_STYLE accepts fullscreen and ambient, rejects others', () => {
+  const ambient = loadConfig({ SUPERVISOR_TOKEN: 'x', VISUAL_BACKDROP_STYLE: 'ambient' });
+  assert.equal(ambient.config.visual.backdropStyle, 'ambient');
+  const fullscreen = loadConfig({ SUPERVISOR_TOKEN: 'x', VISUAL_BACKDROP_STYLE: 'fullscreen' });
+  assert.equal(fullscreen.config.visual.backdropStyle, 'fullscreen');
+  const bogus = loadConfig({ SUPERVISOR_TOKEN: 'x', VISUAL_BACKDROP_STYLE: 'parallax' });
+  assert.equal(bogus.config.visual.backdropStyle, 'fullscreen');
+});
+
+test('VISUAL_BACKDROP_DELAY_MS is clamped to [1000, 600000]', () => {
+  const ok = loadConfig({ SUPERVISOR_TOKEN: 'x', VISUAL_BACKDROP_DELAY_MS: '15000' });
+  assert.equal(ok.config.visual.backdropDelayMs, 15000);
+  const tooSmall = loadConfig({ SUPERVISOR_TOKEN: 'x', VISUAL_BACKDROP_DELAY_MS: '0' });
+  assert.equal(tooSmall.config.visual.backdropDelayMs, 1000);
+  const tooBig = loadConfig({ SUPERVISOR_TOKEN: 'x', VISUAL_BACKDROP_DELAY_MS: '9999999' });
+  assert.equal(tooBig.config.visual.backdropDelayMs, 600000);
+  const garbage = loadConfig({ SUPERVISOR_TOKEN: 'x', VISUAL_BACKDROP_DELAY_MS: 'soon' });
+  assert.equal(garbage.config.visual.backdropDelayMs, 10000);
+});
+
 test('switcher is off by default, on requires FULLY_KIOSKS', () => {
   const off = loadConfig({ SUPERVISOR_TOKEN: 'x' });
   assert.equal(off.config.switcherEnabled, false);

--- a/server/test/plex.test.js
+++ b/server/test/plex.test.js
@@ -4,7 +4,7 @@ import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
-import { parseRatingKey, fetchMediaInfo, parseRatings, parseGenres } from '../src/plex.js';
+import { parseRatingKey, fetchMediaInfo, parseRatings, parseGenres, fetchArts } from '../src/plex.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const metadata = JSON.parse(
@@ -231,4 +231,85 @@ test('fetchMediaInfo: surfaces genres from the canned fixture', async () => {
     plexUrl: 'u', plexToken: 't', ratingKey: '12345', fetchImpl,
   });
   assert.deepEqual(info.genres, ['Action', 'Adventure', 'Science Fiction']);
+});
+
+// ----- #21 backdrop art ---------------------------------------------------
+
+test('fetchMediaInfo: surfaces the item.art path', async () => {
+  const fetchImpl = async () => ({ ok: true, async json() { return metadata; } });
+  const info = await fetchMediaInfo({
+    plexUrl: 'u', plexToken: 't', ratingKey: '12345', fetchImpl,
+  });
+  assert.equal(info.art, '/library/metadata/12345/art/1700000000');
+});
+
+test('fetchMediaInfo: art falls back to empty string when missing', async () => {
+  const fixture = { MediaContainer: { Metadata: [{
+    Media: [{ Part: [{}] }],
+  }] } };
+  const fetchImpl = async () => ({ ok: true, async json() { return fixture; } });
+  const info = await fetchMediaInfo({
+    plexUrl: 'u', plexToken: 't', ratingKey: '1', fetchImpl,
+  });
+  assert.equal(info.art, '');
+});
+
+test('fetchArts: returns /library/ keys from the arts endpoint', async () => {
+  const fetchImpl = async (url) => {
+    assert.ok(url.includes('/library/metadata/12345/arts'));
+    assert.ok(url.includes('X-Plex-Token=tok'));
+    return {
+      ok: true,
+      async json() {
+        return {
+          MediaContainer: {
+            Metadata: [
+              { key: '/library/metadata/12345/arts/100' },
+              { key: '/library/metadata/12345/arts/200' },
+              { key: 'upload://something-else' }, // filtered
+              { key: 42 },                       // filtered (non-string)
+              {},                                // filtered
+            ],
+          },
+        };
+      },
+    };
+  };
+  const arts = await fetchArts({
+    plexUrl: 'https://plex.example:32400', plexToken: 'tok', ratingKey: '12345', fetchImpl,
+  });
+  assert.deepEqual(arts, [
+    '/library/metadata/12345/arts/100',
+    '/library/metadata/12345/arts/200',
+  ]);
+});
+
+test('fetchArts: returns [] on missing plex creds', async () => {
+  assert.deepEqual(await fetchArts({ plexUrl: '', plexToken: 't', ratingKey: '1' }), []);
+  assert.deepEqual(await fetchArts({ plexUrl: 'u', plexToken: '', ratingKey: '1' }), []);
+  assert.deepEqual(await fetchArts({ plexUrl: 'u', plexToken: 't', ratingKey: '' }), []);
+});
+
+test('fetchArts: returns [] on non-ok response', async () => {
+  const fetchImpl = async () => ({ ok: false, status: 500, async json() { return {}; } });
+  const arts = await fetchArts({
+    plexUrl: 'u', plexToken: 't', ratingKey: '1', fetchImpl,
+  });
+  assert.deepEqual(arts, []);
+});
+
+test('fetchArts: returns [] when fetch throws', async () => {
+  const fetchImpl = async () => { throw new Error('network down'); };
+  const arts = await fetchArts({
+    plexUrl: 'u', plexToken: 't', ratingKey: '1', fetchImpl,
+  });
+  assert.deepEqual(arts, []);
+});
+
+test('fetchArts: returns [] when MediaContainer shape is unexpected', async () => {
+  const fetchImpl = async () => ({ ok: true, async json() { return { foo: 'bar' }; } });
+  const arts = await fetchArts({
+    plexUrl: 'u', plexToken: 't', ratingKey: '1', fetchImpl,
+  });
+  assert.deepEqual(arts, []);
 });

--- a/server/test/routes.test.js
+++ b/server/test/routes.test.js
@@ -106,7 +106,17 @@ test('GET /api/config defaults every visual toggle off', async () => {
     assert.equal(resp.status, 200);
     assert.equal(resp.headers.get('cache-control'), 'no-store');
     const body = await resp.json();
-    assert.deepEqual(body, { visual: { progressBar: false, ratingsBadges: false, genreChips: false, infoPanelMode: 'on_tap' } });
+    assert.deepEqual(body, {
+      visual: {
+        progressBar: false,
+        ratingsBadges: false,
+        genreChips: false,
+        infoPanelMode: 'on_tap',
+        useBackdrops: false,
+        backdropStyle: 'fullscreen',
+        backdropDelayMs: 10000,
+      },
+    });
   } finally { server.close(); }
 });
 
@@ -158,6 +168,61 @@ test('GET /api/config surfaces genreChips when enabled', async () => {
     assert.equal(body.visual.genreChips, true);
     assert.equal(body.visual.progressBar, false);
     assert.equal(body.visual.ratingsBadges, false);
+  } finally { server.close(); }
+});
+
+// ===== #21 backdrop — /api/plex-art proxy + /api/config surfacing =====
+
+test('GET /api/config surfaces all backdrop fields when set', async () => {
+  const haClient = { getStates: async () => haStates };
+  const { server, url } = await startApp(
+    baseConfig({
+      visual: {
+        progressBar: false,
+        ratingsBadges: false,
+        infoPanelMode: 'on_tap',
+        useBackdrops: true,
+        backdropStyle: 'ambient',
+        backdropDelayMs: 15000,
+      },
+    }),
+    haClient,
+  );
+  try {
+    const body = await fetch(`${url}/api/config`).then(r => r.json());
+    assert.equal(body.visual.useBackdrops, true);
+    assert.equal(body.visual.backdropStyle, 'ambient');
+    assert.equal(body.visual.backdropDelayMs, 15000);
+  } finally { server.close(); }
+});
+
+test('GET /api/plex-art rejects paths not starting with /library/', async () => {
+  const haClient = { getStates: async () => haStates };
+  const { server, url } = await startApp(baseConfig(), haClient);
+  try {
+    // Classic SSRF vector: attacker tries to redirect the proxy off-host.
+    const cases = [
+      '/etc/passwd',
+      'http://evil.example/',
+      '/../library/metadata/1/art',
+      '',
+    ];
+    for (const path of cases) {
+      const resp = await fetch(`${url}/api/plex-art?path=${encodeURIComponent(path)}`);
+      assert.equal(resp.status, 400, `path ${path} should 400`);
+    }
+  } finally { server.close(); }
+});
+
+test('GET /api/plex-art returns 503 when plex is not configured', async () => {
+  const haClient = { getStates: async () => haStates };
+  const { server, url } = await startApp(
+    baseConfig({ plexUrl: '', plexToken: '' }),
+    haClient,
+  );
+  try {
+    const resp = await fetch(`${url}/api/plex-art?path=/library/metadata/1/art/123`);
+    assert.equal(resp.status, 503);
   } finally { server.close(); }
 });
 

--- a/www/now_showing.html
+++ b/www/now_showing.html
@@ -296,6 +296,88 @@
       opacity: 1;
     }
 
+    /* ===== BACKDROP ART ON PAUSE (#21) =====
+       Two layers, both opt-in via body classes. They never steal pointer
+       events so info-overlay taps still reach the poster underneath.
+
+       1. .backdrop-image — fullscreen crossfade layer. Only revealed when
+          `body.backdrop-fullscreen-visible` is added by the pause timer.
+          Landscape-only via matchMedia in JS: on portrait devices the body
+          class is never added, so this layer stays hidden even when the
+          toggle is on.
+
+       2. .backdrop-ambient — blurred, heavily darkened fanart behind
+          everything, replacing the yellow bulb-lit background. Gated by
+          `body.backdrop-ambient-mode`; once lit it stays for the entire
+          session (doesn't swap on pause, doesn't care about orientation
+          because the blur makes aspect ratio moot). */
+    .backdrop-image {
+      position: fixed;
+      inset: 0;
+      background-size: cover;
+      background-position: center center;
+      background-repeat: no-repeat;
+      opacity: 0;
+      /* 1.2 s is the feel the spec asks for: long enough to read as a
+         deliberate scene change, short enough that someone pausing briefly
+         doesn't get a jarring flash halfway through. */
+      transition: opacity 1.2s ease;
+      pointer-events: none;
+      /* Must sit above .bulbs-outer (z:10) and .marquee (z:2) so the pause
+         takeover is a true cinema-style full-bleed, not fanart peeking
+         through gaps in the theatre chrome. Still below .info-overlay (z:20)
+         so tap-to-show info can still appear over it. */
+      z-index: 15;
+    }
+
+    body.backdrop-fullscreen-visible .backdrop-image {
+      opacity: 1;
+    }
+
+    /* When the fullscreen pause-art is visible, fade the theatre chrome out
+       so the fanart gets the whole screen. We fade rather than hide so the
+       transition in/out matches the backdrop's own 1.2 s crossfade. */
+    .frame-wrapper,
+    .bulbs-outer {
+      transition: opacity 1.2s ease;
+    }
+    body.backdrop-fullscreen-visible .frame-wrapper,
+    body.backdrop-fullscreen-visible .bulbs-outer {
+      opacity: 0;
+    }
+
+    .backdrop-ambient {
+      display: none;
+      position: fixed;
+      inset: 0;
+      background-size: cover;
+      background-position: center center;
+      background-repeat: no-repeat;
+      /* Heavy blur + darken so the image reads as atmosphere, not content. */
+      filter: blur(60px) brightness(0.25) saturate(1.1);
+      /* The blur samples transparent pixels at the edges, which can leave
+         a dim halo. Scale up so the blurred crop covers the whole viewport. */
+      transform: scale(1.2);
+      opacity: 0;
+      transition: opacity 1.5s ease;
+      pointer-events: none;
+      z-index: 0; /* below .ambient-glow’s bulb wash */
+    }
+
+    body.backdrop-ambient-mode .backdrop-ambient {
+      display: block;
+    }
+
+    body.backdrop-ambient-mode .backdrop-ambient.loaded {
+      opacity: 1;
+    }
+
+    /* In ambient mode the yellow bulb wash fights the fanart, so dial it
+       back. Keeps the warmth, lets the art breathe. */
+    body.backdrop-ambient-mode .ambient-glow.active {
+      opacity: 0.35;
+    }
+
     /* Gradient overlay at bottom of poster */
     .poster-overlay {
       position: absolute;
@@ -812,7 +894,15 @@
   </style>
 </head>
 <body>
+  <!-- #21 Backdrop ambient layer. Behind everything; JS only paints the
+       image when useBackdrops+ambient are on. Kept as its own element so the
+       `loaded` class can drive its fade-in after the jpg decode. -->
+  <div class="backdrop-ambient" id="backdropAmbient"></div>
   <div class="ambient-glow" id="ambientGlow"></div>
+  <!-- #21 Backdrop fullscreen layer. Crossfades in after >backdropDelayMs
+       of pause (landscape only). Sits above poster-area, below info-overlay
+       so tap-to-peek still lands on the info panel. -->
+  <div class="backdrop-image" id="backdropImage"></div>
 
   <!-- SETUP GEAR (reopen setup from the live display) -->
   <div class="setup-gear" id="setupGear" title="Open setup" style="display:none;">
@@ -1078,7 +1168,17 @@
     // Server config wins so operators can ship a consistent look across the
     // fleet without touching every tablet.
     const INFO_PANEL_MODES = ['on_tap', 'on_pause', 'always'];
-    const VISUAL = { progressBar: false, ratingsBadges: false, genreChips: false, infoPanelMode: 'on_tap' };
+    const BACKDROP_STYLES = ['fullscreen', 'ambient'];
+    const VISUAL = {
+      progressBar: false,
+      ratingsBadges: false,
+      genreChips: false,
+      infoPanelMode: 'on_tap',
+      // #21 backdrop art on pause.
+      useBackdrops: false,
+      backdropStyle: 'fullscreen', // 'fullscreen' | 'ambient'
+      backdropDelayMs: 10000,
+    };
 
     function readInfoPanelMode(defaultValue) {
       // Hash override takes precedence over localStorage so tablet operators can
@@ -1091,6 +1191,26 @@
       return defaultValue;
     }
 
+    function readBackdropStyle(defaultValue) {
+      // Same resolution order as readInfoPanelMode — hash > localStorage >
+      // default. Only known enum values are honoured.
+      const hash = new URLSearchParams(location.hash.replace(/^#/, ''));
+      const fromHash = hash.get('visualBackdropStyle');
+      if (fromHash && BACKDROP_STYLES.includes(fromHash)) return fromHash;
+      const fromStorage = localStorage.getItem('pns.visualBackdropStyle');
+      if (fromStorage && BACKDROP_STYLES.includes(fromStorage)) return fromStorage;
+      return defaultValue;
+    }
+
+    function readIntClamped(key, defaultValue, min, max) {
+      const hash = new URLSearchParams(location.hash.replace(/^#/, ''));
+      const raw = hash.get(key) || localStorage.getItem('pns.' + key);
+      if (raw == null || raw === '') return defaultValue;
+      const n = parseInt(String(raw), 10);
+      if (!Number.isFinite(n)) return defaultValue;
+      return Math.max(min, Math.min(max, n));
+    }
+
     async function loadVisualConfig() {
       // Local overrides apply first so the tablet still looks right even if
       // the server is briefly unreachable.
@@ -1098,6 +1218,9 @@
       VISUAL.ratingsBadges = readBool('visualRatingsBadges', false);
       VISUAL.genreChips = readBool('visualGenreChips', false);
       VISUAL.infoPanelMode = readInfoPanelMode('on_tap');
+      VISUAL.useBackdrops = readBool('visualUseBackdrops', false);
+      VISUAL.backdropStyle = readBackdropStyle('fullscreen');
+      VISUAL.backdropDelayMs = readIntClamped('visualBackdropDelayMs', 10000, 1000, 600000);
 
       await serverModeReady;
       if (!SERVER_MODE) return;
@@ -1111,6 +1234,13 @@
         if (v && typeof v.genreChips === 'boolean') VISUAL.genreChips = v.genreChips;
         if (v && typeof v.infoPanelMode === 'string' && INFO_PANEL_MODES.includes(v.infoPanelMode)) {
           VISUAL.infoPanelMode = v.infoPanelMode;
+        }
+        if (v && typeof v.useBackdrops === 'boolean') VISUAL.useBackdrops = v.useBackdrops;
+        if (v && typeof v.backdropStyle === 'string' && BACKDROP_STYLES.includes(v.backdropStyle)) {
+          VISUAL.backdropStyle = v.backdropStyle;
+        }
+        if (v && Number.isFinite(v.backdropDelayMs)) {
+          VISUAL.backdropDelayMs = Math.max(1000, Math.min(600000, v.backdropDelayMs));
         }
       } catch (err) {
         console.warn('[plex-now-showing] /api/config fetch failed — using local defaults.', err);
@@ -1126,6 +1256,17 @@
       document.body.classList.toggle('info-mode-on-tap', VISUAL.infoPanelMode === 'on_tap');
       document.body.classList.toggle('info-mode-on-pause', VISUAL.infoPanelMode === 'on_pause');
       document.body.classList.toggle('info-mode-always', VISUAL.infoPanelMode === 'always');
+      // #21 backdrop art. Two body classes:
+      //   backdrop-ambient-mode  — flag for CSS to reveal the blurred layer
+      //   backdrop-fullscreen-visible — set dynamically by the pause timer,
+      //                                 so applyVisualToggles() only *clears*
+      //                                 it here (don't leak stale state when
+      //                                 toggles change at runtime).
+      const ambientOn = VISUAL.useBackdrops && VISUAL.backdropStyle === 'ambient';
+      document.body.classList.toggle('backdrop-ambient-mode', ambientOn);
+      if (!VISUAL.useBackdrops || VISUAL.backdropStyle !== 'fullscreen') {
+        document.body.classList.remove('backdrop-fullscreen-visible');
+      }
     }
 
     // ===== SETUP PAGE CONTROLLER (#setup) =====
@@ -1293,6 +1434,8 @@
     const mediaType = document.getElementById('mediaType');
     const playerName = document.getElementById('playerName');
     const ambientGlow = document.getElementById('ambientGlow');
+    const backdropAmbient = document.getElementById('backdropAmbient');
+    const backdropImage = document.getElementById('backdropImage');
     const bulbsOuterContainer = document.getElementById('bulbsOuter');
     const marquee = document.getElementById('marquee');
 
@@ -1424,6 +1567,12 @@
           width: media.width || 0,
           height: media.height || 0,
           ratings: parseRatingsClient(item),
+          // #21 backdrop art. HACS-only users still fetch directly from Plex,
+          // which means the token is already in the URL — we can use item.art
+          // as a full URL (path + token). The unified-server path never hits
+          // this branch; it uses /api/plex-art?path=... which strips the
+          // token server-side.
+          art: typeof item?.art === 'string' ? item.art : '',
         };
         cachedMediaInfo[ratingKey] = info;
         return info;
@@ -1880,6 +2029,142 @@
       progressBar.classList.remove('paused');
     }
 
+    // ===== BACKDROP ART ON PAUSE (#21) =====
+    //
+    // Two presentation modes, both opt-in. The master switch VISUAL.useBackdrops
+    // and VISUAL.backdropStyle pick which path runs; the others are no-ops.
+    //
+    //   fullscreen — landscape-only crossfade. After backdropDelayMs of
+    //                 sustained pause, swap the poster-area view to the
+    //                 fanart. Clears on play or state change.
+    //   ambient    — a blurred + dimmed copy of the fanart sits behind the
+    //                 poster frame at all times, regardless of pause state.
+    //                 Works in portrait because blur hides the crop.
+    //
+    // The frontend never sees the Plex token: it hits /api/plex-art?path=...
+    // which adds the token server-side. HACS-only users fall back to the
+    // full artUrl returned from the direct-to-Plex fetch (token is already
+    // baked into item.art via PLEX_URL).
+    const backdropCtx = {
+      ratingKey: null,      // last ratingKey we resolved art for
+      artUrl: null,         // resolved CDN/proxy URL, or null
+      pauseTimer: null,     // setTimeout handle for the fullscreen fade-in
+    };
+
+    function resolveBackdropUrl(art) {
+      if (!art || typeof art !== 'string') return null;
+      if (SERVER_MODE) {
+        // Only /library/ paths go through the proxy — anything else would
+        // be rejected server-side anyway.
+        if (!art.startsWith('/library/')) return null;
+        return `/api/plex-art?path=${encodeURIComponent(art)}`;
+      }
+      // HACS-only: item.art may already be an absolute URL with token baked
+      // in, or a /library/ path we can stitch to PLEX_URL + token.
+      if (art.startsWith('http')) return art;
+      if (art.startsWith('/library/') && PLEX_URL && PLEX_TOKEN) {
+        const sep = art.includes('?') ? '&' : '?';
+        return `${PLEX_URL}${art}${sep}X-Plex-Token=${PLEX_TOKEN}`;
+      }
+      return null;
+    }
+
+    function clearBackdropFullscreen() {
+      if (backdropCtx.pauseTimer) {
+        clearTimeout(backdropCtx.pauseTimer);
+        backdropCtx.pauseTimer = null;
+      }
+      document.body.classList.remove('backdrop-fullscreen-visible');
+    }
+
+    function scheduleBackdropFullscreen() {
+      clearBackdropFullscreen();
+      if (!VISUAL.useBackdrops || VISUAL.backdropStyle !== 'fullscreen') return;
+      if (!backdropCtx.artUrl) return;
+      // Landscape-only gate. On portrait we silently skip — the poster look
+      // on phones doesn't benefit from a fanart crossfade and usually crops
+      // badly. Ambient mode covers portrait instead.
+      try {
+        if (!window.matchMedia('(orientation: landscape)').matches) return;
+      } catch (_) { /* matchMedia unsupported — fall through */ }
+      const delay = Math.max(1000, VISUAL.backdropDelayMs || 10000);
+      backdropCtx.pauseTimer = setTimeout(() => {
+        // Double-check state at fire time — user may have resumed before the
+        // timer elapsed (showMedia would have called clearBackdropFullscreen
+        // already, but belt-and-braces so a stale timer can't flash the art).
+        if (!currentMediaData || currentMediaData.state !== 'paused') return;
+        if (!backdropCtx.artUrl) return;
+        backdropImage.style.backgroundImage = `url("${backdropCtx.artUrl}")`;
+        document.body.classList.add('backdrop-fullscreen-visible');
+      }, delay);
+    }
+
+    function applyBackdropAmbient() {
+      if (!VISUAL.useBackdrops || VISUAL.backdropStyle !== 'ambient') {
+        backdropAmbient.classList.remove('loaded');
+        return;
+      }
+      if (!backdropCtx.artUrl) {
+        // No fanart for this item — fade out gracefully.
+        backdropAmbient.classList.remove('loaded');
+        return;
+      }
+      // Preload the image before painting so the fade-in doesn't show a
+      // half-decoded frame.
+      const img = new Image();
+      img.onload = () => {
+        backdropAmbient.style.backgroundImage = `url("${backdropCtx.artUrl}")`;
+        backdropAmbient.classList.add('loaded');
+      };
+      img.onerror = () => {
+        // Art failed to load — keep the previous image up rather than
+        // flashing to black.
+        console.warn('[plex-now-showing] backdrop art failed to load');
+      };
+      img.src = backdropCtx.artUrl;
+    }
+
+    // Called after media-info resolves so we've got the Plex `art` path.
+    // Idempotent per ratingKey: repeat calls with the same key are no-ops.
+    function setBackdropArtFromMediaInfo(ratingKey, art) {
+      if (!VISUAL.useBackdrops) return;
+      if (ratingKey === backdropCtx.ratingKey && backdropCtx.artUrl) return;
+      backdropCtx.ratingKey = ratingKey;
+      backdropCtx.artUrl = resolveBackdropUrl(art);
+      applyBackdropAmbient();
+      // If we're currently paused the fullscreen timer may already be
+      // running with a stale URL — reschedule so the fresh art lands.
+      if (currentMediaData && currentMediaData.state === 'paused') {
+        scheduleBackdropFullscreen();
+      }
+    }
+
+    function resetBackdropForIdle() {
+      clearBackdropFullscreen();
+      backdropCtx.ratingKey = null;
+      backdropCtx.artUrl = null;
+      backdropImage.style.backgroundImage = '';
+      backdropAmbient.style.backgroundImage = '';
+      backdropAmbient.classList.remove('loaded');
+    }
+
+    // Keep the backdrop's landscape gate honest when the device rotates.
+    // A portrait→landscape flip while paused should reveal the fanart;
+    // landscape→portrait should hide it immediately.
+    try {
+      const mql = window.matchMedia('(orientation: landscape)');
+      const handler = () => {
+        if (!VISUAL.useBackdrops || VISUAL.backdropStyle !== 'fullscreen') return;
+        if (mql.matches && currentMediaData && currentMediaData.state === 'paused') {
+          scheduleBackdropFullscreen();
+        } else {
+          clearBackdropFullscreen();
+        }
+      };
+      if (typeof mql.addEventListener === 'function') mql.addEventListener('change', handler);
+      else if (typeof mql.addListener === 'function') mql.addListener(handler); // Safari
+    } catch (_) { /* matchMedia unsupported — skip */ }
+
     // ===== UPDATE DISPLAY =====
     function showMedia(data) {
       const artworkUrl = data.artwork.startsWith('http')
@@ -1901,6 +2186,15 @@
         // the progress bar's paused class, then bail out of the full re-render.
         syncInfoPanelForMode(data);
         setProgressFromState(data);
+        // #21 fullscreen backdrop reacts to pause/play transitions only (the
+        // ambient layer doesn't change on state). The media key hasn't
+        // changed, so backdropCtx.artUrl is still valid — (re)schedule on
+        // pause, clear on play.
+        if (data.state === 'paused') {
+          scheduleBackdropFullscreen();
+        } else {
+          clearBackdropFullscreen();
+        }
         return;
       }
 
@@ -1967,6 +2261,28 @@
       // Info-panel mode may need the panel to appear on first frame of new
       // media (always), on pause state (on_pause), or not at all (on_tap).
       syncInfoPanelForMode(data);
+
+      // #21 backdrop. New media — clear any stale fullscreen overlay, reset
+      // the context, and kick off a media-info fetch to resolve the `art`
+      // path. fetchPlexMediaInfo caches per ratingKey so this is cheap; we
+      // call it here (rather than only from showInfo) because ambient mode
+      // needs the art even when the info panel isn't shown.
+      clearBackdropFullscreen();
+      backdropCtx.ratingKey = null;
+      backdropCtx.artUrl = null;
+      backdropAmbient.classList.remove('loaded');
+      if (VISUAL.useBackdrops && data.ratingKey && (SERVER_MODE || PLEX_URL)) {
+        const rk = data.ratingKey;
+        fetchPlexMediaInfo(rk).then(mi => {
+          // Guard against stale responses arriving after the user changed
+          // media. currentMediaData.ratingKey is the source of truth.
+          if (!currentMediaData || currentMediaData.ratingKey !== rk) return;
+          if (mi && mi.art) {
+            setBackdropArtFromMediaInfo(rk, mi.art);
+            if (data.state === 'paused') scheduleBackdropFullscreen();
+          }
+        }).catch(() => { /* swallow — backdrop is best-effort */ });
+      }
     }
 
     function showIdle() {
@@ -1987,6 +2303,8 @@
       idleContent.classList.add('visible');
       ambientGlow.classList.remove('active');
       hideProgressBar();
+      // #21 backdrop — nothing playing, so tear the art layers down.
+      resetBackdropForIdle();
     }
 
     // ===== POLLING LOOP =====


### PR DESCRIPTION
Closes #21.

Adds optional Plex fanart as a backdrop in two styles, each gated by a toggle. Default is **off** so nobody gets surprised visuals on upgrade.

## Modes

- **`fullscreen` (default when enabled)** — after 10 s paused, the fanart crossfades to full-bleed and the theatre chrome (frame, bulbs, marquee) fades out for a true cinema takeover. Landscape-only; portrait rotation is silently skipped via `matchMedia('(orientation: landscape)')`.
- **`ambient`** — blurred (60 px) and darkened (brightness 0.25) fanart replaces the bulb-lit background for the whole session, no pause required. Works both orientations. The `.ambient-glow` bulb wash dims to 0.35 so the art can breathe.

## Config (all new, all defaulted off/sensible)

| env | default | range |
|---|---|---|
| `VISUAL_USE_BACKDROPS` | `false` | bool |
| `VISUAL_BACKDROP_STYLE` | `fullscreen` | `fullscreen` \| `ambient` |
| `VISUAL_BACKDROP_DELAY_MS` | `10000` | `1000` – `600000` |

Follows the existing pattern: env → `visual.x` in loadConfig → `/api/config` → frontend `VISUAL.x` via `loadVisualConfig()` with localStorage + URL-hash fallback → `body.visual-*` / backdrop body classes → CSS feature reveals.

Surfaced everywhere a toggle lives: `config.yaml` schema, `DOCS.md`, CHANGELOG, translations, Docker `.env.example` + compose example, HA add-on `run` script, `server/README.md`.

## Security

The Plex token never leaves the server. The browser hits `/api/plex-art?path=/library/...`. The route:

- rejects any path that doesn't start with `/library/` (400) to block SSRF
- returns 503 when Plex isn't configured
- caches responses for 3600 s

## Tests

14 new, 85/85 pass:

- `config.test.js` — 4 new (defaults, clamping, enum validation)
- `plex.test.js` — 6 new (art field on fetchMediaInfo, fetchArts success/missing/error)
- `routes.test.js` — 4 new (/api/config exposes new fields, /api/plex-art path validation + 503)

## Screenshots

See attached `backdrop_compare` for the three modes side-by-side. Fullscreen-landscape is a clean sunset takeover; ambient-portrait shows the blurred atmospheric halo framing the poster.

## Out of scope (future)

- Backdrop cycling (`VISUAL_BACKDROP_CYCLE_MS`) — single art only for this PR
- Custom backdrop delay via localStorage — server config only for now