### PR TITLE
[codex] Fix dev add-on image tag

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -10,8 +10,8 @@ Registry (GHCR), one image per arch.
 | Trigger                               | Image tag(s)       | Pushed? |
 |---------------------------------------|--------------------|---------|
 | Pull request touching the add-on      | — (build-only)     | no      |
-| Push to `dev`                         | `:dev`             | yes     |
-| Push to `main`                        | `:main`            | yes     |
+| Push to `dev`                         | `:<config version>` + `:dev` | yes |
+| Push to `main`                        | `:<config version>` + `:main` | yes |
 | Tag `addon-v1.2.3`                    | `:1.2.3` + `:latest` | yes   |
 
 ### Image names
@@ -26,13 +26,14 @@ ghcr.io/rusty4444/plex-now-showing-i386
 
 These exactly match `image: ghcr.io/rusty4444/plex-now-showing-{arch}` in
 `addons/plex-now-showing/config.yaml` — Supervisor substitutes `{arch}` at
-install time.
+install time and pulls the tag named by the add-on `version`.
 
 ### Cutting a release
 
 ```bash
-# On dev, bump the version in addons/plex-now-showing/config.yaml and
-# CHANGELOG.md, merge to main, then:
+# On dev, change the pre-release version in
+# addons/plex-now-showing/config.yaml (for example 0.1.0-dev) to the release
+# version, update CHANGELOG.md, merge to main, then:
 git tag addon-v0.1.0
 git push origin addon-v0.1.0
 ```

--- a/.github/workflows/build-addon.yml
+++ b/.github/workflows/build-addon.yml
@@ -12,9 +12,12 @@
 #   ghcr.io/rusty4444/plex-now-showing-i386
 #
 # Tagging strategy:
-#   - push to `dev`                -> :dev           (rolling pre-release)
+#   - push to `dev` / `main`        -> :<config.yaml version> + :dev/:main
 #   - push a Git tag `addon-vX.Y.Z` -> :X.Y.Z + :latest (proper release)
 #   - pull_request                  -> build-only, no push (CI proof)
+#
+# Supervisor pulls the Docker tag from config.yaml's `version` field when
+# `image:` is set, so branch builds must publish that exact tag.
 
 name: Build add-on
 
@@ -103,22 +106,40 @@ jobs:
         id: ver
         run: |
           # addon-vX.Y.Z tag → release
+          ADDON_VERSION="$(python3 - <<'PY'
+          from pathlib import Path
+
+          config = Path('addons/plex-now-showing/config.yaml')
+          for line in config.read_text(encoding='utf-8').splitlines():
+              if line.strip().startswith('version:'):
+                  value = line.split(':', 1)[1].split('#', 1)[0].strip()
+                  print(value.strip('"').strip("'"))
+                  break
+          else:
+              raise SystemExit('version not found in addons/plex-now-showing/config.yaml')
+          PY
+          )"
+          ROLLING_TAG=""
+
           if [[ "${GITHUB_REF}" == refs/tags/addon-v* ]]; then
             VERSION="${GITHUB_REF#refs/tags/addon-v}"
             CHANNEL="release"
-          elif [[ "${GITHUB_REF}" == refs/heads/dev ]]; then
-            VERSION="dev"
-            CHANNEL="dev"
-          elif [[ "${GITHUB_REF}" == refs/heads/main ]]; then
-            VERSION="main"
-            CHANNEL="main"
+            if [[ "${VERSION}" != "${ADDON_VERSION}" ]]; then
+              echo "::error::Tag addon-v${VERSION} does not match config.yaml version ${ADDON_VERSION}"
+              exit 1
+            fi
+          elif [[ "${GITHUB_REF}" == refs/heads/dev || "${GITHUB_REF}" == refs/heads/main ]]; then
+            VERSION="${ADDON_VERSION}"
+            CHANNEL="${GITHUB_REF#refs/heads/}"
+            ROLLING_TAG="${CHANNEL}"
           else
             VERSION="pr-${{ github.event.pull_request.number || 'x' }}"
             CHANNEL="pr"
           fi
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
           echo "channel=${CHANNEL}" >> "$GITHUB_OUTPUT"
-          echo "Building version=${VERSION} channel=${CHANNEL}"
+          echo "rolling_tag=${ROLLING_TAG}" >> "$GITHUB_OUTPUT"
+          echo "Building version=${VERSION} channel=${CHANNEL} rolling_tag=${ROLLING_TAG}"
 
       - name: Set up QEMU
         if: matrix.arch != 'amd64'
@@ -143,7 +164,8 @@ jobs:
           tags: |
             type=raw,value=${{ steps.ver.outputs.version }}
             type=raw,value=latest,enable=${{ steps.ver.outputs.channel == 'release' }}
-            type=raw,value=dev,enable=${{ steps.ver.outputs.channel == 'dev' }}
+            type=raw,value=dev,enable=${{ steps.ver.outputs.rolling_tag == 'dev' }}
+            type=raw,value=main,enable=${{ steps.ver.outputs.rolling_tag == 'main' }}
           labels: |
             org.opencontainers.image.title=Plex Now Showing (${{ matrix.arch }})
             org.opencontainers.image.description=HA add-on image for Plex Now Showing

--- a/addons/plex-now-showing/CHANGELOG.md
+++ b/addons/plex-now-showing/CHANGELOG.md
@@ -83,3 +83,9 @@ The project follows [Semantic Versioning](https://semver.org/).
   `plex`, `jellyfin`, `emby`, or `kodi`; new generic `player` / `PLAYER`
   option can pin any exact `media_player` entity. Existing Plex defaults and
   `plex_player` / `PLEX_PLAYER` remain backward-compatible.
+
+### Fixed
+- Dev add-on installs now use a matching pre-release image tag
+  (`0.1.0-dev`) and the build workflow publishes the exact `config.yaml`
+  version tag alongside the rolling `:dev` alias, so Supervisor no longer
+  tries to pull a missing `:0.1.0` image from GHCR.

--- a/addons/plex-now-showing/config.yaml
+++ b/addons/plex-now-showing/config.yaml
@@ -9,7 +9,7 @@
 # Docs on each field: https://developers.home-assistant.io/docs/add-ons/configuration
 
 name: Plex Now Showing
-version: "0.1.0"
+version: "0.1.0-dev"
 slug: plex_now_showing
 description: Cinema-style now-playing kiosk for Plex, served directly from Home Assistant.
 url: https://github.com/rusty4444/plex-now-showing


### PR DESCRIPTION
## Summary

- Change the dev add-on version to 0.1.0-dev so Supervisor pulls a dev-specific pre-release image tag.
- Update the add-on build workflow to publish the exact config.yaml version tag on dev/main pushes, plus rolling dev/main aliases.
- Document the tag behavior and record the install fix in the add-on changelog.

## Root cause

Home Assistant Supervisor uses the add-on version as the Docker image tag when image is set. The dev branch advertised version 0.1.0, but the workflow only published :dev, so Supervisor tried to pull ghcr.io/rusty4444/plex-now-showing-amd64:0.1.0 and got 404.

## Validation

- git diff --check
- Confirmed config.yaml version/image values with Node
- Confirmed workflow contains config-version tag plus rolling dev/main tags

## Notes

After this merges to dev, the build workflow needs to complete before refreshing/installing the add-on in Home Assistant.