### PR TITLE
[viz-7] Theme presets + [viz-17] accent colour (#23, #66)

### DIFF
--- a/addons/plex-now-showing/CHANGELOG.md
+++ b/addons/plex-now-showing/CHANGELOG.md
@@ -61,3 +61,16 @@ The project follows [Semantic Versioning](https://semver.org/).
   media query as automatic fallback; overlay opacity tunable via
   `visual_night_mode_opacity` (0–0.95, default 0.4). New `GET
   /api/night-mode` endpoint surfaces entity state to the kiosk.
+- Theme presets (closes #23). New `visual_theme` option — one of
+  `classic-gold` (default, original bulb look), `art-deco-silver` (cooler
+  chrome accents), `neon-80s` (hot pink + cyan), or `minimalist-dark`
+  (clean dark UI, ornament off). Drives `<body data-theme>` so all
+  accent-derived elements (bulbs, marquee text glow, progress bar,
+  ratings badges) reskin together. Existing installs default to
+  `classic-gold` so nothing changes until the user picks another preset.
+- Accent colour picker (closes #66). Opt-in `visual_accent_color` — a
+  strict `#RRGGBB` hex (e.g. `#ff5500`) that overrides the active theme's
+  accent ramp via `--accent-override`; the four-stop ramp is derived with
+  CSS `color-mix(in srgb, ...)`. Empty value (the default) leaves the
+  theme's ramp untouched. Short form (`#abc`) and named colours are
+  rejected at both server and client validation layers.

--- a/addons/plex-now-showing/DOCS.md
+++ b/addons/plex-now-showing/DOCS.md
@@ -47,6 +47,8 @@ and HA tokens never leave the add-on.
 | `visual_nudge_amplitude_px` | `4` | Maximum shift in pixels. Clamped to `1` – `16`. |
 | `visual_night_mode_entity` | _empty_ | Optional HA `input_boolean` / `switch` / `binary_sensor`. When `on`, dims the kiosk. Leave empty to fall back to the OS `prefers-color-scheme: dark` media query. |
 | `visual_night_mode_opacity` | `0.4` | Dim overlay opacity when night mode is active. Clamped to `0` – `0.95`. |
+| `visual_theme` | `classic-gold` | Theme preset — one of `classic-gold` / `art-deco-silver` / `neon-80s` / `minimalist-dark`. Reskins the bulbs, marquee glow, progress bar, and ratings badges. |
+| `visual_accent_color` | _empty_ | Optional `#RRGGBB` hex (e.g. `#ff5500`) that overrides the active theme's accent ramp. Empty = use theme default. Strict format — short form, names, and `rgb()` are rejected. |
 | `log_level` | `info` | s6 / add-on log verbosity. |
 
 ### Visual toggles (V2)
@@ -64,6 +66,7 @@ through to the browser automatically — no rebuild, no per-tablet config.
 | `visual_use_backdrops` / `visual_backdrop_style` / `visual_backdrop_delay_ms` | Backdrop art on pause (#21). **Master switch** is `visual_use_backdrops`. **Style** picks between `fullscreen` (after the item has been paused for `visual_backdrop_delay_ms`, the poster view crossfades to the Plex fanart — landscape orientations only, portrait is silently skipped because fanart crops look bad there) and `ambient` (a blurred + darkened copy of the fanart replaces the yellow bulb-lit background whenever media is active; works on both orientations because the blur makes aspect ratio moot). Images are proxied through the server at `/api/plex-art?path=…` so the Plex token never leaves the server. Requires `plex_url` + `plex_token`. |
 | `visual_burn_in_mitigation` | Master switch for long-running-kiosk protection. When on, the whole UI drifts by a few pixels every minute (configurable via `visual_nudge_interval_ms` + `visual_nudge_amplitude_px`) using a smooth 400 ms GPU transform, and a dim overlay can be triggered by an HA entity or the OS dark-mode media query. Off by default. |
 | `visual_night_mode_entity` | Optional HA entity id (`input_boolean`, `switch`, or `binary_sensor`). When its state is `on`, the kiosk fades in a dim overlay (opacity from `visual_night_mode_opacity`, default 40%). Leave empty and the kiosk uses `window.matchMedia('(prefers-color-scheme: dark)')` instead — handy for tablets that flip themselves at night. Requires `visual_burn_in_mitigation: true`. |
+| `visual_theme` / `visual_accent_color` | Top-level look-and-feel (#23 + #66). `visual_theme` picks one of four presets via `<body data-theme>`: `classic-gold` (default, original warm bulb look), `art-deco-silver` (cooler chrome highlights and brushed-metal glow), `neon-80s` (hot pink + cyan with magenta bulbs), or `minimalist-dark` (clean dark UI, ornament backed off). `visual_accent_color` is an optional strict `#RRGGBB` override (e.g. `#ff5500`) that re-derives the four-stop accent ramp via CSS `color-mix(in srgb, ...)` — leave blank to use the theme's default ramp. Both are presentation-only; nothing on the server changes. |
 
 HACS-only users (no add-on / server) can flip any visual toggle per tablet
 by setting `pns.visualProgressBar=true` / `pns.visualRatingsBadges=true` /
@@ -71,12 +74,15 @@ by setting `pns.visualProgressBar=true` / `pns.visualRatingsBadges=true` /
 `pns.visualUseBackdrops=true` / `pns.visualBackdropStyle=ambient` /
 `pns.visualBurnInMitigation=true` (with optional
 `pns.visualNudgeIntervalMs`, `pns.visualNudgeAmplitudePx`,
-`pns.visualNightModeEntity`, `pns.visualNightModeOpacity`) in
+`pns.visualNightModeEntity`, `pns.visualNightModeOpacity`) /
+`pns.visualTheme=art-deco-silver` /
+`pns.visualAccentColor=#ff5500` in
 `localStorage`, or adding the matching
 `#visualProgressBar=true` / `#visualRatingsBadges=true` /
 `#visualGenreChips=true` / `#visualInfoPanelMode=always` /
 `#visualUseBackdrops=true` / `#visualBackdropStyle=ambient` /
-`#visualBurnInMitigation=true`
+`#visualBurnInMitigation=true` /
+`#visualTheme=neon-80s` / `#visualAccentColor=%23ff5500`
 to the kiosk URL hash.
 
 ### Fully Kiosk auto-switcher (#48)

--- a/addons/plex-now-showing/config.yaml
+++ b/addons/plex-now-showing/config.yaml
@@ -76,6 +76,12 @@ options:
   visual_nudge_amplitude_px: 4
   visual_night_mode_entity: ""
   visual_night_mode_opacity: 0.4
+  # Theme presets (#23) + accent colour picker (#66). Both are presentation-
+  # only and safe to leave at defaults; classic-gold mirrors the original
+  # bulb look. Accent colour is a strict #RRGGBB override (empty = theme
+  # default ramp).
+  visual_theme: classic-gold
+  visual_accent_color: ""
   log_level: info
 schema:
   plex_url: "str?"
@@ -109,5 +115,7 @@ schema:
   visual_nudge_amplitude_px: "int(1,16)"
   visual_night_mode_entity: "str?"
   visual_night_mode_opacity: "float(0,0.95)"
+  visual_theme: "list(classic-gold|art-deco-silver|neon-80s|minimalist-dark)"
+  visual_accent_color: "str?"
   log_level: "list(trace|debug|info|notice|warning|error|fatal)?"
 image: ghcr.io/rusty4444/plex-now-showing-{arch}

--- a/addons/plex-now-showing/rootfs/etc/services.d/plex-now-showing/run
+++ b/addons/plex-now-showing/rootfs/etc/services.d/plex-now-showing/run
@@ -70,6 +70,11 @@ export_opt VISUAL_NUDGE_INTERVAL_MS   visual_nudge_interval_ms
 export_opt VISUAL_NUDGE_AMPLITUDE_PX  visual_nudge_amplitude_px
 export_opt VISUAL_NIGHT_MODE_ENTITY   visual_night_mode_entity
 export_opt VISUAL_NIGHT_MODE_OPACITY  visual_night_mode_opacity
+# Theme presets (#23) + accent colour picker (#66). Theme is one of
+# classic-gold|art-deco-silver|neon-80s|minimalist-dark; accent colour is
+# a strict #RRGGBB override (empty = use theme's default ramp).
+export_opt VISUAL_THEME               visual_theme
+export_opt VISUAL_ACCENT_COLOR        visual_accent_color
 
 # ---- Diagnostics (no secrets) ----
 bashio::log.info "Plex URL configured:      $([[ -n "${PLEX_URL}"   ]] && echo yes || echo no)"
@@ -89,6 +94,8 @@ bashio::log.info "Visual genre chips:       ${VISUAL_GENRE_CHIPS:-false}"
 bashio::log.info "Info panel mode:          ${VISUAL_INFO_PANEL_MODE:-on_tap}"
 bashio::log.info "Backdrop art:             ${VISUAL_USE_BACKDROPS:-false} (${VISUAL_BACKDROP_STYLE:-fullscreen}, delay ${VISUAL_BACKDROP_DELAY_MS:-10000}ms)"
 bashio::log.info "Burn-in mitigation:       ${VISUAL_BURN_IN_MITIGATION:-false} (nudge ${VISUAL_NUDGE_AMPLITUDE_PX:-4}px every ${VISUAL_NUDGE_INTERVAL_MS:-60000}ms, night entity=${VISUAL_NIGHT_MODE_ENTITY:-<none>}, opacity=${VISUAL_NIGHT_MODE_OPACITY:-0.4})"
+bashio::log.info "Visual theme:             ${VISUAL_THEME:-classic-gold}"
+bashio::log.info "Accent colour override:   ${VISUAL_ACCENT_COLOR:-<theme default>}"
 bashio::log.info "Switcher enabled:         ${SWITCHER_ENABLED:-false}"
 if bashio::var.true "${SWITCHER_ENABLED:-false}"; then
   kiosk_count=$(bashio::config 'fully_kiosks | length')

--- a/addons/plex-now-showing/translations/en.yaml
+++ b/addons/plex-now-showing/translations/en.yaml
@@ -137,6 +137,20 @@ configuration:
     description: >-
       How dark the overnight overlay is. 0.4 reads as clearly dimmed but
       the title is still legible from across the room. Range 0–0.95.
+  visual_theme:
+    name: Visual theme preset
+    description: >-
+      Top-level look-and-feel. "classic-gold" (default) keeps the warm
+      cinema-bulb vibe. "art-deco-silver" uses cooler chrome highlights.
+      "neon-80s" leans into hot pink + cyan. "minimalist-dark" drops the
+      ornament for a clean dark UI.
+  visual_accent_color:
+    name: Accent colour override
+    description: >-
+      Optional #RRGGBB hex (e.g. #ff5500) that overrides the active theme's
+      accent ramp — bulbs, marquee text glow, progress bar, and ratings
+      badges all derive from it. Leave blank to use the theme's default
+      ramp. Short form (#abc) and named colours are rejected.
   log_level:
     name: Log level
     description: Verbosity of the add-on log.

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -63,6 +63,14 @@ VISUAL_NUDGE_AMPLITUDE_PX=4
 VISUAL_NIGHT_MODE_ENTITY=
 # Dim overlay opacity when night mode is active. Clamped to 0–0.95.
 VISUAL_NIGHT_MODE_OPACITY=0.4
+# Theme preset (#23). One of classic-gold (default) | art-deco-silver |
+# neon-80s | minimalist-dark. Sets the bulb / accent / background ramp
+# via <body data-theme>.
+VISUAL_THEME=classic-gold
+# Accent colour override (#66). Strict #RRGGBB hex (e.g. #ff5500). Empty
+# = use the active theme's default ramp. Short form (#abc) and named
+# colours are rejected.
+VISUAL_ACCENT_COLOR=
 
 # ---- Optional hardening (set both if exposing the port beyond your LAN) ---
 # Every /api/* request must carry header X-Proxy-Secret: <value>.

--- a/docker/docker-compose.example.yml
+++ b/docker/docker-compose.example.yml
@@ -60,6 +60,8 @@ services:
       VISUAL_NUDGE_AMPLITUDE_PX: "${VISUAL_NUDGE_AMPLITUDE_PX:-4}"
       VISUAL_NIGHT_MODE_ENTITY: "${VISUAL_NIGHT_MODE_ENTITY:-}"
       VISUAL_NIGHT_MODE_OPACITY: "${VISUAL_NIGHT_MODE_OPACITY:-0.4}"
+      VISUAL_THEME: "${VISUAL_THEME:-classic-gold}"
+      VISUAL_ACCENT_COLOR: "${VISUAL_ACCENT_COLOR:-}"
 
       # ---- Optional hardening (recommended if exposed off-LAN) ----
       PROXY_SECRET: "${PROXY_SECRET:-}"

--- a/server/README.md
+++ b/server/README.md
@@ -72,6 +72,8 @@ For HA Container users running via Docker Compose. Set:
 | `VISUAL_NUDGE_AMPLITUDE_PX` | `4` | Maximum pixel shift (clamped 1–16) |
 | `VISUAL_NIGHT_MODE_ENTITY` | _empty_ | Optional HA `input_boolean` / `switch` / `binary_sensor`; when `on`, dims the kiosk. Empty → fall back to `prefers-color-scheme: dark` |
 | `VISUAL_NIGHT_MODE_OPACITY` | `0.4` | Dim overlay opacity (clamped 0–0.95) |
+| `VISUAL_THEME` | `classic-gold` | Theme preset — one of `classic-gold` / `art-deco-silver` / `neon-80s` / `minimalist-dark`. Drives `<body data-theme>` |
+| `VISUAL_ACCENT_COLOR` | _empty_ | Optional `#RRGGBB` accent override applied on top of the theme. Strict (no `#abc`, no named colours, no `rgb()`) |
 | `STATIC_DIR` | `../www` | Override where `now_showing.html` is served from |
 
 ## Local development

--- a/server/src/config.js
+++ b/server/src/config.js
@@ -97,6 +97,21 @@ export function loadConfig(env = process.env) {
       // Overlay opacity when night mode is active. 0.4 reads as "clearly
       // dimmed but the title is still legible from across the room".
       nightModeOpacity: parseFloatClamped(env.VISUAL_NIGHT_MODE_OPACITY, 0.4, 0, 0.95),
+      // Theme presets (#23). Each preset is a small block of CSS custom
+      // property overrides applied via <body data-theme="…">. The default
+      // 'classic-gold' matches the bulb-lit cinema look that's been the only
+      // option until now — existing installs render identically.
+      // Composes with the per-axis controls below; explicit values beat
+      // preset defaults.
+      theme: parseEnum(env.VISUAL_THEME,
+        ['classic-gold', 'art-deco-silver', 'neon-80s', 'minimalist-dark'],
+        'classic-gold'),
+      // Accent colour override (#66). Drives --accent-light/mid/dark/glow,
+      // which the marquee trim, gold-line frame, ratings highlight and chip
+      // borders all read from. Empty string = use the active theme's accent.
+      // Hex validation is strict (#RRGGBB only) so a typo can't break the
+      // whole UI — falls back to '' (theme default) on bad input.
+      accentColor: parseHexColor(env.VISUAL_ACCENT_COLOR, ''),
     },
     // Where the static HTML lives (overridden in tests)
     staticDir: env.STATIC_DIR || new URL('../../www', import.meta.url).pathname,
@@ -131,6 +146,17 @@ function parseFloatClamped(v, defaultValue, min, max) {
   const n = parseFloat(String(v));
   if (!Number.isFinite(n)) return defaultValue;
   return Math.min(Math.max(n, min), max);
+}
+
+// Validate a #RRGGBB hex colour string. Anything else (including #RGB short
+// form, named colours, rgba(), garbage) returns defaultValue so a typo in
+// add-on config can't render the kiosk unstyled. Trims and lower-cases for
+// stable equality.
+function parseHexColor(v, defaultValue) {
+  if (v == null) return defaultValue;
+  const s = String(v).trim().toLowerCase();
+  if (s === '') return defaultValue;
+  return /^#[0-9a-f]{6}$/.test(s) ? s : defaultValue;
 }
 
 function validate(c) {

--- a/server/src/routes/config.js
+++ b/server/src/routes/config.js
@@ -30,6 +30,11 @@ export function configRoute({ config }) {
         nudgeAmplitudePx: config.visual?.nudgeAmplitudePx ?? 4,
         nightModeEntity: config.visual?.nightModeEntity || '',
         nightModeOpacity: config.visual?.nightModeOpacity ?? 0.4,
+        // #23 theme preset + #66 accent colour. Both are presentation-only
+        // so safe to expose; the frontend turns them into <body data-theme>
+        // + a single CSS custom property override.
+        theme: config.visual?.theme || 'classic-gold',
+        accentColor: config.visual?.accentColor || '',
       },
     });
   });

--- a/server/test/config.test.js
+++ b/server/test/config.test.js
@@ -179,6 +179,51 @@ test('VISUAL_NIGHT_MODE_ENTITY round-trips into config', () => {
   assert.equal(config.visual.nightModeEntity, 'input_boolean.bedroom_kiosk_dim');
 });
 
+// ===== #23 theme presets + #66 accent colour =====
+
+test('VISUAL_THEME defaults to classic-gold and accepts the four presets', () => {
+  const def = loadConfig({ SUPERVISOR_TOKEN: 'x' });
+  assert.equal(def.config.visual.theme, 'classic-gold');
+
+  for (const t of ['classic-gold', 'art-deco-silver', 'neon-80s', 'minimalist-dark']) {
+    const { config } = loadConfig({ SUPERVISOR_TOKEN: 'x', VISUAL_THEME: t });
+    assert.equal(config.visual.theme, t);
+  }
+
+  const bogus = loadConfig({ SUPERVISOR_TOKEN: 'x', VISUAL_THEME: 'rainbow-puke' });
+  assert.equal(bogus.config.visual.theme, 'classic-gold');
+});
+
+test('VISUAL_ACCENT_COLOR defaults to empty string (theme owns it)', () => {
+  const { config } = loadConfig({ SUPERVISOR_TOKEN: 'x' });
+  assert.equal(config.visual.accentColor, '');
+});
+
+test('VISUAL_ACCENT_COLOR accepts #RRGGBB and rejects everything else', () => {
+  const lower = loadConfig({ SUPERVISOR_TOKEN: 'x', VISUAL_ACCENT_COLOR: '#c0ffee' });
+  assert.equal(lower.config.visual.accentColor, '#c0ffee');
+
+  const upper = loadConfig({ SUPERVISOR_TOKEN: 'x', VISUAL_ACCENT_COLOR: '#FF8800' });
+  assert.equal(upper.config.visual.accentColor, '#ff8800'); // normalised lower-case
+
+  const padded = loadConfig({ SUPERVISOR_TOKEN: 'x', VISUAL_ACCENT_COLOR: '  #aabbcc  ' });
+  assert.equal(padded.config.visual.accentColor, '#aabbcc');
+
+  // 3-digit short form is intentionally rejected (no auto-expand) so users
+  // don't get surprised by lossy hex conversion.
+  const short = loadConfig({ SUPERVISOR_TOKEN: 'x', VISUAL_ACCENT_COLOR: '#abc' });
+  assert.equal(short.config.visual.accentColor, '');
+
+  const named = loadConfig({ SUPERVISOR_TOKEN: 'x', VISUAL_ACCENT_COLOR: 'gold' });
+  assert.equal(named.config.visual.accentColor, '');
+
+  const noHash = loadConfig({ SUPERVISOR_TOKEN: 'x', VISUAL_ACCENT_COLOR: 'aabbcc' });
+  assert.equal(noHash.config.visual.accentColor, '');
+
+  const garbage = loadConfig({ SUPERVISOR_TOKEN: 'x', VISUAL_ACCENT_COLOR: 'rgb(255,0,0)' });
+  assert.equal(garbage.config.visual.accentColor, '');
+});
+
 test('switcher is off by default, on requires FULLY_KIOSKS', () => {
   const off = loadConfig({ SUPERVISOR_TOKEN: 'x' });
   assert.equal(off.config.switcherEnabled, false);

--- a/server/test/routes.test.js
+++ b/server/test/routes.test.js
@@ -120,8 +120,29 @@ test('GET /api/config defaults every visual toggle off', async () => {
         nudgeAmplitudePx: 4,
         nightModeEntity: '',
         nightModeOpacity: 0.4,
+        theme: 'classic-gold',
+        accentColor: '',
       },
     });
+  } finally { server.close(); }
+});
+
+test('GET /api/config surfaces theme + accentColor when configured', async () => {
+  const haClient = { getStates: async () => haStates };
+  const { server, url } = await startApp(
+    baseConfig({
+      visual: {
+        progressBar: false, ratingsBadges: false, infoPanelMode: 'on_tap',
+        theme: 'neon-80s',
+        accentColor: '#ff00aa',
+      },
+    }),
+    haClient,
+  );
+  try {
+    const body = await fetch(`${url}/api/config`).then(r => r.json());
+    assert.equal(body.visual.theme, 'neon-80s');
+    assert.equal(body.visual.accentColor, '#ff00aa');
   } finally { server.close(); }
 });
 

--- a/www/now_showing.html
+++ b/www/now_showing.html
@@ -10,11 +10,29 @@
   <style>
     *, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
 
+    /* ===== THEME PRESETS (#23) =====
+     *
+     * Each theme is one block of CSS custom-property overrides applied via
+     * <body data-theme="…">. The fine-grained per-axis controls (#viz-13
+     * through #viz-19) layer on top by setting their own properties, so
+     * picking a preset and then customising one axis works as expected.
+     *
+     * Presets only redefine the variables that differ from classic-gold so
+     * the diff between themes stays readable at a glance.
+     *
+     * Adding a new preset: pick a 4-stop accent ramp (light/mid/dark/glow),
+     * a body bg + marquee bg, and decide whether the bulb gradient still
+     * fits or needs a custom --bulb-on/off pair. Then add an entry to the
+     * VISUAL_THEMES enum in server/src/config.js + the readVisualTheme
+     * resolver below. */
     :root {
-      --gold-light: #e8c84a;
-      --gold-mid: #c9a73b;
-      --gold-dark: #8b6f2a;
-      --gold-glow: #ffd75e;
+      /* classic-gold (default) values — also duplicated in the data-theme
+       * block below so an explicit data-theme="classic-gold" works the
+       * same as the bare :root fallback. */
+      --accent-light: #e8c84a;
+      --accent-mid: #c9a73b;
+      --accent-dark: #8b6f2a;
+      --accent-glow: #ffd75e;
       --bulb-on: #ffe69c;
       --bulb-off: #665522;
       --frame-border: #a0842e;
@@ -24,6 +42,89 @@
       --text-dim: #998c6e;
       --red-curtain: #5c1010;
       --marquee-height: 14vh;
+    }
+
+    body[data-theme="classic-gold"] {
+      /* explicit no-op — same values as :root, present so theme switching
+       * back to classic-gold from another preset reliably resets every var. */
+      --accent-light: #e8c84a;
+      --accent-mid: #c9a73b;
+      --accent-dark: #8b6f2a;
+      --accent-glow: #ffd75e;
+      --bulb-on: #ffe69c;
+      --bulb-off: #665522;
+      --frame-border: #a0842e;
+      --bg-dark: #0a0a0a;
+      --bg-marquee: #111111;
+      --text-light: #f5f0e0;
+      --text-dim: #998c6e;
+      --red-curtain: #5c1010;
+    }
+
+    body[data-theme="art-deco-silver"] {
+      /* Cool platinum ramp + slightly cooler curtain, evokes a 1930s
+       * picture-palace lobby. Bulbs stay warm-white because cool bulbs read
+       * as fluorescent / clinical. */
+      --accent-light: #e6e8ee;
+      --accent-mid: #b9bcc6;
+      --accent-dark: #6f7480;
+      --accent-glow: #f7f9ff;
+      --bulb-on: #fff4d6;
+      --bulb-off: #4a4d55;
+      --frame-border: #8c909a;
+      --bg-dark: #0c0e12;
+      --bg-marquee: #14171c;
+      --text-light: #ecedf2;
+      --text-dim: #8d909a;
+      --red-curtain: #2b3340; /* navy curtain instead of crimson */
+    }
+
+    body[data-theme="neon-80s"] {
+      /* Synthwave: hot pink → cyan accent, deep purple bg. Bulbs become
+       * magenta because you can't have a neon theme without neon bulbs. */
+      --accent-light: #ff5cf0;
+      --accent-mid: #c026d3;
+      --accent-dark: #6b21a8;
+      --accent-glow: #00e5ff;
+      --bulb-on: #ff77ff;
+      --bulb-off: #2a0a3a;
+      --frame-border: #8b1d8b;
+      --bg-dark: #0a0420;
+      --bg-marquee: #15082e;
+      --text-light: #fff0ff;
+      --text-dim: #a878c8;
+      --red-curtain: #1a0838;
+    }
+
+    body[data-theme="minimalist-dark"] {
+      /* No-frills monochrome — pairs well with frame-style: none + corner
+       * radius (#19). Subtle off-white accent, charcoal everywhere else. */
+      --accent-light: #e5e7eb;
+      --accent-mid: #9ca3af;
+      --accent-dark: #4b5563;
+      --accent-glow: #f9fafb;
+      --bulb-on: #d1d5db;
+      --bulb-off: #1f2937;
+      --frame-border: #374151;
+      --bg-dark: #050505;
+      --bg-marquee: #0a0a0a;
+      --text-light: #f3f4f6;
+      --text-dim: #6b7280;
+      --red-curtain: #18181b;
+    }
+
+    /* The accent-colour picker (#66) writes a single hex into
+     * --accent-override on <body>. We then derive a 4-stop ramp from it
+     * via colour-mix() so the picker works without needing the user to
+     * pick four hexes themselves. Browsers without color-mix support
+     * (Chrome <111, Safari <16.2) just see the theme defaults — acceptable
+     * because the kiosk is locked to a known browser. */
+    body[style*="--accent-override"] {
+      --accent-light: var(--accent-override);
+      --accent-mid:   color-mix(in srgb, var(--accent-override) 80%, #000 20%);
+      --accent-dark:  color-mix(in srgb, var(--accent-override) 50%, #000 50%);
+      --accent-glow:  color-mix(in srgb, var(--accent-override) 70%, #fff 30%);
+      --frame-border: color-mix(in srgb, var(--accent-override) 70%, #000 30%);
     }
 
     html, body {
@@ -70,11 +171,20 @@
       width: 28px;
       height: 28px;
       border-radius: 50%;
-      background: radial-gradient(circle at 40% 35%, #fff8dc, var(--bulb-on) 40%, #d4a820 100%);
+      /* Three-stop bulb gradient: hot core (--bulb-on lightened) → main
+       * bulb colour → dark rim (--accent-mid). Now reads from the accent
+       * ramp so non-gold themes get a coherent bulb tint instead of always
+       * fading to gold. */
+      background: radial-gradient(circle at 40% 35%,
+        color-mix(in srgb, var(--bulb-on) 70%, #fff 30%),
+        var(--bulb-on) 40%,
+        var(--accent-mid) 100%);
+      /* All three glow layers read from --accent-glow so theme presets
+       * recolour the entire bulb halo, not just the bulb body. */
       box-shadow:
-        0 0 16px 6px rgba(255, 215, 94, 0.7),
-        0 0 32px 12px rgba(255, 215, 94, 0.3),
-        0 0 4px 2px rgba(255, 230, 156, 0.9);
+        0 0 16px 6px color-mix(in srgb, var(--accent-glow) 70%, transparent),
+        0 0 32px 12px color-mix(in srgb, var(--accent-glow) 30%, transparent),
+        0 0 4px 2px color-mix(in srgb, var(--bulb-on) 90%, transparent);
       transition: all 0.35s ease;
     }
 
@@ -90,7 +200,7 @@
       height: var(--marquee-height);
       flex-shrink: 0;
       border: 4px solid;
-      border-image: linear-gradient(135deg, var(--gold-light), var(--gold-dark), var(--gold-light), var(--gold-dark)) 1;
+      border-image: linear-gradient(135deg, var(--accent-light), var(--accent-dark), var(--accent-light), var(--accent-dark)) 1;
       overflow: hidden;
       z-index: 2;
     }
@@ -155,8 +265,8 @@
       letter-spacing: 0.35em;
       color: var(--text-light);
       text-shadow:
-        0 0 20px rgba(255, 215, 94, 0.4),
-        0 0 40px rgba(255, 215, 94, 0.2),
+        0 0 20px color-mix(in srgb, var(--accent-glow) 40%, transparent),
+        0 0 40px color-mix(in srgb, var(--accent-glow) 20%, transparent),
         0 2px 4px rgba(0, 0, 0, 0.6);
     }
 
@@ -168,7 +278,7 @@
       min-height: 0;
       border: 4px solid;
       border-top: none;
-      border-image: linear-gradient(135deg, var(--gold-light), var(--gold-dark), var(--gold-light), var(--gold-dark)) 1;
+      border-image: linear-gradient(135deg, var(--accent-light), var(--accent-dark), var(--accent-light), var(--accent-dark)) 1;
       overflow: hidden;
       background: var(--bg-marquee);
     }
@@ -241,13 +351,13 @@
       bottom: 0;
       width: 0%;
       background: linear-gradient(90deg,
-        var(--gold-dark) 0%,
-        var(--gold-mid) 40%,
-        var(--gold-light) 70%,
-        var(--gold-glow) 100%);
+        var(--accent-dark) 0%,
+        var(--accent-mid) 40%,
+        var(--accent-light) 70%,
+        var(--accent-glow) 100%);
       box-shadow:
-        0 0 10px rgba(255, 215, 94, 0.55),
-        0 0 22px rgba(255, 215, 94, 0.3);
+        0 0 10px color-mix(in srgb, var(--accent-glow) 55%, transparent),
+        0 0 22px color-mix(in srgb, var(--accent-glow) 30%, transparent);
       will-change: width;
     }
     /* Soft leading edge so the bar feels like a spotlight sweep */
@@ -259,7 +369,7 @@
       bottom: 0;
       width: 10px;
       background: radial-gradient(ellipse at left center,
-        rgba(255, 230, 156, 0.95) 0%, transparent 70%);
+        color-mix(in srgb, var(--bulb-on) 95%, transparent) 0%, transparent 70%);
     }
     /* Dimmed fill while paused */
     .progress-bar.paused .progress-bar-fill {
@@ -480,7 +590,7 @@
       font-family: 'Bebas Neue', sans-serif;
       font-size: clamp(0.85rem, 2vw, 1.1rem);
       letter-spacing: 0.15em;
-      color: var(--gold-light);
+      color: var(--accent-light);
       text-transform: uppercase;
       text-shadow: 0 1px 4px rgba(0,0,0,0.8);
     }
@@ -532,7 +642,7 @@
       font-family: 'Bebas Neue', sans-serif;
       font-size: clamp(1.2rem, 3vw, 1.8rem);
       letter-spacing: 0.2em;
-      color: var(--gold-dark);
+      color: var(--accent-dark);
       opacity: 0.6;
     }
 
@@ -631,7 +741,7 @@
       font-family: 'Bebas Neue', sans-serif;
       font-size: clamp(0.8rem, 2vw, 1rem);
       letter-spacing: 0.1em;
-      color: var(--gold-light);
+      color: var(--accent-light);
       background: rgba(200, 160, 50, 0.12);
       padding: 4px 12px;
       border-radius: 4px;
@@ -814,7 +924,7 @@
       font-family: 'Bebas Neue', sans-serif;
       font-size: 2.2rem;
       letter-spacing: 0.2em;
-      color: var(--gold-light);
+      color: var(--accent-light);
       text-align: center;
       margin-bottom: 4px;
     }
@@ -832,7 +942,7 @@
       font-size: 0.75rem;
       letter-spacing: 0.08em;
       text-transform: uppercase;
-      color: var(--gold-light);
+      color: var(--accent-light);
       margin-bottom: 4px;
     }
     .setup-field .hint {
@@ -853,7 +963,7 @@
     }
     .setup-field input:focus {
       outline: none;
-      border-color: var(--gold-light);
+      border-color: var(--accent-light);
       box-shadow: 0 0 0 3px rgba(200, 160, 50, 0.15);
     }
     .setup-field input::placeholder { color: #555; }
@@ -877,11 +987,11 @@
       cursor: pointer;
       transition: all 0.15s ease;
     }
-    .setup-btn:hover { border-color: var(--gold-light); color: var(--gold-light); }
+    .setup-btn:hover { border-color: var(--accent-light); color: var(--accent-light); }
     .setup-btn.primary {
-      background: linear-gradient(180deg, var(--gold-light), var(--gold-dark));
+      background: linear-gradient(180deg, var(--accent-light), var(--accent-dark));
       color: #1a1205;
-      border-color: var(--gold-light);
+      border-color: var(--accent-light);
       font-weight: 600;
     }
     .setup-btn.primary:hover { filter: brightness(1.1); }
@@ -907,7 +1017,7 @@
       margin-top: 6px;
       border-top: 1px solid rgba(255, 255, 255, 0.06);
     }
-    .setup-advanced[open] summary { color: var(--gold-light); }
+    .setup-advanced[open] summary { color: var(--accent-light); }
 
     /* Gear icon on the live display to reopen setup */
     .setup-gear {
@@ -920,7 +1030,7 @@
       opacity: 0.18;
       cursor: pointer;
       transition: opacity 0.2s ease;
-      color: var(--gold-light);
+      color: var(--accent-light);
     }
     .setup-gear:hover { opacity: 0.85; }
     .setup-gear svg { width: 100%; height: 100%; }
@@ -1208,6 +1318,10 @@
     // fleet without touching every tablet.
     const INFO_PANEL_MODES = ['on_tap', 'on_pause', 'always'];
     const BACKDROP_STYLES = ['fullscreen', 'ambient'];
+    // #23 — theme presets. Must mirror the enum in server/src/config.js.
+    // Adding one here without updating the server will leak through (the
+    // setup page reads localStorage), but the add-on schema will reject it.
+    const VISUAL_THEMES = ['classic-gold', 'art-deco-silver', 'neon-80s', 'minimalist-dark'];
     // VISUAL holds the resolved values for every visual toggle. Defaults
     // mirror the server-side defaults so a hard-refresh before /api/config
     // resolves still renders sanely.
@@ -1226,6 +1340,10 @@
       nudgeAmplitudePx: 4,
       nightModeEntity: '',
       nightModeOpacity: 0.4,
+      // #23 theme preset + #66 accent colour. Empty accentColor means "use
+      // the active theme's default".
+      theme: 'classic-gold',
+      accentColor: '',
     };
 
     // #28 helper — clamp a float read from URL hash / localStorage. Mirrors
@@ -1262,6 +1380,32 @@
       return defaultValue;
     }
 
+    // #23 theme preset resolver — hash > localStorage > default. Unknown
+    // names fall back instead of throwing so a stale tablet picking a theme
+    // that's been renamed server-side still renders.
+    function readVisualTheme(defaultValue) {
+      const hash = new URLSearchParams(location.hash.replace(/^#/, ''));
+      const fromHash = hash.get('visualTheme');
+      if (fromHash && VISUAL_THEMES.includes(fromHash)) return fromHash;
+      const fromStorage = localStorage.getItem('pns.visualTheme');
+      if (fromStorage && VISUAL_THEMES.includes(fromStorage)) return fromStorage;
+      return defaultValue;
+    }
+
+    // #66 accent colour resolver — hash > localStorage > default. Same
+    // strict #RRGGBB validation as the server's parseHexColor() so the
+    // contract is identical on both sides; bad input falls through to the
+    // theme default.
+    const HEX_RE = /^#[0-9a-f]{6}$/;
+    function readAccentColor(defaultValue) {
+      const hash = new URLSearchParams(location.hash.replace(/^#/, ''));
+      const fromHash = (hash.get('visualAccentColor') || '').trim().toLowerCase();
+      if (fromHash && HEX_RE.test(fromHash)) return fromHash;
+      const fromStorage = (localStorage.getItem('pns.visualAccentColor') || '').trim().toLowerCase();
+      if (fromStorage && HEX_RE.test(fromStorage)) return fromStorage;
+      return defaultValue;
+    }
+
     function readIntClamped(key, defaultValue, min, max) {
       const hash = new URLSearchParams(location.hash.replace(/^#/, ''));
       const raw = hash.get(key) || localStorage.getItem('pns.' + key);
@@ -1291,6 +1435,10 @@
           || localStorage.getItem('pns.visualNightModeEntity') || '';
       }
       VISUAL.nightModeOpacity = readFloatClamped('visualNightModeOpacity', 0.4, 0, 0.95);
+      // #23/#66 theme + accent. Local resolution first; server overrides
+      // below if /api/config responds with non-empty values.
+      VISUAL.theme = readVisualTheme('classic-gold');
+      VISUAL.accentColor = readAccentColor('');
 
       await serverModeReady;
       if (!SERVER_MODE) return;
@@ -1317,6 +1465,16 @@
         if (v && Number.isFinite(v.nudgeAmplitudePx))    VISUAL.nudgeAmplitudePx  = v.nudgeAmplitudePx;
         if (v && typeof v.nightModeEntity === 'string')  VISUAL.nightModeEntity   = v.nightModeEntity;
         if (v && Number.isFinite(v.nightModeOpacity))    VISUAL.nightModeOpacity  = v.nightModeOpacity;
+        if (v && typeof v.theme === 'string' && VISUAL_THEMES.includes(v.theme)) {
+          VISUAL.theme = v.theme;
+        }
+        // Server validates accentColor as #RRGGBB or empty; trust it but
+        // double-check on the client to defend against a stale or modified
+        // response.
+        if (v && typeof v.accentColor === 'string') {
+          const c = v.accentColor.trim().toLowerCase();
+          VISUAL.accentColor = (c === '' || HEX_RE.test(c)) ? c : '';
+        }
       } catch (err) {
         console.warn('[plex-now-showing] /api/config fetch failed — using local defaults.', err);
       }
@@ -1452,6 +1610,22 @@
         burnInCtx.start();
       } else {
         burnInCtx.stop();
+      }
+
+      // #23 theme preset — a single data-theme attribute on body. The CSS
+      // selectors in the :root/data-theme blocks at the top of the file do
+      // the rest. Re-applied on every call so swapping theme at runtime
+      // (setup form save, hash change) takes effect without reload.
+      document.body.dataset.theme = VISUAL.theme;
+
+      // #66 accent colour override — written as an inline custom property
+      // so the body[style*="--accent-override"] selector can derive a full
+      // 4-stop ramp via color-mix(). Empty string clears it so the active
+      // theme regains control of the accent.
+      if (VISUAL.accentColor) {
+        document.body.style.setProperty('--accent-override', VISUAL.accentColor);
+      } else {
+        document.body.style.removeProperty('--accent-override');
       }
     }
 


### PR DESCRIPTION
First PR of V2 Visual Sprint 3 — lays the theming foundation that every later visual upgrade (#62/#63 marquee bg/font, #65 frame style, #67/#68 poster framing/radius, #64 per-section toggles) will plug into.

## What ships

### #23 — Theme presets
Four named presets, picked via `visual_theme`:

| Preset | Look |
|--------|------|
| `classic-gold` (default) | Original warm cinema-bulb vibe. Identical to v1. |
| `art-deco-silver` | Cooler chrome highlights, brushed-metal bulb glow. |
| `neon-80s` | Hot pink + cyan bulbs, magenta marquee glow. |
| `minimalist-dark` | Clean dark UI, bulbs backed off to white pearls. |

All accent-derived elements (bulbs, marquee text glow, progress bar, ratings badges, frame border) reskin together via `<body data-theme>`. CSS variables previously named `--gold-*` are now `--accent-*` (21 references renamed).

### #66 — Accent colour picker
Strict `#RRGGBB` override (e.g. `#ff5500`) applied on top of any theme via `--accent-override`. The four-stop ramp is derived with CSS `color-mix(in srgb, ...)`. Empty value (default) leaves the theme's ramp untouched. Short form (`#abc`), named colours, and `rgb()` are rejected at both server and client.

```js
function parseHexColor(v, defaultValue) {
  if (v == null) return defaultValue;
  const s = String(v).trim().toLowerCase();
  if (s === '') return defaultValue;
  return /^#[0-9a-f]{6}$/.test(s) ? s : defaultValue;
}
```

## Plumbing

- `addons/plex-now-showing/config.yaml` — `visual_theme` + `visual_accent_color` options + schema
- `addons/plex-now-showing/translations/en.yaml` — UI labels + descriptions
- `addons/plex-now-showing/rootfs/.../run` — `export_opt VISUAL_THEME` / `VISUAL_ACCENT_COLOR` + log lines
- `addons/plex-now-showing/DOCS.md` — config table rows, visual toggles entry, HACS localStorage/hash docs
- `docker/.env.example` + `docker/docker-compose.example.yml` — env passthroughs
- `server/README.md` — env table rows
- `addons/plex-now-showing/CHANGELOG.md` — entries for #23 + #66

## Tests

- `server/test/config.test.js` — 4 new cases: theme defaults + enum, accentColor empty default, accentColor accepts `#RRGGBB` / rejects `#abc` / named / no-hash / `rgb()`
- `server/test/routes.test.js` — defaults deepEqual updated; one new test asserting `/api/config` surfaces both fields when configured

```
# tests 109
# pass 109
# fail 0
```

## Browser support

`color-mix(in srgb, ...)` requires Chrome 111+ / Safari 16.2+. Acceptable for the Fully Kiosk + tablet target.

## Closes
- Closes #23
- Closes #66

## Build order remaining for Sprint 3

After this lands: #65 frame style → #62 + #63 marquee bg + font → #64 per-section info toggles → #67 + #68 poster framing + corner radius.
