### PR TITLE
[codex] add Apple TV and Kaleidescape backends

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@
 > multi-backend playback, and no-code display controls.
 
 A full-screen cinema marquee display for Home Assistant that shows what is
-currently playing on Plex, Jellyfin, Emby, or Kodi. It is designed for
-wall-mounted tablets running Fully Kiosk Browser, but it also works in any
-modern browser.
+currently playing on Plex, Jellyfin, Emby, Kodi, Apple TV, or Kaleidescape.
+It is designed for wall-mounted tablets running Fully Kiosk Browser, but it
+also works in any modern browser.
 
 V2 keeps the original marquee feel while adding a secure server/add-on path,
 Docker support, multi-backend playback detection, tablet switching, visual
@@ -58,7 +58,7 @@ not exposed to the tablet browser.
 | Home Assistant add-on | `addons/plex-now-showing` wraps the server as a Supervisor add-on with Ingress, a config form, logs, multi-arch GHCR images, and optional direct port `8099`. |
 | Docker Compose | `docker/docker-compose.example.yml` and `.env.example` run the same image for HA Container users. |
 | Unified server | `server/` serves the kiosk and exposes `/api/state`, `/api/config`, `/api/media-info/:ratingKey`, `/api/artwork`, `/api/night-mode`, and `/healthz`. |
-| Multi-backend support | `backend` selects `plex`, `jellyfin`, `emby`, or `kodi`; `player` can pin any exact `media_player` entity. Plex-specific `plex_player` is still accepted for compatibility. |
+| Multi-backend support | `backend` selects `plex`, `jellyfin`, `emby`, `kodi`, `apple_tv`, or `kaleidescape`; `player` can pin any exact `media_player` entity. Plex-specific `plex_player` is still accepted for compatibility. |
 | Fully Kiosk switching | Use either the bundled HA Blueprint or the add-on/server's built-in Fully Kiosk REST switcher. |
 | Visual toggles | Progress bar, ratings badges, genre chips, info-panel display modes, pause backdrops, burn-in mitigation, night dimming, frame styles, marquee font picker, theme presets, and accent color overrides. |
 | CI / release plumbing | Multi-arch add-on builds, config linting, Docker image publishing, server tests, add-on docs, and examples. |
@@ -67,8 +67,10 @@ not exposed to the tablet browser.
 
 - Cinema marquee display with animated bulb frame, title overlays, idle state,
   and portrait or landscape layouts.
-- Playback support for Plex, Jellyfin, Emby, and Kodi Home Assistant
-  `media_player` entities.
+- Playback support for Plex, Jellyfin, Emby, Kodi, Apple TV, and
+  Kaleidescape Home Assistant `media_player` entities.
+- Apple TV app-name badges with app icons when Home Assistant exposes
+  `app_name`.
 - Optional exact player pinning via `player`.
 - Plex username filtering so shared Plex servers can show only your sessions.
 - Tap-for-info panel with synopsis, player, rating, duration, progress, and
@@ -95,7 +97,7 @@ not exposed to the tablet browser.
 ## Requirements
 
 - Home Assistant with at least one supported media integration configured:
-  Plex, Jellyfin, Emby, or Kodi.
+  Plex, Jellyfin, Emby, Kodi, Apple TV, or Kaleidescape.
 - One or more active `media_player` entities from that integration.
 - Fully Kiosk Browser if you want automatic wall-tablet switching.
 - Plex URL + Plex token only if you want Plex-only enhanced metadata such as
@@ -127,7 +129,8 @@ because Home Assistant Supervisor supplies the API token automatically.
 
 4. Install **Plex Now Showing**.
 5. Configure the add-on:
-   - `backend`: `plex`, `jellyfin`, `emby`, or `kodi`
+   - `backend`: `plex`, `jellyfin`, `emby`, `kodi`, `apple_tv`, or
+     `kaleidescape`
    - `player`: optional exact entity ID, for example `media_player.kodi`
    - `plex_url` and `plex_token`: optional, Plex enhanced metadata only
    - visual options such as `visual_theme`, `visual_frame_style`,
@@ -248,7 +251,7 @@ Then edit `now_showing.config.js` before copying it to Home Assistant:
 window.NOW_SHOWING_CONFIG = {
   haUrl: 'http://homeassistant.local:8123',
   haToken: 'YOUR_LONG_LIVED_ACCESS_TOKEN',
-  backend: 'plex', // plex | jellyfin | emby | kodi
+  backend: 'plex', // plex | jellyfin | emby | kodi | apple_tv | kaleidescape
   player: '',
   plexUsername: '',
   plexUrl: '',
@@ -291,7 +294,7 @@ Equivalent URL hash example:
 
 | Purpose | Add-on option | Docker env | Frontend key | Values |
 |---------|---------------|------------|--------------|--------|
-| Media backend | `backend` | `BACKEND` | `backend` | `plex`, `jellyfin`, `emby`, `kodi` |
+| Media backend | `backend` | `BACKEND` | `backend` | `plex`, `jellyfin`, `emby`, `kodi`, `apple_tv`, `kaleidescape` |
 | Exact player pin | `player` | `PLAYER` | `player` | Any `media_player.*` entity ID |
 | Plex username filter | `plex_username` | `PLEX_USERNAME` | `plexUsername` | Optional Plex username; blank shows the first active Plex player |
 | Legacy Plex player pin | `plex_player` | `PLEX_PLAYER` | `plexPlayer` | Prefer `player` for new installs |
@@ -340,6 +343,8 @@ for the selected backend:
 | Jellyfin | `media_player.jellyfin_*` or `media_player.jellyfin` |
 | Emby | `media_player.emby_*` or `media_player.emby` |
 | Kodi | `media_player.kodi_*` or `media_player.kodi` |
+| Apple TV | `media_player.apple_tv`, `media_player.apple_tv*`, or entity IDs containing `_apple_tv` / `appletv` |
+| Kaleidescape | `media_player.kaleidescape`, `media_player.kaleidescape_*`, or entity IDs containing `kaleidescape` |
 
 If `player` is set, that exact entity is used regardless of backend prefix.
 For Plex, `plex_username` still filters auto-detected sessions to your user.
@@ -430,7 +435,8 @@ paused, or always visible while media is active.
 
 Looking for a dashboard card showing recently added media? Check out
 [recently-added-media-card](https://github.com/rusty4444/recently-added-media-card),
-a unified Lovelace card that supports Plex, Kodi, Jellyfin, and Emby.
+a unified Lovelace card that supports Plex, Kodi, Jellyfin, Emby, and related
+Home Assistant media sources.
 
 Want to show upcoming movies and TV episodes alongside your recently added
 media? Check out

--- a/addons/plex-now-showing/CHANGELOG.md
+++ b/addons/plex-now-showing/CHANGELOG.md
@@ -93,6 +93,12 @@ The project follows [Semantic Versioning](https://semver.org/).
 - Setup Automation tab links to the tablet-switching Blueprint import/download
   flow and generates add-on/Docker config for the built-in Fully Kiosk
   switcher.
+- Apple TV backend support (closes #77). `backend: apple_tv` auto-detects
+  active Apple TV media players, carries HA `app_name` through to the kiosk,
+  and shows a compact app badge/icon when available.
+- Kaleidescape backend support (closes #78). `backend: kaleidescape`
+  auto-detects active Kaleidescape `media_player` entities exposed by Home
+  Assistant and renders their now-playing artwork and metadata.
 
 ### Fixed
 - Dev add-on installs now use a matching pre-release image tag and the build

--- a/addons/plex-now-showing/DOCS.md
+++ b/addons/plex-now-showing/DOCS.md
@@ -21,7 +21,7 @@ probe of `/api`) and switches to `/api/state`. Plex-only metadata calls use
 
 | Option | Default | Purpose |
 |--------|---------|---------|
-| `backend` | `plex` | Media backend to watch: `plex`, `jellyfin`, `emby`, or `kodi`. |
+| `backend` | `plex` | Media backend to watch: `plex`, `jellyfin`, `emby`, `kodi`, `apple_tv`, or `kaleidescape`. |
 | `player` | _empty_ | Optional exact `media_player` entity id. Leave empty to auto-detect active players for `backend`. |
 | `plex_url` | _empty_ | e.g. `https://plex.example.com:32400`. Needed for the info panel. |
 | `plex_token` | _empty_ | Plex `X-Plex-Token`. Required together with `plex_url`. |

--- a/addons/plex-now-showing/config.yaml
+++ b/addons/plex-now-showing/config.yaml
@@ -11,7 +11,7 @@
 name: Plex Now Showing
 version: "2.0.0"
 slug: plex_now_showing
-description: Cinema-style now-playing kiosk for Plex, Jellyfin, Emby, and Kodi.
+description: Cinema-style now-playing kiosk for Plex, Jellyfin, Emby, Kodi, Apple TV, and Kaleidescape.
 url: https://github.com/rusty4444/plex-now-showing
 arch:
   - amd64
@@ -88,7 +88,7 @@ options:
   visual_accent_color: ""
   log_level: info
 schema:
-  backend: "list(plex|jellyfin|emby|kodi)"
+  backend: "list(plex|jellyfin|emby|kodi|apple_tv|kaleidescape)"
   player: "str?"
   plex_url: "str?"
   plex_token: "password?"

--- a/addons/plex-now-showing/translations/en.yaml
+++ b/addons/plex-now-showing/translations/en.yaml
@@ -5,13 +5,14 @@ configuration:
   backend:
     name: Backend
     description: >-
-      Media backend to watch in Home Assistant: Plex, Jellyfin, Emby, or Kodi.
+      Media backend to watch in Home Assistant: Plex, Jellyfin, Emby, Kodi,
+      Apple TV, or Kaleidescape.
   player:
     name: Player entity
     description: >-
-      Optional media_player entity id to pin, e.g. media_player.kodi or
-      media_player.jellyfin_living_room. Leave empty to auto-detect active
-      players for the selected backend.
+      Optional media_player entity id to pin, e.g. media_player.kodi,
+      media_player.living_room_apple_tv, or media_player.kaleidescape_theater.
+      Leave empty to auto-detect active players for the selected backend.
   plex_url:
     name: Plex URL
     description: >-

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -12,7 +12,7 @@ HA_URL=http://homeassistant.local:8123
 HA_TOKEN=
 
 # ---- Backend selection ----------------------------------------------------
-# One of: plex, jellyfin, emby, kodi.
+# One of: plex, jellyfin, emby, kodi, apple_tv, kaleidescape.
 BACKEND=plex
 # Optional exact media_player entity id. Leave empty to auto-detect active
 # players for the selected backend.

--- a/server/README.md
+++ b/server/README.md
@@ -48,7 +48,7 @@ For HA Container users running via Docker Compose. Set:
 | `PORT` | `8099` | Listen port |
 | `SUPERVISOR_TOKEN` | – | Set by Supervisor; switches to add-on mode |
 | `HA_URL` / `HA_TOKEN` | – | Standalone mode |
-| `BACKEND` | `plex` | Media backend to watch: `plex`, `jellyfin`, `emby`, or `kodi` |
+| `BACKEND` | `plex` | Media backend to watch: `plex`, `jellyfin`, `emby`, `kodi`, `apple_tv`, or `kaleidescape` |
 | `PLAYER` | – | Optional exact `media_player` entity id. Leave empty to auto-detect active players for `BACKEND` |
 | `PLEX_URL` / `PLEX_TOKEN` | – | Required together if you want `/api/media-info/:ratingKey` |
 | `PLEX_USERNAME` | – | Filters which `media_player.plex_*` entities count as "yours" |

--- a/server/package.json
+++ b/server/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "start": "node src/server.js",
     "dev": "node --watch src/server.js",
-    "test": "node --test test/"
+    "test": "node --test \"test/*.js\""
   },
   "dependencies": {
     "express": "^4.19.2"

--- a/server/src/backends.js
+++ b/server/src/backends.js
@@ -1,4 +1,11 @@
-export const BACKENDS = Object.freeze(['plex', 'jellyfin', 'emby', 'kodi']);
+export const BACKENDS = Object.freeze([
+  'plex',
+  'jellyfin',
+  'emby',
+  'kodi',
+  'apple_tv',
+  'kaleidescape',
+]);
 
 export const BACKEND_RULES = Object.freeze({
   plex: Object.freeze({
@@ -27,6 +34,22 @@ export const BACKEND_RULES = Object.freeze({
     label: 'Kodi',
     entityPrefix: 'media_player.kodi_',
     exactEntities: Object.freeze(['media_player.kodi']),
+    defaultPlayer: '',
+  }),
+  apple_tv: Object.freeze({
+    id: 'apple_tv',
+    label: 'Apple TV',
+    entityPrefix: 'media_player.apple_tv',
+    exactEntities: Object.freeze(['media_player.apple_tv']),
+    entityIncludes: Object.freeze(['_apple_tv', 'appletv']),
+    defaultPlayer: '',
+  }),
+  kaleidescape: Object.freeze({
+    id: 'kaleidescape',
+    label: 'Kaleidescape',
+    entityPrefix: 'media_player.kaleidescape_',
+    exactEntities: Object.freeze(['media_player.kaleidescape']),
+    entityIncludes: Object.freeze(['kaleidescape']),
     defaultPlayer: '',
   }),
 });

--- a/server/src/state.js
+++ b/server/src/state.js
@@ -51,7 +51,8 @@ export function normalise(states, {
 function isBackendPlayer(state, rule) {
   if (!state || typeof state.entity_id !== 'string') return false;
   return state.entity_id.startsWith(rule.entityPrefix)
-    || rule.exactEntities.includes(state.entity_id);
+    || rule.exactEntities.includes(state.entity_id)
+    || (rule.entityIncludes || []).some(token => state.entity_id.includes(token));
 }
 
 function shape(playerState) {
@@ -84,5 +85,7 @@ function shape(playerState) {
     positionUpdatedAt,
     summary: attrs.media_summary || '',
     ratingKey: attrs.media_content_id || '',
+    appName: attrs.app_name || '',
+    appId: attrs.app_id || '',
   };
 }

--- a/server/test/config.test.js
+++ b/server/test/config.test.js
@@ -25,11 +25,11 @@ test('standalone mode strips trailing slash on HA_URL', () => {
   assert.equal(config.haUrl, 'https://ha.example.com:8123');
 });
 
-test('backend defaults to plex and accepts Jellyfin, Emby, and Kodi', () => {
+test('backend defaults to plex and accepts supported HA media backends', () => {
   const def = loadConfig({ SUPERVISOR_TOKEN: 'x' });
   assert.equal(def.config.backend, 'plex');
 
-  for (const backend of ['plex', 'jellyfin', 'emby', 'kodi']) {
+  for (const backend of ['plex', 'jellyfin', 'emby', 'kodi', 'apple_tv', 'kaleidescape']) {
     const { config } = loadConfig({ SUPERVISOR_TOKEN: 'x', BACKEND: backend });
     assert.equal(config.backend, backend);
   }

--- a/server/test/state.test.js
+++ b/server/test/state.test.js
@@ -78,7 +78,7 @@ test('generic player pins work for non-Plex backends', () => {
   assert.ok(r.artwork.startsWith('/api/artwork?path='));
 });
 
-test('Jellyfin, Emby, and Kodi scan their matching media_player entities', () => {
+test('Jellyfin, Emby, Kodi, Apple TV, and Kaleidescape scan matching media players', () => {
   const providerStates = [
     {
       entity_id: 'media_player.jellyfin_living_room',
@@ -95,11 +95,30 @@ test('Jellyfin, Emby, and Kodi scan their matching media_player entities', () =>
       state: 'playing',
       attributes: { media_title: 'Kodi Clip', friendly_name: 'Kodi' },
     },
+    {
+      entity_id: 'media_player.living_room_apple_tv',
+      state: 'playing',
+      attributes: {
+        media_title: 'Silo',
+        friendly_name: 'Living Room Apple TV',
+        app_name: 'Apple TV',
+        entity_picture: '/api/media_player_proxy/media_player.living_room_apple_tv',
+      },
+    },
+    {
+      entity_id: 'media_player.kaleidescape_theater',
+      state: 'paused',
+      attributes: { media_title: 'Blade Runner 2049', friendly_name: 'Kaleidescape Theater' },
+    },
   ];
 
   assert.equal(normalise(providerStates, { backend: 'jellyfin' }).title, 'Jellyfin Movie');
   assert.equal(normalise(providerStates, { backend: 'emby' }).title, 'Emby Show');
   assert.equal(normalise(providerStates, { backend: 'kodi' }).title, 'Kodi Clip');
+  const appleTv = normalise(providerStates, { backend: 'apple_tv' });
+  assert.equal(appleTv.title, 'Silo');
+  assert.equal(appleTv.appName, 'Apple TV');
+  assert.equal(normalise(providerStates, { backend: 'kaleidescape' }).title, 'Blade Runner 2049');
 });
 
 test('backend falls back to plex on unknown values', () => {

--- a/www/now_showing.config.example.js
+++ b/www/now_showing.config.example.js
@@ -17,7 +17,7 @@ window.NOW_SHOWING_CONFIG = {
   // haToken: 'PASTE_LONG_LIVED_TOKEN_HERE',        // better: store in localStorage via #setup
 
   // Backend selection
-  backend: 'plex',    // plex | jellyfin | emby | kodi
+  backend: 'plex',    // plex | jellyfin | emby | kodi | apple_tv | kaleidescape
   player:  '',        // optional: lock to a specific media_player entity id
 
   // Plex filtering

--- a/www/now_showing.html
+++ b/www/now_showing.html
@@ -690,6 +690,30 @@
       text-shadow: 0 1px 4px rgba(0,0,0,0.8);
     }
 
+    .media-info .app-badge {
+      display: none;
+      align-items: center;
+      justify-content: flex-end;
+      gap: 6px;
+      margin-top: 7px;
+      font-family: 'Inter', sans-serif;
+      font-size: clamp(0.62rem, 1.2vw, 0.78rem);
+      color: rgba(255,255,255,0.78);
+      text-shadow: 0 1px 4px rgba(0,0,0,0.8);
+    }
+
+    .media-info .app-badge.visible {
+      display: flex;
+    }
+
+    .media-info .app-badge img {
+      width: 20px;
+      height: 20px;
+      object-fit: contain;
+      border-radius: 4px;
+      background: rgba(0,0,0,0.22);
+    }
+
     /* ===== IDLE STATE ===== */
     .idle-wrap {
       position: absolute;
@@ -1276,6 +1300,8 @@
             <option value="jellyfin">Jellyfin</option>
             <option value="emby">Emby</option>
             <option value="kodi">Kodi</option>
+            <option value="apple_tv">Apple TV</option>
+            <option value="kaleidescape">Kaleidescape</option>
           </select>
         </div>
 
@@ -1530,6 +1556,10 @@
       <div class="media-info" id="mediaInfo">
         <div class="media-type" id="mediaType"></div>
         <div class="player-name" id="playerName"></div>
+        <div class="app-badge" id="appBadge">
+          <img id="appIcon" alt="" loading="lazy">
+          <span id="appName"></span>
+        </div>
       </div>
 
       <!-- PLAYBACK PROGRESS BAR (#17) — opt-in via VISUAL_PROGRESS_BAR env -->
@@ -1643,12 +1673,22 @@
       return Number.isFinite(n) ? n : defaultValue;
     }
 
-    const BACKENDS = ['plex', 'jellyfin', 'emby', 'kodi'];
+    const BACKENDS = ['plex', 'jellyfin', 'emby', 'kodi', 'apple_tv', 'kaleidescape'];
     const BACKEND_RULES = {
       plex: { entityPrefix: 'media_player.plex_', exactEntities: [] },
       jellyfin: { entityPrefix: 'media_player.jellyfin_', exactEntities: ['media_player.jellyfin'] },
       emby: { entityPrefix: 'media_player.emby_', exactEntities: ['media_player.emby'] },
       kodi: { entityPrefix: 'media_player.kodi_', exactEntities: ['media_player.kodi'] },
+      apple_tv: {
+        entityPrefix: 'media_player.apple_tv',
+        exactEntities: ['media_player.apple_tv'],
+        entityIncludes: ['_apple_tv', 'appletv']
+      },
+      kaleidescape: {
+        entityPrefix: 'media_player.kaleidescape_',
+        exactEntities: ['media_player.kaleidescape'],
+        entityIncludes: ['kaleidescape']
+      },
     };
     function readBackend(value) {
       const v = String(value || '').trim().toLowerCase();
@@ -2114,9 +2154,15 @@
       }
       const player = document.getElementById('cfgPlayer');
       if (player) {
-        player.placeholder = backend === 'plex'
-          ? 'media_player.plex_plex_for_lg_tv'
-          : `media_player.${backend}`;
+        const examples = {
+          plex: 'media_player.plex_plex_for_lg_tv',
+          jellyfin: 'media_player.jellyfin_living_room',
+          emby: 'media_player.emby_living_room',
+          kodi: 'media_player.kodi_theater',
+          apple_tv: 'media_player.living_room_apple_tv',
+          kaleidescape: 'media_player.kaleidescape_theater'
+        };
+        player.placeholder = examples[backend] || `media_player.${backend}`;
       }
     }
 
@@ -2430,6 +2476,9 @@
     const mediaInfo = document.getElementById('mediaInfo');
     const mediaType = document.getElementById('mediaType');
     const playerName = document.getElementById('playerName');
+    const appBadge = document.getElementById('appBadge');
+    const appIcon = document.getElementById('appIcon');
+    const appName = document.getElementById('appName');
     const ambientGlow = document.getElementById('ambientGlow');
     const backdropAmbient = document.getElementById('backdropAmbient');
     const backdropImage = document.getElementById('backdropImage');
@@ -2758,7 +2807,9 @@
       }
 
       // Player
-      infoPlayer.textContent = `Playing on ${d.playerName}`;
+      infoPlayer.textContent = d.appName
+        ? `Playing on ${d.playerName} via ${d.appName}`
+        : `Playing on ${d.playerName}`;
 
       infoOverlay.classList.add('visible');
 
@@ -2984,11 +3035,44 @@
     function isBackendPlayer(state, rule) {
       if (!state || typeof state.entity_id !== 'string') return false;
       return state.entity_id.startsWith(rule.entityPrefix)
-        || rule.exactEntities.includes(state.entity_id);
+        || rule.exactEntities.includes(state.entity_id)
+        || (rule.entityIncludes || []).some(token => state.entity_id.includes(token));
+    }
+
+    const APP_ICON_SLUGS = {
+      'Disney+': 'disney-plus',
+      'Prime Video': 'amazon-prime',
+      'Amazon Prime Video': 'amazon-prime',
+      'Apple TV': 'apple-tv-plus',
+      'Apple TV+': 'apple-tv-plus',
+      'HBO Max': 'hbo',
+      'Max': 'hbo',
+      'YouTube': 'youtube',
+      'Netflix': 'netflix',
+      'Hulu': 'hulu',
+      'Plex': 'plex',
+      'Spotify': 'spotify',
+      'Twitch': 'twitch',
+      'Infuse': 'infuse',
+      'Paramount+': 'paramount-plus',
+      'Peacock': 'peacock'
+    };
+
+    function appIconUrlFor(app) {
+      if (!app) return '';
+      const slug = APP_ICON_SLUGS[app]
+        || String(app).trim().toLowerCase()
+          .replace(/&/g, 'and')
+          .replace(/\+/g, '-plus')
+          .replace(/[^a-z0-9]+/g, '-')
+          .replace(/^-+|-+$/g, '');
+      if (!slug) return '';
+      return `https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/${slug}.png`;
     }
 
     function buildMediaData(playerState) {
       const attrs = playerState.attributes || {};
+      const app = attrs.app_name || '';
       return {
         title: attrs.media_title || 'Unknown Title',
         seriesTitle: attrs.media_series_title || '',
@@ -3003,7 +3087,10 @@
         position: Number.isFinite(attrs.media_position) ? attrs.media_position : 0,
         positionUpdatedAt: attrs.media_position_updated_at || '',
         summary: attrs.media_summary || '',
-        ratingKey: attrs.media_content_id || ''
+        ratingKey: attrs.media_content_id || '',
+        appName: app,
+        appId: attrs.app_id || '',
+        appIconUrl: appIconUrlFor(app)
       };
     }
 
@@ -3190,6 +3277,30 @@
       else if (typeof mql.addListener === 'function') mql.addListener(handler); // Safari
     } catch (_) { /* matchMedia unsupported — skip */ }
 
+    function renderAppBadge(data) {
+      if (!appBadge || !appIcon || !appName) return;
+      const label = data && data.appName ? String(data.appName).trim() : '';
+      if (!label) {
+        appBadge.classList.remove('visible');
+        appName.textContent = '';
+        appIcon.removeAttribute('src');
+        return;
+      }
+      appName.textContent = label;
+      const icon = data.appIconUrl || appIconUrlFor(label);
+      if (icon) {
+        appIcon.style.display = '';
+        appIcon.src = icon;
+      } else {
+        appIcon.style.display = 'none';
+        appIcon.removeAttribute('src');
+      }
+      appIcon.onerror = () => {
+        appIcon.style.display = 'none';
+      };
+      appBadge.classList.add('visible');
+    }
+
     // ===== UPDATE DISPLAY =====
     function showMedia(data) {
       const artworkUrl = data.artwork.startsWith('http')
@@ -3211,6 +3322,7 @@
         // the progress bar's paused class, then bail out of the full re-render.
         syncInfoPanelForMode(data);
         setProgressFromState(data);
+        renderAppBadge(data);
         // #21 fullscreen backdrop reacts to pause/play transitions only (the
         // ambient layer doesn't change on state). The media key hasn't
         // changed, so backdropCtx.artUrl is still valid — (re)schedule on
@@ -3271,6 +3383,7 @@
 
       mediaType.textContent = typeLabel;
       playerName.textContent = data.playerName;
+      renderAppBadge(data);
       mediaInfo.classList.add('visible');
 
       // Hide idle
@@ -3325,6 +3438,7 @@
       posterOverlay.style.display = 'none';
       posterTitle.style.display = 'none';
       mediaInfo.classList.remove('visible');
+      renderAppBadge(null);
       idleContent.classList.add('visible');
       ambientGlow.classList.remove('active');
       hideProgressBar();


### PR DESCRIPTION
Adds apple_tv and kaleidescape backend selections, carries Home Assistant app metadata for Apple TV app badges, and updates docs/tests. Closes #77. Closes #78. Validation: npm.cmd test from server/ (120/120 passing).