### PR TITLE
[codex] Fix blank Plex username playback detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ Equivalent URL hash example:
 |---------|---------------|------------|--------------|--------|
 | Media backend | `backend` | `BACKEND` | `backend` | `plex`, `jellyfin`, `emby`, `kodi` |
 | Exact player pin | `player` | `PLAYER` | `player` | Any `media_player.*` entity ID |
-| Plex username filter | `plex_username` | `PLEX_USERNAME` | `plexUsername` | Plex username |
+| Plex username filter | `plex_username` | `PLEX_USERNAME` | `plexUsername` | Optional Plex username; blank shows the first active Plex player |
 | Legacy Plex player pin | `plex_player` | `PLEX_PLAYER` | `plexPlayer` | Prefer `player` for new installs |
 | Plex server URL | `plex_url` | `PLEX_URL` | `plexUrl` | Optional; enables Plex metadata |
 | Plex token | `plex_token` | `PLEX_TOKEN` | `plexToken` | Required with `plex_url` |

--- a/addons/plex-now-showing/CHANGELOG.md
+++ b/addons/plex-now-showing/CHANGELOG.md
@@ -93,3 +93,6 @@ The project follows [Semantic Versioning](https://semver.org/).
   (`0.1.0-dev`) and the build workflow publishes the exact `config.yaml`
   version tag alongside the rolling `:dev` alias, so Supervisor no longer
   tries to pull a missing `:0.1.0` image from GHCR.
+- Blank Plex username now correctly disables user filtering in both server and
+  frontend-only mode, so HA Plex entities with a `username` attribute still
+  show as active playback.

--- a/addons/plex-now-showing/DOCS.md
+++ b/addons/plex-now-showing/DOCS.md
@@ -25,7 +25,7 @@ probe of `/api`) and switches to `/api/state`. Plex-only metadata calls use
 | `player` | _empty_ | Optional exact `media_player` entity id. Leave empty to auto-detect active players for `backend`. |
 | `plex_url` | _empty_ | e.g. `https://plex.example.com:32400`. Needed for the info panel. |
 | `plex_token` | _empty_ | Plex `X-Plex-Token`. Required together with `plex_url`. |
-| `plex_username` | _empty_ | Filter `media_player.plex_*` entities to your username. |
+| `plex_username` | _empty_ | Optional filter for `media_player.plex_*` entities. Leave empty to show the first active Plex player. |
 | `plex_player` | _empty_ | Legacy Plex-only player pin. Prefer `player` for new installs. |
 | `landscape` | `false` | Forces landscape layout on portrait tablets. |
 | `theme` | `classic-gold` | Visual theme. |

--- a/server/src/state.js
+++ b/server/src/state.js
@@ -26,16 +26,20 @@ export function normalise(states, {
   }
 
   // Otherwise pick from active media_player entities for the configured
-  // backend. Plex keeps its username filter; the other providers use the
+  // backend. Plex only filters by username when one is configured; blank
+  // means "show the first active Plex player". The other providers use the
   // first active matching player, mirroring their standalone repos.
   const active = states.filter(s => isBackendPlayer(s, rule) && PLAYING.has(s.state));
   if (active.length === 0) return null;
 
   if (backendId !== 'plex') return shape(active[0]);
 
+  const wantedUser = String(plexUsername || '').trim();
+  if (!wantedUser) return shape(active[0]);
+
   const mine = active.filter(p => {
     const attrs = p.attributes || {};
-    if (attrs.username) return attrs.username === plexUsername;
+    if (attrs.username) return attrs.username === wantedUser;
     const id = p.entity_id.replace('media_player.plex_', '');
     return id.startsWith('plex_for_') || id.startsWith('plex_web_');
   });

--- a/server/test/state.test.js
+++ b/server/test/state.test.js
@@ -119,6 +119,12 @@ test('falls back to user-filtered active players when no plexPlayer', () => {
   assert.ok(['Pilot', 'Dune: Part Two'].includes(r.title));
 });
 
+test('blank Plex username does not filter active Plex playback', () => {
+  const r = normalise(states, { backend: 'plex', plexUsername: '' });
+  assert.ok(r, 'should show the first active Plex player when username is blank');
+  assert.equal(r.title, 'Pilot');
+});
+
 test('username mismatch filters the player out', () => {
   const r = normalise(states, { plexUsername: 'nobody' });
   // No matching user and no plex_for_* generic match → null.

--- a/www/now_showing.html
+++ b/www/now_showing.html
@@ -2756,10 +2756,13 @@
 
         if (backend !== 'plex') return buildMediaData(active[0]);
 
+        const wantedPlexUser = String(PLEX_USERNAME || '').trim();
+        if (!wantedPlexUser) return buildMediaData(active[0]);
+
         const myPlayers = active.filter(p => {
           const attrs = p.attributes || {};
           if (attrs.username) {
-            return attrs.username === PLEX_USERNAME;
+            return attrs.username === wantedPlexUser;
           }
           const id = p.entity_id.replace('media_player.plex_', '');
           const isGenericClient = id.startsWith('plex_for_') || id.startsWith('plex_web_');


### PR DESCRIPTION
## Summary

- Treat a blank Plex username as no user filter in the unified server state normaliser.
- Apply the same blank-username behavior to the frontend-only direct-to-HA path.
- Add a regression test and clarify docs that plex_username is optional.

## Root cause

When Home Assistant Plex entities included a username attribute, a blank plex_username still compared attrs.username against an empty string. That filtered out every active Plex player, so the kiosk stayed idle even though Home Assistant showed playback.

## Validation

- Server tests: 118/118 passing
- Embedded now_showing.html script parsed with node --check
- git diff --check

## Immediate workaround before this lands

Set Plex Username in setup/add-on config to the exact username shown on the HA Plex media_player entity, or pin the exact player entity with player.