### PR TITLE
[feat] add Coming Soon display mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@
 > multi-backend playback, and no-code display controls.
 
 A full-screen cinema marquee display for Home Assistant that shows what is
-currently playing on Plex, Jellyfin, Emby, Kodi, Apple TV, or Kaleidescape.
+currently playing on Plex, Jellyfin, Emby, Kodi, Apple TV, generic streaming
+devices, or Kaleidescape.
 It is designed for wall-mounted tablets running Fully Kiosk Browser, but it
 also works in any modern browser.
 
@@ -58,7 +59,8 @@ not exposed to the tablet browser.
 | Home Assistant add-on | `addons/plex-now-showing` wraps the server as a Supervisor add-on with Ingress, a config form, logs, multi-arch GHCR images, and optional direct port `8099`. |
 | Docker Compose | `docker/docker-compose.example.yml` and `.env.example` run the same image for HA Container users. |
 | Unified server | `server/` serves the kiosk and exposes `/api/state`, `/api/config`, `/api/media-info/:ratingKey`, `/api/artwork`, `/api/night-mode`, and `/healthz`. |
-| Multi-backend support | `backend` selects `plex`, `jellyfin`, `emby`, `kodi`, `apple_tv`, or `kaleidescape`; `player` can pin any exact `media_player` entity. Plex-specific `plex_player` is still accepted for compatibility. |
+| Multi-backend support | `backend` selects `plex`, `jellyfin`, `emby`, `kodi`, `apple_tv`, `streaming`, or `kaleidescape`; `player` can pin any exact `media_player` entity. Plex-specific `plex_player` is still accepted for compatibility. |
+| Coming Soon mode | `display_mode: coming_soon` turns the kiosk into a Radarr/Sonarr upcoming-release screensaver with a `COMING SOON` marquee. |
 | Fully Kiosk switching | Use either the bundled HA Blueprint or the add-on/server's built-in Fully Kiosk REST switcher. |
 | Visual toggles | Progress bar, ratings badges, genre chips, info-panel display modes, pause backdrops, burn-in mitigation, night dimming, frame styles, marquee font picker, theme presets, and accent color overrides. |
 | CI / release plumbing | Multi-arch add-on builds, config linting, Docker image publishing, server tests, add-on docs, and examples. |
@@ -67,10 +69,12 @@ not exposed to the tablet browser.
 
 - Cinema marquee display with animated bulb frame, title overlays, idle state,
   and portrait or landscape layouts.
-- Playback support for Plex, Jellyfin, Emby, Kodi, Apple TV, and
-  Kaleidescape Home Assistant `media_player` entities.
-- Apple TV app-name badges with app icons when Home Assistant exposes
-  `app_name`.
+- Playback support for Plex, Jellyfin, Emby, Kodi, Apple TV, generic
+  streaming devices, and Kaleidescape Home Assistant `media_player` entities.
+- Streaming app-name badges with app icons when Home Assistant exposes
+  `app_name`, including Disney+, YouTube, Netflix, Plex, and similar apps.
+- Coming Soon mode for Radarr/Sonarr upcoming movies and episodes, with
+  rotating poster or fanart art for Fully Kiosk screensavers and automations.
 - Optional exact player pinning via `player`.
 - Plex username filtering so shared Plex servers can show only your sessions.
 - Tap-for-info panel with synopsis, player, rating, duration, progress, and
@@ -97,8 +101,10 @@ not exposed to the tablet browser.
 ## Requirements
 
 - Home Assistant with at least one supported media integration configured:
-  Plex, Jellyfin, Emby, Kodi, Apple TV, or Kaleidescape.
+  Plex, Jellyfin, Emby, Kodi, Apple TV, a streaming device exposing
+  `app_name`, or Kaleidescape.
 - One or more active `media_player` entities from that integration.
+- Radarr or Sonarr URL + API key if you want `display_mode: coming_soon`.
 - Fully Kiosk Browser if you want automatic wall-tablet switching.
 - Plex URL + Plex token only if you want Plex-only enhanced metadata such as
   codec/HDR details, ratings, genre chips, or Plex backdrop art.
@@ -129,7 +135,7 @@ because Home Assistant Supervisor supplies the API token automatically.
 
 4. Install **Plex Now Showing**.
 5. Configure the add-on:
-   - `backend`: `plex`, `jellyfin`, `emby`, `kodi`, `apple_tv`, or
+   - `backend`: `plex`, `jellyfin`, `emby`, `kodi`, `apple_tv`, `streaming`, or
      `kaleidescape`
    - `player`: optional exact entity ID, for example `media_player.kodi`
    - `plex_url` and `plex_token`: optional, Plex enhanced metadata only
@@ -223,8 +229,8 @@ tablet browser must hold the HA token.
    ```
 
 3. If no token is configured, the page opens `#setup`. Fill:
-   - **Connection**: Home Assistant URL, HA token, backend, optional player,
-     optional Plex URL/token, and landscape mode
+   - **Connection**: display mode, Home Assistant URL/token, backend, optional
+     player, optional Plex URL/token, Coming Soon sources, and landscape mode
    - **Display**: theme preset, accent color, frame style, marquee font,
      progress bar, ratings badges, genre chips, info-panel mode, backdrops,
      burn-in mitigation, pixel nudge, and night dimming
@@ -251,8 +257,14 @@ Then edit `now_showing.config.js` before copying it to Home Assistant:
 window.NOW_SHOWING_CONFIG = {
   haUrl: 'http://homeassistant.local:8123',
   haToken: 'YOUR_LONG_LIVED_ACCESS_TOKEN',
-  backend: 'plex', // plex | jellyfin | emby | kodi | apple_tv | kaleidescape
+  displayMode: 'now_showing',
+  backend: 'plex', // plex | jellyfin | emby | kodi | apple_tv | streaming | kaleidescape
   player: '',
+  comingSoonTitle: 'Coming Soon',
+  comingSoonMoviesCount: 5,
+  comingSoonShowsCount: 5,
+  comingSoonCycleInterval: 8,
+  comingSoonImageType: 'poster',
   plexUsername: '',
   plexUrl: '',
   plexToken: '',
@@ -294,7 +306,8 @@ Equivalent URL hash example:
 
 | Purpose | Add-on option | Docker env | Frontend key | Values |
 |---------|---------------|------------|--------------|--------|
-| Media backend | `backend` | `BACKEND` | `backend` | `plex`, `jellyfin`, `emby`, `kodi`, `apple_tv`, `kaleidescape` |
+| Display mode | `display_mode` | `DISPLAY_MODE` | `displayMode` | `now_showing`, `coming_soon` |
+| Media backend | `backend` | `BACKEND` | `backend` | `plex`, `jellyfin`, `emby`, `kodi`, `apple_tv`, `streaming`, `kaleidescape` |
 | Exact player pin | `player` | `PLAYER` | `player` | Any `media_player.*` entity ID |
 | Plex username filter | `plex_username` | `PLEX_USERNAME` | `plexUsername` | Optional Plex username; blank shows the first active Plex player |
 | Legacy Plex player pin | `plex_player` | `PLEX_PLAYER` | `plexPlayer` | Prefer `player` for new installs |
@@ -306,6 +319,25 @@ Equivalent URL hash example:
 | Media-info cache | `media_info_ttl_ms` | `MEDIA_INFO_TTL_MS` | Server only | Default `600000` |
 | API shared secret | `proxy_secret` | `PROXY_SECRET` | Server only | Optional `X-Proxy-Secret` hardening |
 | Origin allowlist | `allowed_origins` | `ALLOWED_ORIGINS` | Server only | Comma-separated origins |
+
+## Coming Soon Configuration
+
+Set `display_mode` / `DISPLAY_MODE` / `displayMode` to `coming_soon` to make
+the kiosk rotate upcoming Radarr/Sonarr items instead of live playback. This is
+useful as a Fully Kiosk screensaver URL or as a target for HA automations.
+
+| Purpose | Add-on option | Docker env | Frontend key | Values |
+|---------|---------------|------------|--------------|--------|
+| Marquee text | `coming_soon_title` | `COMING_SOON_TITLE` | `comingSoonTitle` | Default `Coming Soon` |
+| Radarr URL | `radarr_url` | `RADARR_URL` | `radarrUrl` | Optional source |
+| Radarr API key | `radarr_api_key` | `RADARR_API_KEY` | `radarrApiKey` | Required with Radarr URL |
+| Sonarr URL | `sonarr_url` | `SONARR_URL` | `sonarrUrl` | Optional source |
+| Sonarr API key | `sonarr_api_key` | `SONARR_API_KEY` | `sonarrApiKey` | Required with Sonarr URL |
+| Movie count | `coming_soon_movies_count` | `COMING_SOON_MOVIES_COUNT` | `comingSoonMoviesCount` | `0` to `50` |
+| Show count | `coming_soon_shows_count` | `COMING_SOON_SHOWS_COUNT` | `comingSoonShowsCount` | `0` to `50` |
+| Cycle interval | `coming_soon_cycle_interval` | `COMING_SOON_CYCLE_INTERVAL` | `comingSoonCycleInterval` | Seconds, `2` to `300` |
+| Days offset | `coming_soon_days_offset` | `COMING_SOON_DAYS_OFFSET` | `comingSoonDaysOffset` | Include recent past releases |
+| Image type | `coming_soon_image_type` | `COMING_SOON_IMAGE_TYPE` | `comingSoonImageType` | `poster`, `fanart` |
 
 ## Visual Configuration
 
@@ -344,6 +376,7 @@ for the selected backend:
 | Emby | `media_player.emby_*` or `media_player.emby` |
 | Kodi | `media_player.kodi_*` or `media_player.kodi` |
 | Apple TV | `media_player.apple_tv`, `media_player.apple_tv*`, or entity IDs containing `_apple_tv` / `appletv` |
+| Streaming Device | Any active `media_player.*` entity with an `app_name` attribute, useful for Roku, Google TV, Android TV, Apple TV, and similar providers |
 | Kaleidescape | `media_player.kaleidescape`, `media_player.kaleidescape_*`, or entity IDs containing `kaleidescape` |
 
 If `player` is set, that exact entity is used regardless of backend prefix.

--- a/addons/plex-now-showing/CHANGELOG.md
+++ b/addons/plex-now-showing/CHANGELOG.md
@@ -96,9 +96,17 @@ The project follows [Semantic Versioning](https://semver.org/).
 - Apple TV backend support (closes #77). `backend: apple_tv` auto-detects
   active Apple TV media players, carries HA `app_name` through to the kiosk,
   and shows a compact app badge/icon when available.
+- Generic streaming backend support (refs #77). `backend: streaming`
+  auto-detects any active `media_player.*` entity with an `app_name`
+  attribute, so the same app-name, title, artwork, and dashboard-icons badge
+  path works for Roku, Google TV, Android TV, YouTube, Disney+, Netflix, Plex,
+  and similar providers.
 - Kaleidescape backend support (closes #78). `backend: kaleidescape`
   auto-detects active Kaleidescape `media_player` entities exposed by Home
   Assistant and renders their now-playing artwork and metadata.
+- Coming Soon display mode (closes #33). `display_mode: coming_soon` turns
+  the kiosk into a Radarr/Sonarr upcoming-release carousel with a Coming Soon
+  marquee, poster/fanart selection, counts, cycle interval, and days offset.
 
 ### Fixed
 - Dev add-on installs now use a matching pre-release image tag and the build

--- a/addons/plex-now-showing/DOCS.md
+++ b/addons/plex-now-showing/DOCS.md
@@ -21,7 +21,8 @@ probe of `/api`) and switches to `/api/state`. Plex-only metadata calls use
 
 | Option | Default | Purpose |
 |--------|---------|---------|
-| `backend` | `plex` | Media backend to watch: `plex`, `jellyfin`, `emby`, `kodi`, `apple_tv`, or `kaleidescape`. |
+| `display_mode` | `now_showing` | `now_showing` for live playback, `coming_soon` for a Radarr/Sonarr upcoming-release screensaver. |
+| `backend` | `plex` | Media backend to watch: `plex`, `jellyfin`, `emby`, `kodi`, `apple_tv`, `streaming`, or `kaleidescape`. Use `streaming` for Roku, Google TV, Android TV, Apple TV, or any `media_player` exposing `app_name`. |
 | `player` | _empty_ | Optional exact `media_player` entity id. Leave empty to auto-detect active players for `backend`. |
 | `plex_url` | _empty_ | e.g. `https://plex.example.com:32400`. Needed for the info panel. |
 | `plex_token` | _empty_ | Plex `X-Plex-Token`. Required together with `plex_url`. |
@@ -32,6 +33,17 @@ probe of `/api`) and switches to `/api/state`. Plex-only metadata calls use
 | `poll_interval` | `5000` | Kiosk poll interval (ms). |
 | `state_ttl_ms` | `3000` | Server-side cache for `/api/state`. Smooths multi-tablet polls. |
 | `media_info_ttl_ms` | `600000` | Server-side cache for `/api/media-info/:ratingKey`. |
+| `coming_soon_ttl_ms` | `900000` | Server-side cache for `/api/coming-soon`. |
+| `coming_soon_title` | `Coming Soon` | Marquee text in Coming Soon mode. |
+| `radarr_url` | _empty_ | Optional Radarr URL for upcoming movies. |
+| `radarr_api_key` | _empty_ | Required with `radarr_url`. |
+| `sonarr_url` | _empty_ | Optional Sonarr URL for upcoming episodes. |
+| `sonarr_api_key` | _empty_ | Required with `sonarr_url`. |
+| `coming_soon_movies_count` | `5` | Number of Radarr movies to include. |
+| `coming_soon_shows_count` | `5` | Number of Sonarr series to include. |
+| `coming_soon_cycle_interval` | `8` | Seconds each upcoming title stays on screen. |
+| `coming_soon_days_offset` | `0` | Include releases from this many days in the past. |
+| `coming_soon_image_type` | `poster` | `poster` or `fanart`. |
 | `proxy_secret` | _empty_ | If set, requests to `/api/*` must carry `X-Proxy-Secret`. |
 | `allowed_origins` | `[]` | Comma-joined allowlist for the `Origin` header on `/api/*`. Leave empty for Ingress-only. |
 | `switcher_enabled` | `false` | Turn on the built-in Fully Kiosk auto-switcher. Use **this or the Blueprint (#47)** — not both. |

--- a/addons/plex-now-showing/config.yaml
+++ b/addons/plex-now-showing/config.yaml
@@ -11,7 +11,7 @@
 name: Plex Now Showing
 version: "2.0.0"
 slug: plex_now_showing
-description: Cinema-style now-playing kiosk for Plex, Jellyfin, Emby, Kodi, Apple TV, and Kaleidescape.
+description: Cinema-style now-playing kiosk for Plex, Jellyfin, Emby, Kodi, Apple TV, streaming devices, and Kaleidescape.
 url: https://github.com/rusty4444/plex-now-showing
 arch:
   - amd64
@@ -40,6 +40,7 @@ ports_description:
 map:
   - ssl
 options:
+  display_mode: now_showing
   backend: plex
   player: ""
   plex_url: ""
@@ -51,6 +52,17 @@ options:
   poll_interval: 5000
   state_ttl_ms: 3000
   media_info_ttl_ms: 600000
+  coming_soon_ttl_ms: 900000
+  coming_soon_title: Coming Soon
+  radarr_url: ""
+  radarr_api_key: ""
+  sonarr_url: ""
+  sonarr_api_key: ""
+  coming_soon_movies_count: 5
+  coming_soon_shows_count: 5
+  coming_soon_cycle_interval: 8
+  coming_soon_days_offset: 0
+  coming_soon_image_type: poster
   proxy_secret: ""
   allowed_origins: []
   # Fully Kiosk auto-switcher (#48) — disabled by default. Enable this OR the
@@ -88,7 +100,8 @@ options:
   visual_accent_color: ""
   log_level: info
 schema:
-  backend: "list(plex|jellyfin|emby|kodi|apple_tv|kaleidescape)"
+  display_mode: "list(now_showing|coming_soon)"
+  backend: "list(plex|jellyfin|emby|kodi|apple_tv|streaming|kaleidescape)"
   player: "str?"
   plex_url: "str?"
   plex_token: "password?"
@@ -99,6 +112,17 @@ schema:
   poll_interval: "int(1000,60000)"
   state_ttl_ms: "int(500,30000)"
   media_info_ttl_ms: "int(10000,3600000)"
+  coming_soon_ttl_ms: "int(10000,3600000)"
+  coming_soon_title: "str?"
+  radarr_url: "str?"
+  radarr_api_key: "password?"
+  sonarr_url: "str?"
+  sonarr_api_key: "password?"
+  coming_soon_movies_count: "int(0,50)"
+  coming_soon_shows_count: "int(0,50)"
+  coming_soon_cycle_interval: "int(2,300)"
+  coming_soon_days_offset: "int(0,365)"
+  coming_soon_image_type: "list(poster|fanart)"
   proxy_secret: "password?"
   allowed_origins:
     - "url?"

--- a/addons/plex-now-showing/rootfs/etc/services.d/plex-now-showing/run
+++ b/addons/plex-now-showing/rootfs/etc/services.d/plex-now-showing/run
@@ -28,6 +28,7 @@ export_opt() {
 
 # ---- User options → env ----
 export_opt BACKEND           backend
+export_opt DISPLAY_MODE      display_mode
 export_opt PLAYER            player
 export_opt PLEX_URL          plex_url
 export_opt PLEX_TOKEN        plex_token
@@ -38,7 +39,18 @@ export_opt THEME             theme
 export_opt POLL              poll_interval
 export_opt STATE_TTL_MS      state_ttl_ms
 export_opt MEDIA_INFO_TTL_MS media_info_ttl_ms
+export_opt COMING_SOON_TTL_MS coming_soon_ttl_ms
 export_opt PROXY_SECRET      proxy_secret
+export_opt COMING_SOON_TITLE coming_soon_title
+export_opt RADARR_URL        radarr_url
+export_opt RADARR_API_KEY    radarr_api_key
+export_opt SONARR_URL        sonarr_url
+export_opt SONARR_API_KEY    sonarr_api_key
+export_opt COMING_SOON_MOVIES_COUNT coming_soon_movies_count
+export_opt COMING_SOON_SHOWS_COUNT  coming_soon_shows_count
+export_opt COMING_SOON_CYCLE_INTERVAL coming_soon_cycle_interval
+export_opt COMING_SOON_DAYS_OFFSET coming_soon_days_offset
+export_opt COMING_SOON_IMAGE_TYPE  coming_soon_image_type
 
 # allowed_origins is a list → join with commas for the server's parser.
 if bashio::config.has_value 'allowed_origins'; then
@@ -82,6 +94,7 @@ export_opt VISUAL_ACCENT_COLOR        visual_accent_color
 
 # ---- Diagnostics (no secrets) ----
 bashio::log.info "Backend:                  ${BACKEND:-plex}"
+bashio::log.info "Display mode:             ${DISPLAY_MODE:-now_showing}"
 bashio::log.info "Player entity:            ${PLAYER:-<auto>}"
 bashio::log.info "Plex URL configured:      $([[ -n "${PLEX_URL}"   ]] && echo yes || echo no)"
 bashio::log.info "Plex token configured:    $([[ -n "${PLEX_TOKEN}" ]] && echo yes || echo no)"
@@ -92,6 +105,10 @@ bashio::log.info "Theme:                    ${THEME}"
 bashio::log.info "Poll interval (ms):       ${POLL}"
 bashio::log.info "State cache TTL (ms):     ${STATE_TTL_MS}"
 bashio::log.info "Media-info cache TTL (ms):${MEDIA_INFO_TTL_MS}"
+bashio::log.info "Coming Soon cache TTL:    ${COMING_SOON_TTL_MS:-900000}"
+bashio::log.info "Coming Soon title:        ${COMING_SOON_TITLE:-Coming Soon}"
+bashio::log.info "Radarr configured:        $([[ -n "${RADARR_URL}" && -n "${RADARR_API_KEY}" ]] && echo yes || echo no)"
+bashio::log.info "Sonarr configured:        $([[ -n "${SONARR_URL}" && -n "${SONARR_API_KEY}" ]] && echo yes || echo no)"
 bashio::log.info "Proxy secret:             $([[ -n "${PROXY_SECRET}" ]] && echo set || echo unset)"
 bashio::log.info "Allowed origins:          ${ALLOWED_ORIGINS:-<any (ingress-only)>}"
 bashio::log.info "Visual progress bar:      ${VISUAL_PROGRESS_BAR:-false}"

--- a/addons/plex-now-showing/translations/en.yaml
+++ b/addons/plex-now-showing/translations/en.yaml
@@ -2,17 +2,23 @@
 # Translations for the Options tab in the HA add-on UI.
 # Keys match fields in config.yaml's `options:` / `schema:` blocks.
 configuration:
+  display_mode:
+    name: Display mode
+    description: >-
+      Choose "now_showing" for live media playback or "coming_soon" for a
+      Radarr/Sonarr upcoming-release screensaver.
   backend:
     name: Backend
     description: >-
       Media backend to watch in Home Assistant: Plex, Jellyfin, Emby, Kodi,
-      Apple TV, or Kaleidescape.
+      Apple TV, generic streaming device, or Kaleidescape.
   player:
     name: Player entity
     description: >-
       Optional media_player entity id to pin, e.g. media_player.kodi,
-      media_player.living_room_apple_tv, or media_player.kaleidescape_theater.
-      Leave empty to auto-detect active players for the selected backend.
+      media_player.living_room_apple_tv, media_player.living_room_roku, or
+      media_player.kaleidescape_theater. Leave empty to auto-detect active
+      players for the selected backend.
   plex_url:
     name: Plex URL
     description: >-
@@ -49,6 +55,39 @@ configuration:
   media_info_ttl_ms:
     name: Media-info cache TTL (ms)
     description: Server-side cache window for /api/media-info/:ratingKey.
+  coming_soon_ttl_ms:
+    name: Coming Soon cache TTL (ms)
+    description: Server-side cache window for /api/coming-soon.
+  coming_soon_title:
+    name: Coming Soon title
+    description: Marquee text shown when Display mode is coming_soon.
+  radarr_url:
+    name: Radarr URL
+    description: Base URL of your Radarr server, e.g. http://radarr.local:7878.
+  radarr_api_key:
+    name: Radarr API key
+    description: Radarr API key from Settings > General.
+  sonarr_url:
+    name: Sonarr URL
+    description: Base URL of your Sonarr server, e.g. http://sonarr.local:8989.
+  sonarr_api_key:
+    name: Sonarr API key
+    description: Sonarr API key from Settings > General.
+  coming_soon_movies_count:
+    name: Coming Soon movies
+    description: Number of upcoming Radarr movies to include.
+  coming_soon_shows_count:
+    name: Coming Soon shows
+    description: Number of upcoming Sonarr series to include.
+  coming_soon_cycle_interval:
+    name: Coming Soon cycle interval (s)
+    description: Seconds each upcoming title stays on screen before cycling.
+  coming_soon_days_offset:
+    name: Coming Soon days offset
+    description: Include releases from this many days in the past.
+  coming_soon_image_type:
+    name: Coming Soon image type
+    description: Use portrait poster art or landscape fanart/backdrop art.
   proxy_secret:
     name: Proxy secret (optional)
     description: >-

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -12,7 +12,10 @@ HA_URL=http://homeassistant.local:8123
 HA_TOKEN=
 
 # ---- Backend selection ----------------------------------------------------
-# One of: plex, jellyfin, emby, kodi, apple_tv, kaleidescape.
+DISPLAY_MODE=now_showing
+# One of: plex, jellyfin, emby, kodi, apple_tv, streaming, kaleidescape.
+# Use streaming for Roku, Google TV, Android TV, or any media_player exposing
+# app_name / media_title / entity_picture attributes.
 BACKEND=plex
 # Optional exact media_player entity id. Leave empty to auto-detect active
 # players for the selected backend.
@@ -34,6 +37,21 @@ THEME=classic-gold
 POLL=5000
 STATE_TTL_MS=3000
 MEDIA_INFO_TTL_MS=600000
+
+# ---- Coming Soon mode -----------------------------------------------------
+# Set DISPLAY_MODE=coming_soon to use the kiosk as a Radarr/Sonarr upcoming
+# release screensaver. At least one source (Radarr or Sonarr) is required.
+COMING_SOON_TITLE=Coming Soon
+RADARR_URL=
+RADARR_API_KEY=
+SONARR_URL=
+SONARR_API_KEY=
+COMING_SOON_MOVIES_COUNT=5
+COMING_SOON_SHOWS_COUNT=5
+COMING_SOON_CYCLE_INTERVAL=8
+COMING_SOON_DAYS_OFFSET=0
+COMING_SOON_IMAGE_TYPE=poster
+COMING_SOON_TTL_MS=900000
 
 # ---- Visual toggles (V2 visual sprint) ------------------------------------
 # Each visual feature is opt-in. Defaults preserve the v1 look.

--- a/server/README.md
+++ b/server/README.md
@@ -18,6 +18,7 @@ Standalone (HACS-only) installs continue to work against the unmodified
 | GET    | `/now_showing.html`               | The kiosk UI (served from `STATIC_DIR`, default `../www`) |
 | GET    | `/api`                            | Version + mode + backend + endpoint listing              |
 | GET    | `/api/state`                      | Normalised now-playing payload (3 s TTL cache)          |
+| GET    | `/api/coming-soon`                | Radarr/Sonarr upcoming items for Coming Soon mode       |
 | GET    | `/api/config`                     | Browser-safe runtime flags (visual toggles)              |
 | GET    | `/api/night-mode`                 | `{configured, on}` for the optional night-mode HA entity |
 | GET    | `/api/media-info/:ratingKey`      | Plex metadata for the info panel (10 min TTL cache)      |
@@ -48,7 +49,8 @@ For HA Container users running via Docker Compose. Set:
 | `PORT` | `8099` | Listen port |
 | `SUPERVISOR_TOKEN` | – | Set by Supervisor; switches to add-on mode |
 | `HA_URL` / `HA_TOKEN` | – | Standalone mode |
-| `BACKEND` | `plex` | Media backend to watch: `plex`, `jellyfin`, `emby`, `kodi`, `apple_tv`, or `kaleidescape` |
+| `DISPLAY_MODE` | `now_showing` | `now_showing` or `coming_soon` |
+| `BACKEND` | `plex` | Media backend to watch: `plex`, `jellyfin`, `emby`, `kodi`, `apple_tv`, `streaming`, or `kaleidescape` |
 | `PLAYER` | – | Optional exact `media_player` entity id. Leave empty to auto-detect active players for `BACKEND` |
 | `PLEX_URL` / `PLEX_TOKEN` | – | Required together if you want `/api/media-info/:ratingKey` |
 | `PLEX_USERNAME` | – | Filters which `media_player.plex_*` entities count as "yours" |
@@ -58,6 +60,15 @@ For HA Container users running via Docker Compose. Set:
 | `POLL` | `5000` | Kiosk poll interval in ms |
 | `STATE_TTL_MS` | `3000` | Server-side `/api/state` cache |
 | `MEDIA_INFO_TTL_MS` | `600000` | Server-side media-info cache |
+| `COMING_SOON_TTL_MS` | `900000` | Server-side `/api/coming-soon` cache |
+| `COMING_SOON_TITLE` | `Coming Soon` | Marquee text in Coming Soon mode |
+| `RADARR_URL` / `RADARR_API_KEY` | – | Optional upcoming movie source for Coming Soon mode |
+| `SONARR_URL` / `SONARR_API_KEY` | – | Optional upcoming TV source for Coming Soon mode |
+| `COMING_SOON_MOVIES_COUNT` | `5` | Number of Radarr movies to include |
+| `COMING_SOON_SHOWS_COUNT` | `5` | Number of Sonarr series to include |
+| `COMING_SOON_CYCLE_INTERVAL` | `8` | Seconds per upcoming title |
+| `COMING_SOON_DAYS_OFFSET` | `0` | Include releases from this many days in the past |
+| `COMING_SOON_IMAGE_TYPE` | `poster` | `poster` or `fanart` |
 | `PROXY_SECRET` | – | If set, requests to `/api/*` must carry `X-Proxy-Secret` |
 | `ALLOWED_ORIGINS` | – | Comma-separated allowlist for `Origin` on `/api/*` |
 | `SWITCHER_ENABLED` | `false` | Turn on the built-in Fully Kiosk auto-switcher (#48) |

--- a/server/src/backends.js
+++ b/server/src/backends.js
@@ -4,6 +4,7 @@ export const BACKENDS = Object.freeze([
   'emby',
   'kodi',
   'apple_tv',
+  'streaming',
   'kaleidescape',
 ]);
 
@@ -42,6 +43,14 @@ export const BACKEND_RULES = Object.freeze({
     entityPrefix: 'media_player.apple_tv',
     exactEntities: Object.freeze(['media_player.apple_tv']),
     entityIncludes: Object.freeze(['_apple_tv', 'appletv']),
+    defaultPlayer: '',
+  }),
+  streaming: Object.freeze({
+    id: 'streaming',
+    label: 'Streaming Device',
+    entityPrefix: 'media_player.',
+    exactEntities: Object.freeze([]),
+    requiredAttributes: Object.freeze(['app_name']),
     defaultPlayer: '',
   }),
   kaleidescape: Object.freeze({

--- a/server/src/comingSoon.js
+++ b/server/src/comingSoon.js
@@ -1,0 +1,179 @@
+const DAY_MS = 86400000;
+
+export function hasComingSoonSource(config = {}) {
+  const c = config.comingSoon || {};
+  return !!((c.radarrUrl && c.radarrApiKey) || (c.sonarrUrl && c.sonarrApiKey));
+}
+
+export async function fetchComingSoonItems({
+  config,
+  fetchImpl = globalThis.fetch,
+  now = new Date(),
+} = {}) {
+  const c = config?.comingSoon || {};
+  const offsetDays = numberOr(c.daysOffset, 0);
+  const start = startOfDay(new Date(now.getTime() - offsetDays * DAY_MS));
+  const end = new Date(now.getTime() + 90 * DAY_MS);
+
+  const [movies, shows] = await Promise.all([
+    fetchRadarrItems({ config: c, fetchImpl, start, end, now }),
+    fetchSonarrItems({ config: c, fetchImpl, start, end, now }),
+  ]);
+
+  return interleave(
+    movies.slice(0, numberOr(c.moviesCount, 5)),
+    shows.slice(0, numberOr(c.showsCount, 5)),
+  );
+}
+
+async function fetchRadarrItems({ config, fetchImpl, start, end, now }) {
+  if (!config.radarrUrl || !config.radarrApiKey) return [];
+  const base = trimSlash(config.radarrUrl);
+  const url = `${base}/api/v3/calendar?start=${dateOnly(start)}&end=${dateOnly(end)}&unmonitored=false`;
+  const resp = await fetchImpl(url, { headers: { 'X-Api-Key': config.radarrApiKey } });
+  if (!resp.ok) {
+    const err = new Error(`Radarr calendar returned ${resp.status}`);
+    err.status = resp.status;
+    throw err;
+  }
+  const data = await resp.json();
+  return (Array.isArray(data) ? data : [])
+    .filter(item => !item.hasFile && item.digitalRelease && new Date(item.digitalRelease) >= start)
+    .sort((a, b) => new Date(a.digitalRelease) - new Date(b.digitalRelease))
+    .map(item => {
+      const id = item.id || item.movieId || '';
+      const genres = Array.isArray(item.genres) ? item.genres.filter(Boolean).join(' / ') : '';
+      return {
+        type: 'movie',
+        typeLabel: 'Movie',
+        title: item.title || 'Untitled Movie',
+        subtitle: [item.year, genres].filter(Boolean).join(' / '),
+        releaseDate: item.digitalRelease,
+        countdown: formatCountdown(item.digitalRelease, now),
+        releaseLabel: formatReleaseDate(item.digitalRelease),
+        overview: item.overview || '',
+        posterUrl: imageUrl(item.images, 'poster'),
+        fanartUrl: imageUrl(item.images, 'fanart'),
+        localPosterUrl: id ? `${base}/api/v3/MediaCover/${id}/poster.jpg?apikey=${encodeURIComponent(config.radarrApiKey)}` : '',
+        localFanartUrl: id ? `${base}/api/v3/MediaCover/${id}/fanart.jpg?apikey=${encodeURIComponent(config.radarrApiKey)}` : '',
+      };
+    });
+}
+
+async function fetchSonarrItems({ config, fetchImpl, start, end, now }) {
+  if (!config.sonarrUrl || !config.sonarrApiKey) return [];
+  const base = trimSlash(config.sonarrUrl);
+  const url = `${base}/api/v3/calendar?start=${dateOnly(start)}&end=${dateOnly(end)}&unmonitored=false&includeSeries=true`;
+  const resp = await fetchImpl(url, { headers: { 'X-Api-Key': config.sonarrApiKey } });
+  if (!resp.ok) {
+    const err = new Error(`Sonarr calendar returned ${resp.status}`);
+    err.status = resp.status;
+    throw err;
+  }
+  const data = await resp.json();
+  const seenSeries = new Set();
+  return (Array.isArray(data) ? data : [])
+    .filter(item => !item.hasFile && item.airDateUtc && new Date(item.airDateUtc) >= start)
+    .sort((a, b) => new Date(a.airDateUtc) - new Date(b.airDateUtc))
+    .filter(item => {
+      const id = item.seriesId || item.series?.id || item.series?.title || item.title;
+      if (seenSeries.has(id)) return false;
+      seenSeries.add(id);
+      return true;
+    })
+    .map(item => {
+      const series = item.series || {};
+      const id = series.id || item.seriesId || '';
+      const season = String(item.seasonNumber || 0).padStart(2, '0');
+      const episode = String(item.episodeNumber || 0).padStart(2, '0');
+      const episodeLabel = `S${season}E${episode}${item.title ? ` / ${item.title}` : ''}`;
+      const releaseDate = item.airDate || (item.airDateUtc ? item.airDateUtc.split('T')[0] : '');
+      return {
+        type: 'tv',
+        typeLabel: 'TV',
+        title: series.title || item.title || 'Untitled Series',
+        subtitle: episodeLabel,
+        releaseDate,
+        countdown: formatCountdown(releaseDate, now),
+        releaseLabel: formatReleaseDate(releaseDate),
+        overview: item.overview || '',
+        posterUrl: imageUrl(series.images, 'poster'),
+        fanartUrl: imageUrl(series.images, 'fanart'),
+        localPosterUrl: id ? `${base}/api/v3/MediaCover/${id}/poster.jpg?apikey=${encodeURIComponent(config.sonarrApiKey)}` : '',
+        localFanartUrl: id ? `${base}/api/v3/MediaCover/${id}/fanart.jpg?apikey=${encodeURIComponent(config.sonarrApiKey)}` : '',
+        seriesTitle: series.title || '',
+        seasonNumber: item.seasonNumber || null,
+        episodeNumber: item.episodeNumber || null,
+      };
+    });
+}
+
+function interleave(movies, shows) {
+  const items = [];
+  const max = Math.max(movies.length, shows.length);
+  for (let i = 0; i < max; i += 1) {
+    if (i < movies.length) items.push(movies[i]);
+    if (i < shows.length) items.push(shows[i]);
+  }
+  return items;
+}
+
+function imageUrl(images, coverType) {
+  if (!Array.isArray(images)) return '';
+  const image = images.find(i => i && i.coverType === coverType);
+  return image?.remoteUrl || '';
+}
+
+function trimSlash(value) {
+  return String(value || '').replace(/\/+$/, '');
+}
+
+function startOfDay(value) {
+  const d = new Date(value);
+  d.setHours(0, 0, 0, 0);
+  return d;
+}
+
+function dateOnly(value) {
+  return value.toISOString().split('T')[0];
+}
+
+function numberOr(value, fallback) {
+  const n = Number(value);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+export function formatReleaseDate(dateStr) {
+  const d = new Date(dateStr);
+  if (Number.isNaN(d.getTime())) return '';
+  const months = [
+    'January', 'February', 'March', 'April', 'May', 'June',
+    'July', 'August', 'September', 'October', 'November', 'December',
+  ];
+  const day = d.getUTCDate();
+  return `${ordinal(day)} of ${months[d.getUTCMonth()]} ${d.getUTCFullYear()}`;
+}
+
+export function formatCountdown(dateStr, now = new Date()) {
+  if (!dateStr) return '';
+  const target = startOfDay(new Date(`${String(dateStr).substring(0, 10)}T00:00:00`));
+  if (Number.isNaN(target.getTime())) return '';
+  const today = startOfDay(now);
+  const diff = Math.round((target - today) / DAY_MS);
+  if (diff < 0) return 'Available';
+  if (diff === 0) return 'Today';
+  if (diff === 1) return 'Tomorrow';
+  if (diff < 7) return `In ${diff} days`;
+  if (diff < 14) return 'In 1 week';
+  if (diff < 30) return `In ${Math.round(diff / 7)} weeks`;
+  if (diff < 60) return 'In 1 month';
+  if (diff < 365) return `In ${Math.round(diff / 30)} months`;
+  const years = Math.round(diff / 365);
+  return `In ${years} year${years === 1 ? '' : 's'}`;
+}
+
+function ordinal(n) {
+  const suffixes = ['th', 'st', 'nd', 'rd'];
+  const v = n % 100;
+  return `${n}${suffixes[(v - 20) % 10] || suffixes[v] || suffixes[0]}`;
+}

--- a/server/src/config.js
+++ b/server/src/config.js
@@ -23,10 +23,13 @@ export function loadConfig(env = process.env) {
     : (env.HA_URL || '').replace(/\/$/, '');
   const haToken = mode === 'addon' ? supervisorToken : (env.HA_TOKEN || '');
   const backend = normaliseBackend(env.BACKEND || env.MEDIA_SERVER || env.SERVER_TYPE, 'plex');
+  const displayMode = parseEnum(env.DISPLAY_MODE || env.DISPLAY_MODE_DEFAULT,
+    ['now_showing', 'coming_soon'], 'now_showing');
 
   const config = {
     mode,
     port: parseInt(env.PORT || '8099', 10),
+    displayMode,
     backend,
     haUrl,
     haToken,
@@ -45,6 +48,19 @@ export function loadConfig(env = process.env) {
     // TTLs (ms) — tuned below 1× poll interval so a second tablet doesn't re-hit HA
     stateTtl: parseInt(env.STATE_TTL_MS || '3000', 10),
     mediaInfoTtl: parseInt(env.MEDIA_INFO_TTL_MS || '600000', 10), // 10 min
+    comingSoonTtl: parseInt(env.COMING_SOON_TTL_MS || '900000', 10), // 15 min
+    comingSoon: {
+      title: env.COMING_SOON_TITLE || 'Coming Soon',
+      radarrUrl: (env.RADARR_URL || '').replace(/\/$/, ''),
+      radarrApiKey: env.RADARR_API_KEY || '',
+      sonarrUrl: (env.SONARR_URL || '').replace(/\/$/, ''),
+      sonarrApiKey: env.SONARR_API_KEY || '',
+      moviesCount: parseIntClamped(env.COMING_SOON_MOVIES_COUNT, 5, 0, 50),
+      showsCount: parseIntClamped(env.COMING_SOON_SHOWS_COUNT, 5, 0, 50),
+      cycleInterval: parseIntClamped(env.COMING_SOON_CYCLE_INTERVAL, 8, 2, 300),
+      daysOffset: parseIntClamped(env.COMING_SOON_DAYS_OFFSET, 0, 0, 365),
+      imageType: parseEnum(env.COMING_SOON_IMAGE_TYPE, ['poster', 'fanart'], 'poster'),
+    },
     // Fully Kiosk auto-switcher (#48). Disabled by default; users who prefer
     // the HA Blueprint (#47) can leave it off and vice versa.
     switcherEnabled: parseBool(env.SWITCHER_ENABLED, false),
@@ -181,6 +197,12 @@ function validate(c) {
   if (c.plexUrl && !c.plexToken) errors.push('plexToken is required when plexUrl is set');
   if (!Number.isFinite(c.port) || c.port < 1 || c.port > 65535) errors.push('port must be between 1 and 65535');
   if (!Number.isFinite(c.poll) || c.poll < 1000) errors.push('poll must be \u2265 1000 ms');
+  if (!Number.isFinite(c.comingSoonTtl) || c.comingSoonTtl < 10000) errors.push('comingSoonTtl must be \u2265 10000 ms');
+  if (c.displayMode === 'coming_soon') {
+    const hasSource = !!((c.comingSoon.radarrUrl && c.comingSoon.radarrApiKey)
+      || (c.comingSoon.sonarrUrl && c.comingSoon.sonarrApiKey));
+    if (!hasSource) errors.push('at least one Coming Soon source is required when DISPLAY_MODE=coming_soon');
+  }
   if (c.switcherEnabled && !c.fullyKiosksRaw) {
     errors.push('FULLY_KIOSKS is required when SWITCHER_ENABLED is true');
   }

--- a/server/src/routes/comingSoon.js
+++ b/server/src/routes/comingSoon.js
@@ -1,0 +1,40 @@
+// GET /api/coming-soon - upcoming Radarr/Sonarr titles for the kiosk
+// screensaver mode. API keys stay server-side in add-on / Docker installs.
+
+import { Router } from 'express';
+import { fetchComingSoonItems, hasComingSoonSource } from '../comingSoon.js';
+
+export function comingSoonRoute({ cache, config, fetchImpl = globalThis.fetch }) {
+  const r = Router();
+
+  r.get('/api/coming-soon', async (_req, res) => {
+    if (!hasComingSoonSource(config)) {
+      return res.status(503).json({ error: 'coming_soon_not_configured' });
+    }
+
+    try {
+      let payload = cache.get('coming-soon');
+      if (payload === undefined) {
+        const items = await fetchComingSoonItems({ config, fetchImpl });
+        payload = {
+          title: config.comingSoon?.title || 'Coming Soon',
+          imageType: config.comingSoon?.imageType || 'poster',
+          cycleInterval: config.comingSoon?.cycleInterval || 8,
+          items,
+          generatedAt: new Date().toISOString(),
+        };
+        cache.set('coming-soon', payload);
+      }
+      res.set('Cache-Control', 'no-store');
+      res.json(payload);
+    } catch (err) {
+      res.status(502).json({
+        error: 'coming_soon_unreachable',
+        status: err.status || 0,
+        message: err.message || String(err),
+      });
+    }
+  });
+
+  return r;
+}

--- a/server/src/routes/config.js
+++ b/server/src/routes/config.js
@@ -14,8 +14,19 @@ export function configRoute({ config }) {
     // browsers on the wall might live for days. Let them re-read on reload.
     res.set('Cache-Control', 'no-store');
     res.json({
+      displayMode: config.displayMode || 'now_showing',
       backend: config.backend || 'plex',
       player: config.player || '',
+      comingSoon: {
+        title: config.comingSoon?.title || 'Coming Soon',
+        enabled: !!((config.comingSoon?.radarrUrl && config.comingSoon?.radarrApiKey)
+          || (config.comingSoon?.sonarrUrl && config.comingSoon?.sonarrApiKey)),
+        moviesCount: config.comingSoon?.moviesCount ?? 5,
+        showsCount: config.comingSoon?.showsCount ?? 5,
+        cycleInterval: config.comingSoon?.cycleInterval ?? 8,
+        daysOffset: config.comingSoon?.daysOffset ?? 0,
+        imageType: config.comingSoon?.imageType || 'poster',
+      },
       visual: {
         progressBar: !!config.visual?.progressBar,
         ratingsBadges: !!config.visual?.ratingsBadges,

--- a/server/src/routes/root.js
+++ b/server/src/routes/root.js
@@ -11,9 +11,11 @@ export function rootRoute({ config, version }) {
       name: 'plex-now-showing-server',
       version,
       mode: config.mode,
+      displayMode: config.displayMode || 'now_showing',
       backend: config.backend || 'plex',
       endpoints: {
         state: '/api/state',
+        comingSoon: '/api/coming-soon',
         config: '/api/config',
         mediaInfo: '/api/media-info/:ratingKey',
         healthz: '/healthz',

--- a/server/src/server.js
+++ b/server/src/server.js
@@ -24,6 +24,7 @@ import { mediaInfoRoute } from './routes/mediaInfo.js';
 import { artworkRoute } from './routes/artwork.js';
 import { plexArtRoute } from './routes/plexArt.js';
 import { nightModeRoute } from './routes/nightMode.js';
+import { comingSoonRoute } from './routes/comingSoon.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const pkg = JSON.parse(readFileSync(join(__dirname, '..', 'package.json'), 'utf8'));
@@ -58,6 +59,7 @@ export function createApp({ config, haClient }) {
 
   const stateCache = createCache(config.stateTtl);
   const mediaInfoCache = createCache(config.mediaInfoTtl);
+  const comingSoonCache = createCache(config.comingSoonTtl);
 
   app.use(rootRoute({ config, version: pkg.version }));
   app.use(healthzRoute({ config, version: pkg.version }));
@@ -67,6 +69,7 @@ export function createApp({ config, haClient }) {
   app.use(artworkRoute({ config }));
   app.use(plexArtRoute({ config }));
   app.use(nightModeRoute({ haClient, config }));
+  app.use(comingSoonRoute({ cache: comingSoonCache, config }));
 
   // Static HTML last so /api/* wins on overlap.
   app.use(express.static(config.staticDir, {

--- a/server/src/state.js
+++ b/server/src/state.js
@@ -50,6 +50,9 @@ export function normalise(states, {
 
 function isBackendPlayer(state, rule) {
   if (!state || typeof state.entity_id !== 'string') return false;
+  if ((rule.requiredAttributes || []).some(name => !(state.attributes || {})[name])) {
+    return false;
+  }
   return state.entity_id.startsWith(rule.entityPrefix)
     || rule.exactEntities.includes(state.entity_id)
     || (rule.entityIncludes || []).some(token => state.entity_id.includes(token));

--- a/server/test/comingSoon.test.js
+++ b/server/test/comingSoon.test.js
@@ -1,0 +1,98 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { fetchComingSoonItems, formatCountdown, formatReleaseDate } from '../src/comingSoon.js';
+
+function response(body, ok = true, status = 200) {
+  return {
+    ok,
+    status,
+    json: async () => body,
+  };
+}
+
+test('fetchComingSoonItems interleaves Radarr movies and first Sonarr episode per series', async () => {
+  const calls = [];
+  const fetchImpl = async (url, options) => {
+    calls.push({ url, apiKey: options.headers['X-Api-Key'] });
+    if (url.includes('radarr')) {
+      return response([
+        {
+          id: 10,
+          title: 'Dune Messiah',
+          year: 2026,
+          digitalRelease: '2026-05-10T00:00:00Z',
+          hasFile: false,
+          genres: ['Sci-Fi'],
+          overview: 'The next chapter.',
+          images: [{ coverType: 'poster', remoteUrl: 'https://img/poster.jpg' }],
+        },
+        {
+          id: 11,
+          title: 'Already Here',
+          digitalRelease: '2026-05-09T00:00:00Z',
+          hasFile: true,
+        },
+      ]);
+    }
+    return response([
+      {
+        seriesId: 20,
+        seasonNumber: 1,
+        episodeNumber: 1,
+        title: 'Pilot',
+        airDate: '2026-05-11',
+        airDateUtc: '2026-05-11T10:00:00Z',
+        hasFile: false,
+        overview: 'The beginning.',
+        series: {
+          id: 20,
+          title: 'New Show',
+          images: [{ coverType: 'fanart', remoteUrl: 'https://img/fanart.jpg' }],
+        },
+      },
+      {
+        seriesId: 20,
+        seasonNumber: 1,
+        episodeNumber: 2,
+        airDateUtc: '2026-05-12T10:00:00Z',
+        hasFile: false,
+        series: { id: 20, title: 'New Show' },
+      },
+    ]);
+  };
+
+  const items = await fetchComingSoonItems({
+    config: {
+      comingSoon: {
+        radarrUrl: 'http://radarr.local:7878',
+        radarrApiKey: 'rk',
+        sonarrUrl: 'http://sonarr.local:8989',
+        sonarrApiKey: 'sk',
+        moviesCount: 5,
+        showsCount: 5,
+      },
+    },
+    fetchImpl,
+    now: new Date('2026-05-02T12:00:00Z'),
+  });
+
+  assert.equal(calls.length, 2);
+  assert.equal(calls[0].apiKey, 'rk');
+  assert.equal(calls[1].apiKey, 'sk');
+  assert.equal(items.length, 2);
+  assert.equal(items[0].title, 'Dune Messiah');
+  assert.equal(items[0].countdown, 'In 1 week');
+  assert.equal(items[0].localPosterUrl, 'http://radarr.local:7878/api/v3/MediaCover/10/poster.jpg?apikey=rk');
+  assert.equal(items[1].title, 'New Show');
+  assert.equal(items[1].subtitle, 'S01E01 / Pilot');
+  assert.equal(items[1].localFanartUrl, 'http://sonarr.local:8989/api/v3/MediaCover/20/fanart.jpg?apikey=sk');
+});
+
+test('format helpers match coming-soon-card style', () => {
+  const now = new Date('2026-05-02T12:00:00Z');
+  assert.equal(formatCountdown('2026-05-02', now), 'Today');
+  assert.equal(formatCountdown('2026-05-03', now), 'Tomorrow');
+  assert.equal(formatCountdown('2026-05-08', now), 'In 6 days');
+  assert.equal(formatReleaseDate('2026-05-10'), '10th of May 2026');
+});

--- a/server/test/config.test.js
+++ b/server/test/config.test.js
@@ -29,7 +29,7 @@ test('backend defaults to plex and accepts supported HA media backends', () => {
   const def = loadConfig({ SUPERVISOR_TOKEN: 'x' });
   assert.equal(def.config.backend, 'plex');
 
-  for (const backend of ['plex', 'jellyfin', 'emby', 'kodi', 'apple_tv', 'kaleidescape']) {
+  for (const backend of ['plex', 'jellyfin', 'emby', 'kodi', 'apple_tv', 'streaming', 'kaleidescape']) {
     const { config } = loadConfig({ SUPERVISOR_TOKEN: 'x', BACKEND: backend });
     assert.equal(config.backend, backend);
   }
@@ -71,6 +71,53 @@ test('TTL defaults match spec (3 s state, 10 min media-info)', () => {
   const { config } = loadConfig({ SUPERVISOR_TOKEN: 'x' });
   assert.equal(config.stateTtl, 3000);
   assert.equal(config.mediaInfoTtl, 600000);
+  assert.equal(config.comingSoonTtl, 900000);
+});
+
+test('display mode defaults to now_showing and accepts coming_soon', () => {
+  const def = loadConfig({ SUPERVISOR_TOKEN: 'x' });
+  assert.equal(def.config.displayMode, 'now_showing');
+
+  const comingSoon = loadConfig({
+    SUPERVISOR_TOKEN: 'x',
+    DISPLAY_MODE: 'coming_soon',
+    RADARR_URL: 'http://radarr.local:7878',
+    RADARR_API_KEY: 'rk',
+  });
+  assert.equal(comingSoon.config.displayMode, 'coming_soon');
+  assert.deepEqual(comingSoon.errors, []);
+
+  const invalid = loadConfig({ SUPERVISOR_TOKEN: 'x', DISPLAY_MODE: 'lobby' });
+  assert.equal(invalid.config.displayMode, 'now_showing');
+});
+
+test('coming soon config parses source settings and validates required source', () => {
+  const missing = loadConfig({ SUPERVISOR_TOKEN: 'x', DISPLAY_MODE: 'coming_soon' });
+  assert.ok(missing.errors.some(e => e.includes('Coming Soon source')));
+
+  const { config, errors } = loadConfig({
+    SUPERVISOR_TOKEN: 'x',
+    RADARR_URL: 'http://radarr.local:7878/',
+    RADARR_API_KEY: 'rk',
+    SONARR_URL: 'http://sonarr.local:8989/',
+    SONARR_API_KEY: 'sk',
+    COMING_SOON_TITLE: 'Next Releases',
+    COMING_SOON_MOVIES_COUNT: '9',
+    COMING_SOON_SHOWS_COUNT: '3',
+    COMING_SOON_CYCLE_INTERVAL: '12',
+    COMING_SOON_DAYS_OFFSET: '2',
+    COMING_SOON_IMAGE_TYPE: 'fanart',
+  });
+
+  assert.deepEqual(errors, []);
+  assert.equal(config.comingSoon.title, 'Next Releases');
+  assert.equal(config.comingSoon.radarrUrl, 'http://radarr.local:7878');
+  assert.equal(config.comingSoon.sonarrUrl, 'http://sonarr.local:8989');
+  assert.equal(config.comingSoon.moviesCount, 9);
+  assert.equal(config.comingSoon.showsCount, 3);
+  assert.equal(config.comingSoon.cycleInterval, 12);
+  assert.equal(config.comingSoon.daysOffset, 2);
+  assert.equal(config.comingSoon.imageType, 'fanart');
 });
 
 test('visual toggles all default to false', () => {

--- a/server/test/routes.test.js
+++ b/server/test/routes.test.js
@@ -31,6 +31,20 @@ function baseConfig(overrides = {}) {
     allowedOrigins: [],
     stateTtl: 3000,
     mediaInfoTtl: 600000,
+    comingSoonTtl: 900000,
+    displayMode: 'now_showing',
+    comingSoon: {
+      title: 'Coming Soon',
+      radarrUrl: '',
+      radarrApiKey: '',
+      sonarrUrl: '',
+      sonarrApiKey: '',
+      moviesCount: 5,
+      showsCount: 5,
+      cycleInterval: 8,
+      daysOffset: 0,
+      imageType: 'poster',
+    },
     visual: { progressBar: false, ratingsBadges: false, genreChips: false, infoPanelMode: 'on_tap' },
     staticDir: join(__dirname, '..', 'fixtures'),
     ...overrides,
@@ -107,8 +121,18 @@ test('GET /api/config defaults every visual toggle off', async () => {
     assert.equal(resp.headers.get('cache-control'), 'no-store');
     const body = await resp.json();
     assert.deepEqual(body, {
+      displayMode: 'now_showing',
       backend: 'plex',
       player: '',
+      comingSoon: {
+        title: 'Coming Soon',
+        enabled: false,
+        moviesCount: 5,
+        showsCount: 5,
+        cycleInterval: 8,
+        daysOffset: 0,
+        imageType: 'poster',
+      },
       visual: {
         progressBar: false,
         ratingsBadges: false,
@@ -137,7 +161,63 @@ test('GET /api exposes the configured backend', async () => {
   try {
     const body = await fetch(`${url}/api`).then(r => r.json());
     assert.equal(body.name, 'plex-now-showing-server');
+    assert.equal(body.displayMode, 'now_showing');
     assert.equal(body.backend, 'jellyfin');
+    assert.equal(body.endpoints.comingSoon, '/api/coming-soon');
+  } finally { server.close(); }
+});
+
+test('GET /api/coming-soon returns configured upcoming items', async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () => ({
+    ok: true,
+    status: 200,
+    json: async () => [{
+      id: 1,
+      title: 'The Future',
+      year: 2026,
+      digitalRelease: '2026-06-01T00:00:00Z',
+      hasFile: false,
+      images: [{ coverType: 'poster', remoteUrl: 'https://img/poster.jpg' }],
+    }],
+  });
+
+  const haClient = { getStates: async () => haStates };
+  const { server, url } = await startApp(baseConfig({
+    comingSoon: {
+      title: 'Coming Soon',
+      radarrUrl: 'http://radarr.local:7878',
+      radarrApiKey: 'rk',
+      sonarrUrl: '',
+      sonarrApiKey: '',
+      moviesCount: 5,
+      showsCount: 5,
+      cycleInterval: 8,
+      daysOffset: 0,
+      imageType: 'poster',
+    },
+  }), haClient);
+  try {
+    const resp = await originalFetch(`${url}/api/coming-soon`);
+    assert.equal(resp.status, 200);
+    const body = await resp.json();
+    assert.equal(body.title, 'Coming Soon');
+    assert.equal(body.items.length, 1);
+    assert.equal(body.items[0].title, 'The Future');
+  } finally {
+    server.close();
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('GET /api/coming-soon returns 503 when no source is configured', async () => {
+  const haClient = { getStates: async () => haStates };
+  const { server, url } = await startApp(baseConfig(), haClient);
+  try {
+    const resp = await fetch(`${url}/api/coming-soon`);
+    assert.equal(resp.status, 503);
+    const body = await resp.json();
+    assert.equal(body.error, 'coming_soon_not_configured');
   } finally { server.close(); }
 });
 

--- a/server/test/state.test.js
+++ b/server/test/state.test.js
@@ -121,6 +121,34 @@ test('Jellyfin, Emby, Kodi, Apple TV, and Kaleidescape scan matching media playe
   assert.equal(normalise(providerStates, { backend: 'kaleidescape' }).title, 'Blade Runner 2049');
 });
 
+test('streaming backend scans app_name media players for Roku and Google TV style entities', () => {
+  const providerStates = [
+    {
+      entity_id: 'media_player.living_room_roku',
+      state: 'playing',
+      attributes: {
+        media_title: 'Bluey',
+        friendly_name: 'Living Room Roku',
+        app_name: 'Disney+',
+        entity_picture: '/api/media_player_proxy/media_player.living_room_roku',
+      },
+    },
+    {
+      entity_id: 'media_player.bedroom_tv',
+      state: 'playing',
+      attributes: {
+        media_title: 'Plain HDMI',
+        friendly_name: 'Bedroom TV',
+      },
+    },
+  ];
+
+  const r = normalise(providerStates, { backend: 'streaming' });
+  assert.equal(r.title, 'Bluey');
+  assert.equal(r.appName, 'Disney+');
+  assert.equal(r.playerName, 'Living Room Roku');
+});
+
 test('backend falls back to plex on unknown values', () => {
   const r = normalise(states, { backend: 'laserdisc', plexUsername: 'rusty' });
   assert.ok(r, 'should still find an active Plex player');

--- a/www/now_showing.config.example.js
+++ b/www/now_showing.config.example.js
@@ -17,8 +17,21 @@ window.NOW_SHOWING_CONFIG = {
   // haToken: 'PASTE_LONG_LIVED_TOKEN_HERE',        // better: store in localStorage via #setup
 
   // Backend selection
-  backend: 'plex',    // plex | jellyfin | emby | kodi | apple_tv | kaleidescape
+  displayMode: 'now_showing', // now_showing | coming_soon
+  backend: 'plex',    // plex | jellyfin | emby | kodi | apple_tv | streaming | kaleidescape
   player:  '',        // optional: lock to a specific media_player entity id
+
+  // Coming Soon mode (Radarr/Sonarr). Used when displayMode is coming_soon.
+  comingSoonTitle: 'Coming Soon',
+  // radarrUrl: 'http://192.168.1.100:7878',
+  // radarrApiKey: 'RADARR_API_KEY',
+  // sonarrUrl: 'http://192.168.1.100:8989',
+  // sonarrApiKey: 'SONARR_API_KEY',
+  comingSoonMoviesCount: 5,
+  comingSoonShowsCount: 5,
+  comingSoonCycleInterval: 8,
+  comingSoonDaysOffset: 0,
+  comingSoonImageType: 'poster',
 
   // Plex filtering
   plexUsername: '',   // your Plex username - filters to only your playback

--- a/www/now_showing.html
+++ b/www/now_showing.html
@@ -1294,33 +1294,103 @@
         </div>
 
         <div class="setup-field">
-          <label for="cfgBackend">Backend</label>
-          <select id="cfgBackend" autocomplete="off">
-            <option value="plex">Plex</option>
-            <option value="jellyfin">Jellyfin</option>
-            <option value="emby">Emby</option>
-            <option value="kodi">Kodi</option>
-            <option value="apple_tv">Apple TV</option>
-            <option value="kaleidescape">Kaleidescape</option>
+          <label for="cfgDisplayMode">Display Mode</label>
+          <select id="cfgDisplayMode" autocomplete="off">
+            <option value="now_showing">Now Showing</option>
+            <option value="coming_soon">Coming Soon</option>
           </select>
+          <div class="hint">Now Showing watches active media players. Coming Soon uses Radarr/Sonarr.</div>
         </div>
 
-        <div class="setup-field">
-          <label for="cfgPlexUsername">Plex Username</label>
-          <input id="cfgPlexUsername" type="text" placeholder="your_plex_username" autocomplete="off">
-          <div class="hint">Filters playback to only your sessions.</div>
-        </div>
+        <div class="setup-section-title" id="cfgPlayersSectionTitle">Players</div>
 
-        <details class="setup-advanced">
-          <summary>Optional &mdash; player &amp; Plex API</summary>
-
-          <div class="setup-field" style="margin-top:10px;">
-            <label for="cfgPlayer">Specific Player (entity id)</label>
-            <input id="cfgPlayer" type="text" placeholder="media_player.plex_plex_for_lg_tv" autocomplete="off">
-            <div class="hint">Optional. Lock the display to one player.</div>
+        <div class="setup-field-grid" id="cfgPlayersSection">
+          <div class="setup-field">
+            <label for="cfgBackend">Backend</label>
+            <select id="cfgBackend" autocomplete="off">
+              <option value="plex">Plex</option>
+              <option value="jellyfin">Jellyfin</option>
+              <option value="emby">Emby</option>
+              <option value="kodi">Kodi</option>
+              <option value="apple_tv">Apple TV</option>
+              <option value="streaming">Streaming Device</option>
+              <option value="kaleidescape">Kaleidescape</option>
+            </select>
+            <div class="hint" id="cfgBackendHint">Select which Home Assistant media integration to watch.</div>
           </div>
 
           <div class="setup-field">
+            <label for="cfgPlayer">Player Entity</label>
+            <input id="cfgPlayer" type="text" list="cfgPlayerOptions" placeholder="media_player.plex_plex_for_lg_tv" autocomplete="off">
+            <datalist id="cfgPlayerOptions"></datalist>
+            <div class="hint" id="cfgPlayerHint">Optional. Leave blank to auto-detect an active player.</div>
+          </div>
+        </div>
+
+        <div class="setup-row" id="cfgLoadPlayersRow" style="margin-top:0;">
+          <button class="setup-btn" id="setupLoadPlayersBtn" type="button">Load Players</button>
+        </div>
+
+        <div class="setup-field" id="cfgPlexUsernameField">
+          <label for="cfgPlexUsername">Plex Username</label>
+          <input id="cfgPlexUsername" type="text" placeholder="your_plex_username" autocomplete="off">
+          <div class="hint">Filters Plex playback to only your sessions when no player is pinned.</div>
+        </div>
+
+        <details class="setup-advanced" id="cfgComingSoonDetails">
+          <summary>Coming Soon sources</summary>
+
+          <div class="setup-field-grid" style="margin-top:10px;">
+            <div class="setup-field">
+              <label for="cfgComingSoonTitle">Marquee Text</label>
+              <input id="cfgComingSoonTitle" type="text" placeholder="Coming Soon" autocomplete="off">
+            </div>
+            <div class="setup-field">
+              <label for="cfgComingSoonImageType">Image Type</label>
+              <select id="cfgComingSoonImageType" autocomplete="off">
+                <option value="poster">Poster</option>
+                <option value="fanart">Fanart</option>
+              </select>
+            </div>
+            <div class="setup-field">
+              <label for="cfgRadarrUrl">Radarr URL</label>
+              <input id="cfgRadarrUrl" type="url" placeholder="http://192.168.1.100:7878" autocomplete="off">
+            </div>
+            <div class="setup-field">
+              <label for="cfgRadarrApiKey">Radarr API Key</label>
+              <input id="cfgRadarrApiKey" type="password" autocomplete="off" spellcheck="false">
+            </div>
+            <div class="setup-field">
+              <label for="cfgSonarrUrl">Sonarr URL</label>
+              <input id="cfgSonarrUrl" type="url" placeholder="http://192.168.1.100:8989" autocomplete="off">
+            </div>
+            <div class="setup-field">
+              <label for="cfgSonarrApiKey">Sonarr API Key</label>
+              <input id="cfgSonarrApiKey" type="password" autocomplete="off" spellcheck="false">
+            </div>
+            <div class="setup-field">
+              <label for="cfgComingSoonMoviesCount">Movies</label>
+              <input id="cfgComingSoonMoviesCount" type="number" min="0" max="50" step="1" inputmode="numeric" autocomplete="off">
+            </div>
+            <div class="setup-field">
+              <label for="cfgComingSoonShowsCount">Shows</label>
+              <input id="cfgComingSoonShowsCount" type="number" min="0" max="50" step="1" inputmode="numeric" autocomplete="off">
+            </div>
+            <div class="setup-field">
+              <label for="cfgComingSoonCycleInterval">Cycle Interval (s)</label>
+              <input id="cfgComingSoonCycleInterval" type="number" min="2" max="300" step="1" inputmode="numeric" autocomplete="off">
+            </div>
+            <div class="setup-field">
+              <label for="cfgComingSoonDaysOffset">Days Offset</label>
+              <input id="cfgComingSoonDaysOffset" type="number" min="0" max="365" step="1" inputmode="numeric" autocomplete="off">
+            </div>
+          </div>
+        </details>
+
+        <details class="setup-advanced" id="cfgPlexMetadataDetails">
+          <summary>Plex metadata API</summary>
+
+          <div class="setup-field" style="margin-top:10px;">
             <label for="cfgPlexUrl">Plex Server URL</label>
             <input id="cfgPlexUrl" type="url" placeholder="http://192.168.1.10:32400" autocomplete="off">
             <div class="hint">Enables media-file details (resolution, codec, bitrate).</div>
@@ -1331,14 +1401,14 @@
             <input id="cfgPlexToken" type="password" placeholder="xxxxxxxxxxxxxxxxxxxx" autocomplete="off" spellcheck="false">
             <div class="hint">Required if Plex URL is set.</div>
           </div>
-
-          <div class="setup-field">
-            <label class="setup-check" for="cfgLandscape">
-              <input id="cfgLandscape" type="checkbox">
-              Landscape mode (fit whole poster)
-            </label>
-          </div>
         </details>
+
+        <div class="setup-field">
+          <label class="setup-check" for="cfgLandscape">
+            <input id="cfgLandscape" type="checkbox">
+            Landscape mode (fit whole poster)
+          </label>
+        </div>
       </div>
 
       <div class="setup-tab-panel" id="setupPanelDisplay" role="tabpanel" aria-labelledby="setupTabDisplay" data-setup-panel="display">
@@ -1673,7 +1743,7 @@
       return Number.isFinite(n) ? n : defaultValue;
     }
 
-    const BACKENDS = ['plex', 'jellyfin', 'emby', 'kodi', 'apple_tv', 'kaleidescape'];
+    const BACKENDS = ['plex', 'jellyfin', 'emby', 'kodi', 'apple_tv', 'streaming', 'kaleidescape'];
     const BACKEND_RULES = {
       plex: { entityPrefix: 'media_player.plex_', exactEntities: [] },
       jellyfin: { entityPrefix: 'media_player.jellyfin_', exactEntities: ['media_player.jellyfin'] },
@@ -1684,6 +1754,11 @@
         exactEntities: ['media_player.apple_tv'],
         entityIncludes: ['_apple_tv', 'appletv']
       },
+      streaming: {
+        entityPrefix: 'media_player.',
+        exactEntities: [],
+        requiredAttributes: ['app_name']
+      },
       kaleidescape: {
         entityPrefix: 'media_player.kaleidescape_',
         exactEntities: ['media_player.kaleidescape'],
@@ -1693,6 +1768,11 @@
     function readBackend(value) {
       const v = String(value || '').trim().toLowerCase();
       return BACKENDS.includes(v) ? v : 'plex';
+    }
+    const DISPLAY_MODES = ['now_showing', 'coming_soon'];
+    function readDisplayMode(value) {
+      const v = String(value || '').trim().toLowerCase().replace(/-/g, '_');
+      return DISPLAY_MODES.includes(v) ? v : 'now_showing';
     }
 
     const HA_URL        = readConfig('haUrl',        { aliases: ['ha_url'], defaultValue: window.location.origin });
@@ -1706,6 +1786,19 @@
     const LANDSCAPE_MODE = readBool('landscape', runtimeConfig.landscape === true);
     const POLL_INTERVAL  = readInt('poll', 5000);
     let ACTIVE_BACKEND = BACKEND;
+    let DISPLAY_MODE = readDisplayMode(readConfig('displayMode', { aliases: ['display_mode', 'mode'], defaultValue: 'now_showing' }));
+    const COMING_SOON = {
+      title: readConfig('comingSoonTitle', { aliases: ['coming_soon_title'], defaultValue: 'Coming Soon' }),
+      radarrUrl: readConfig('radarrUrl', { aliases: ['radarr_url'] }),
+      radarrApiKey: readConfig('radarrApiKey', { aliases: ['radarr_api_key'], sensitive: true }),
+      sonarrUrl: readConfig('sonarrUrl', { aliases: ['sonarr_url'] }),
+      sonarrApiKey: readConfig('sonarrApiKey', { aliases: ['sonarr_api_key'], sensitive: true }),
+      moviesCount: readIntClamped('comingSoonMoviesCount', 5, 0, 50),
+      showsCount: readIntClamped('comingSoonShowsCount', 5, 0, 50),
+      cycleInterval: readIntClamped('comingSoonCycleInterval', 8, 2, 300),
+      daysOffset: readIntClamped('comingSoonDaysOffset', 0, 0, 365),
+      imageType: readConfig('comingSoonImageType', { aliases: ['coming_soon_image_type'], defaultValue: 'poster' }) === 'fanart' ? 'fanart' : 'poster',
+    };
 
     // ===== SERVER MODE DETECTION =====
     //
@@ -1723,6 +1816,7 @@
         const body = await resp.json();
         SERVER_MODE = body && body.name === 'plex-now-showing-server';
         if (SERVER_MODE) ACTIVE_BACKEND = readBackend(body.backend || ACTIVE_BACKEND);
+        if (SERVER_MODE) DISPLAY_MODE = readDisplayMode(body.displayMode || DISPLAY_MODE);
         if (SERVER_MODE) console.info('[plex-now-showing] Running against unified server — using /api/state proxy.');
         return SERVER_MODE;
       } catch (_) {
@@ -1870,6 +1964,16 @@
         if (!resp.ok) return;
         const body = await resp.json();
         if (body && body.backend) ACTIVE_BACKEND = readBackend(body.backend);
+        if (body && body.displayMode) DISPLAY_MODE = readDisplayMode(body.displayMode);
+        if (body && body.comingSoon) {
+          const cs = body.comingSoon;
+          if (typeof cs.title === 'string') COMING_SOON.title = cs.title || 'Coming Soon';
+          if (Number.isFinite(cs.moviesCount)) COMING_SOON.moviesCount = cs.moviesCount;
+          if (Number.isFinite(cs.showsCount)) COMING_SOON.showsCount = cs.showsCount;
+          if (Number.isFinite(cs.cycleInterval)) COMING_SOON.cycleInterval = cs.cycleInterval;
+          if (Number.isFinite(cs.daysOffset)) COMING_SOON.daysOffset = cs.daysOffset;
+          if (cs.imageType === 'poster' || cs.imageType === 'fanart') COMING_SOON.imageType = cs.imageType;
+        }
         const v = body && body.visual;
         if (v && typeof v.progressBar === 'boolean') VISUAL.progressBar = v.progressBar;
         if (v && typeof v.ratingsBadges === 'boolean') VISUAL.ratingsBadges = v.ratingsBadges;
@@ -2074,11 +2178,22 @@
       // localStorage key (without pns. prefix), input element id, default
       ['haUrl', 'cfgHaUrl', ''],
       ['haToken', 'cfgHaToken', ''],
+      ['displayMode', 'cfgDisplayMode', DISPLAY_MODE],
       ['backend', 'cfgBackend', BACKEND],
       ['plexUsername', 'cfgPlexUsername', ''],
       ['player', 'cfgPlayer', ''],
       ['plexUrl', 'cfgPlexUrl', ''],
       ['plexToken', 'cfgPlexToken', ''],
+      ['comingSoonTitle', 'cfgComingSoonTitle', 'Coming Soon'],
+      ['radarrUrl', 'cfgRadarrUrl', ''],
+      ['radarrApiKey', 'cfgRadarrApiKey', ''],
+      ['sonarrUrl', 'cfgSonarrUrl', ''],
+      ['sonarrApiKey', 'cfgSonarrApiKey', ''],
+      ['comingSoonMoviesCount', 'cfgComingSoonMoviesCount', '5'],
+      ['comingSoonShowsCount', 'cfgComingSoonShowsCount', '5'],
+      ['comingSoonCycleInterval', 'cfgComingSoonCycleInterval', '8'],
+      ['comingSoonDaysOffset', 'cfgComingSoonDaysOffset', '0'],
+      ['comingSoonImageType', 'cfgComingSoonImageType', 'poster'],
       ['visualTheme', 'cfgVisualTheme', 'classic-gold'],
       ['visualFrameStyle', 'cfgVisualFrameStyle', 'bulbs'],
       ['visualMarqueeFont', 'cfgVisualMarqueeFont', 'bebas-neue'],
@@ -2111,10 +2226,32 @@
       visualNudgeAmplitudePx: { min: 1, max: 16, fallback: 4, float: false },
       visualNightModeOpacity: { min: 0, max: 0.95, fallback: 0.4, float: true },
       switcherIntervalMs: { min: 1000, max: 60000, fallback: 5000, float: false },
+      comingSoonMoviesCount: { min: 0, max: 50, fallback: 5, float: false },
+      comingSoonShowsCount: { min: 0, max: 50, fallback: 5, float: false },
+      comingSoonCycleInterval: { min: 2, max: 300, fallback: 8, float: false },
+      comingSoonDaysOffset: { min: 0, max: 365, fallback: 0, float: false },
     };
     const ACCENT_PICKER_DEFAULT = '#c8a032';
     const BLUEPRINT_URL = 'https://raw.githubusercontent.com/rusty4444/plex-now-showing/dev/blueprints/automation/rusty4444/plex_now_showing_display.yaml';
     const BLUEPRINT_IMPORT_URL = 'https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=' + encodeURIComponent(BLUEPRINT_URL);
+    const SETUP_BACKEND_HINTS = {
+      plex: 'Watches media_player.plex_* entities and can filter by Plex username.',
+      jellyfin: 'Watches media_player.jellyfin_* or media_player.jellyfin entities.',
+      emby: 'Watches media_player.emby_* or media_player.emby entities.',
+      kodi: 'Watches media_player.kodi_* or media_player.kodi entities.',
+      apple_tv: 'Watches Apple TV media_player entities and shows app_name icons.',
+      streaming: 'Watches any media_player.* entity with app_name, media_title, and artwork attributes.',
+      kaleidescape: 'Watches Kaleidescape media_player entities exposed by Home Assistant.',
+    };
+    const SETUP_PLAYER_HINTS = {
+      plex: 'Optional. Leave blank to auto-detect, or pin one Plex media_player entity.',
+      jellyfin: 'Optional. Leave blank to auto-detect, or pin one Jellyfin media_player entity.',
+      emby: 'Optional. Leave blank to auto-detect, or pin one Emby media_player entity.',
+      kodi: 'Optional. Leave blank to auto-detect, or pin one Kodi media_player entity.',
+      apple_tv: 'Optional. Pin your Apple TV entity if auto-detection sees more than one.',
+      streaming: 'Optional. Pin a Roku, Google TV, Android TV, Apple TV, or similar entity.',
+      kaleidescape: 'Optional. Pin your Kaleidescape player if you have multiple rooms.',
+    };
 
     function setupVisible(show) {
       const el = document.getElementById('setupOverlay');
@@ -2138,6 +2275,7 @@
           const stored = window.localStorage.getItem('pns.' + key);
           input.checked = stored == null ? !!defaultValue : /^(1|true|yes|on)$/i.test(stored);
         }
+        syncSetupDisplayModeFields();
         syncSetupBackendFields();
         syncSetupVisualFields();
         syncSetupAutomationFields();
@@ -2148,10 +2286,13 @@
 
     function syncSetupBackendFields() {
       const backend = readBackend(document.getElementById('cfgBackend')?.value || BACKEND);
-      for (const id of ['cfgPlexUsername', 'cfgPlexUrl', 'cfgPlexToken']) {
-        const field = document.getElementById(id)?.closest('.setup-field');
-        if (field) field.style.display = backend === 'plex' ? '' : 'none';
-      }
+      const isPlex = backend === 'plex';
+      const usernameField = document.getElementById('cfgPlexUsernameField');
+      const metadataDetails = document.getElementById('cfgPlexMetadataDetails');
+      if (usernameField) usernameField.style.display = isPlex ? '' : 'none';
+      if (metadataDetails) metadataDetails.style.display = isPlex ? '' : 'none';
+      const backendHint = document.getElementById('cfgBackendHint');
+      if (backendHint) backendHint.textContent = SETUP_BACKEND_HINTS[backend] || SETUP_BACKEND_HINTS.plex;
       const player = document.getElementById('cfgPlayer');
       if (player) {
         const examples = {
@@ -2160,10 +2301,83 @@
           emby: 'media_player.emby_living_room',
           kodi: 'media_player.kodi_theater',
           apple_tv: 'media_player.living_room_apple_tv',
+          streaming: 'media_player.living_room_roku',
           kaleidescape: 'media_player.kaleidescape_theater'
         };
         player.placeholder = examples[backend] || `media_player.${backend}`;
       }
+      const playerHint = document.getElementById('cfgPlayerHint');
+      if (playerHint) playerHint.textContent = SETUP_PLAYER_HINTS[backend] || SETUP_PLAYER_HINTS.plex;
+    }
+
+    function syncSetupDisplayModeFields() {
+      const mode = readDisplayMode(document.getElementById('cfgDisplayMode')?.value || DISPLAY_MODE);
+      const comingSoon = document.getElementById('cfgComingSoonDetails');
+      const isComingSoon = mode === 'coming_soon';
+      if (comingSoon) {
+        comingSoon.style.display = isComingSoon ? '' : 'none';
+        comingSoon.open = isComingSoon;
+      }
+      for (const id of [
+        'cfgPlayersSectionTitle',
+        'cfgPlayersSection',
+        'cfgLoadPlayersRow',
+        'cfgPlexUsernameField',
+        'cfgPlexMetadataDetails',
+      ]) {
+        const field = document.getElementById(id);
+        if (field) field.style.display = isComingSoon ? 'none' : '';
+      }
+      if (!isComingSoon) syncSetupBackendFields();
+    }
+
+    async function loadSetupPlayers() {
+      const haUrl = document.getElementById('cfgHaUrl')?.value.trim() || window.location.origin;
+      const haTok = document.getElementById('cfgHaToken')?.value.trim();
+      const backend = readBackend(document.getElementById('cfgBackend')?.value || BACKEND);
+      if (!haTok) {
+        setupStatus('Enter an HA token to load player entities, or type the entity id manually.', 'err');
+        return;
+      }
+      setupStatus('Loading media players...');
+      let states;
+      try {
+        const r = await fetch(haUrl.replace(/\/$/, '') + '/api/states', {
+          headers: { 'Authorization': 'Bearer ' + haTok, 'Content-Type': 'application/json' }
+        });
+        if (!r.ok) { setupStatus('HA returned ' + r.status + ' while loading players.', 'err'); return; }
+        states = await r.json();
+      } catch (e) {
+        setupStatus('Could not load players: ' + e.message, 'err');
+        return;
+      }
+      const rule = BACKEND_RULES[backend] || BACKEND_RULES.plex;
+      const players = Array.isArray(states)
+        ? states.filter(s => isBackendPlayer(s, rule))
+        : [];
+      const options = document.getElementById('cfgPlayerOptions');
+      if (options) {
+        options.innerHTML = '';
+        for (const state of players) {
+          const attrs = state.attributes || {};
+          const option = document.createElement('option');
+          option.value = state.entity_id;
+          option.label = [
+            attrs.friendly_name || state.entity_id,
+            state.state,
+            attrs.app_name,
+          ].filter(Boolean).join(' / ');
+          options.appendChild(option);
+        }
+      }
+      if (players.length === 1) {
+        const player = document.getElementById('cfgPlayer');
+        if (player && !player.value) player.value = players[0].entity_id;
+      }
+      setupStatus(players.length
+        ? `Loaded ${players.length} ${backend.replace('_', ' ')} player${players.length === 1 ? '' : 's'}.`
+        : `No ${backend.replace('_', ' ')} players found. You can still type the entity id manually.`,
+        players.length ? 'ok' : 'err');
     }
 
     function switchSetupTab(name) {
@@ -2309,11 +2523,37 @@
     }
 
     async function setupTest() {
+      const displayMode = readDisplayMode(document.getElementById('cfgDisplayMode')?.value || DISPLAY_MODE);
       const haUrl = document.getElementById('cfgHaUrl').value.trim() || window.location.origin;
       const haTok = document.getElementById('cfgHaToken').value.trim();
       const backend = readBackend(document.getElementById('cfgBackend').value);
       const plexUrl = document.getElementById('cfgPlexUrl').value.trim();
       const plexTok = document.getElementById('cfgPlexToken').value.trim();
+      const radarrUrl = document.getElementById('cfgRadarrUrl')?.value.trim() || '';
+      const radarrKey = document.getElementById('cfgRadarrApiKey')?.value.trim() || '';
+      const sonarrUrl = document.getElementById('cfgSonarrUrl')?.value.trim() || '';
+      const sonarrKey = document.getElementById('cfgSonarrApiKey')?.value.trim() || '';
+
+      if (displayMode === 'coming_soon') {
+        if (!((radarrUrl && radarrKey) || (sonarrUrl && sonarrKey))) {
+          setupStatus('Add Radarr or Sonarr details first.', 'err');
+          return;
+        }
+        setupStatus('Testing Coming Soon source...');
+        const sourceUrl = radarrUrl || sonarrUrl;
+        const sourceKey = radarrKey || sonarrKey;
+        try {
+          const r = await fetch(sourceUrl.replace(/\/$/, '') + '/api/v3/system/status', {
+            headers: { 'X-Api-Key': sourceKey }
+          });
+          if (!r.ok) { setupStatus('Source returned ' + r.status + '. Check URL and API key.', 'err'); return; }
+        } catch (e) {
+          setupStatus('Could not reach Coming Soon source: ' + e.message, 'err');
+          return;
+        }
+        setupStatus('Coming Soon source responded.', 'ok');
+        return;
+      }
 
       if (!haTok) { setupStatus('Enter an HA token first.', 'err'); return; }
       setupStatus('Testing Home Assistant\u2026');
@@ -2346,7 +2586,18 @@
 
     function setupSave() {
       const haTok = document.getElementById('cfgHaToken').value.trim();
-      if (!haTok) { setupStatus('HA token is required.', 'err'); return; }
+      const displayMode = readDisplayMode(document.getElementById('cfgDisplayMode')?.value || DISPLAY_MODE);
+      if (!haTok && displayMode !== 'coming_soon') { setupStatus('HA token is required.', 'err'); return; }
+      if (displayMode === 'coming_soon') {
+        const hasSource = (document.getElementById('cfgRadarrUrl')?.value.trim()
+          && document.getElementById('cfgRadarrApiKey')?.value.trim())
+          || (document.getElementById('cfgSonarrUrl')?.value.trim()
+          && document.getElementById('cfgSonarrApiKey')?.value.trim());
+        if (!hasSource) {
+          setupStatus('Coming Soon mode needs Radarr or Sonarr details.', 'err');
+          return;
+        }
+      }
       const accentInput = document.getElementById('cfgVisualAccentColor');
       const accentColor = (accentInput?.value || '').trim().toLowerCase();
       if (accentColor && !HEX_RE.test(accentColor)) {
@@ -2395,7 +2646,9 @@
       const save  = document.getElementById('setupSaveBtn');
       const clear = document.getElementById('setupClearBtn');
       const gear  = document.getElementById('setupGear');
+      const displayMode = document.getElementById('cfgDisplayMode');
       const backend = document.getElementById('cfgBackend');
+      const loadPlayers = document.getElementById('setupLoadPlayersBtn');
       const accent = document.getElementById('cfgVisualAccentColor');
       const accentPicker = document.getElementById('cfgVisualAccentColorPicker');
       const copyBlueprint = document.getElementById('setupCopyBlueprintBtn');
@@ -2404,7 +2657,9 @@
       if (test)  test.addEventListener('click', setupTest);
       if (save)  save.addEventListener('click', setupSave);
       if (clear) clear.addEventListener('click', setupClear);
+      if (displayMode) displayMode.addEventListener('change', syncSetupDisplayModeFields);
       if (backend) backend.addEventListener('change', syncSetupBackendFields);
+      if (loadPlayers) loadPlayers.addEventListener('click', loadSetupPlayers);
       for (const tab of document.querySelectorAll('[data-setup-tab]')) {
         tab.addEventListener('click', () => switchSetupTab(tab.dataset.setupTab));
       }
@@ -2438,14 +2693,17 @@
       // Show the gear icon on the live display whenever we have any saved
       // config — it's the escape hatch to reopen setup.
       const hasSavedConfig = (() => {
-        try { return !!window.localStorage.getItem('pns.haToken'); } catch (_) { return false; }
+        try {
+          return !!(window.localStorage.getItem('pns.haToken')
+            || window.localStorage.getItem('pns.displayMode'));
+        } catch (_) { return false; }
       })();
       if (gear && hasSavedConfig) gear.style.display = 'block';
 
       // First-run: if we have no HA token at all and no config script supplied
       // one, auto-open setup. Also honour explicit `#setup` in the hash.
       const forceSetup = /(^|&)setup(=|&|$)/.test(window.location.hash.replace(/^#/, ''));
-      if (forceSetup || !HA_TOKEN) {
+      if (forceSetup || (!HA_TOKEN && DISPLAY_MODE !== 'coming_soon')) {
         switchSetupTab('connection');
         populateSetupForm();
         setupVisible(true);
@@ -2458,7 +2716,7 @@
       initSetup();
     }
 
-    if (!HA_TOKEN) {
+    if (!HA_TOKEN && DISPLAY_MODE !== 'coming_soon') {
       console.warn('[plex-now-showing] No HA token configured — opening setup.');
     }
     if (HA_TOKEN && ACTIVE_BACKEND === 'plex' && !PLEX_USERNAME) {
@@ -2484,6 +2742,7 @@
     const backdropImage = document.getElementById('backdropImage');
     const bulbsOuterContainer = document.getElementById('bulbsOuter');
     const marquee = document.getElementById('marquee');
+    const marqueeHeading = marquee ? marquee.querySelector('h1') : null;
 
     // ===== STATE =====
     let currentMediaKey = '';
@@ -2727,7 +2986,9 @@
       infoTitle.textContent = d.seriesTitle || d.title;
 
       // Subtitle
-      if (d.seriesTitle) {
+      if (d.comingSoon && d.subtitle) {
+        infoSubtitle.textContent = d.subtitle;
+      } else if (d.seriesTitle) {
         let sub = d.title;
         if (d.season && d.episode) {
           sub = `S${String(d.season).padStart(2,'0')}E${String(d.episode).padStart(2,'0')} · ${d.title}`;
@@ -2739,13 +3000,15 @@
 
       // Meta tags
       let tags = [];
-      let typeLabel = 'Movie';
-      if (d.contentType === 'tvshow' || d.contentType === 'episode' || d.seriesTitle) {
+      let typeLabel = d.comingSoon ? (d.typeLabel || 'Coming Soon') : 'Movie';
+      if (!d.comingSoon && (d.contentType === 'tvshow' || d.contentType === 'episode' || d.seriesTitle)) {
         typeLabel = 'TV Series';
-      } else if (d.contentType === 'music') {
+      } else if (!d.comingSoon && d.contentType === 'music') {
         typeLabel = 'Music';
       }
       tags.push(typeLabel);
+      if (d.comingSoon && d.countdown) tags.push(d.countdown);
+      if (d.comingSoon && d.releaseLabel) tags.push(d.releaseLabel);
       if (d.contentRating) tags.push(d.contentRating);
       if (d.duration) {
         const mins = Math.round(d.duration / 60);
@@ -2775,7 +3038,7 @@
       // we fall through to the direct fetch which requires the URL + token.
       infoTech.innerHTML = '';
       renderRatingsBadges(null); // reset
-      if (d.ratingKey && hasPlexMetadataAccess()) {
+      if (!d.comingSoon && d.ratingKey && hasPlexMetadataAccess()) {
         const mi = await fetchPlexMediaInfo(d.ratingKey);
         if (mi) {
           renderRatingsBadges(mi.ratings);
@@ -2960,8 +3223,192 @@
       chaseOffset = (chaseOffset + 1) % 3;
     }
 
+    let comingSoonCache = { items: [], fetchedAt: 0 };
+
+    function syncDisplayModeText() {
+      if (!marqueeHeading) return;
+      marqueeHeading.textContent = DISPLAY_MODE === 'coming_soon'
+        ? (COMING_SOON.title || 'Coming Soon')
+        : 'NOW SHOWING';
+      document.body.classList.toggle('display-coming-soon', DISPLAY_MODE === 'coming_soon');
+    }
+
+    async function fetchComingSoonData() {
+      await serverModeReady;
+      let payload = null;
+      if (SERVER_MODE) {
+        const resp = await fetch('/api/coming-soon', { cache: 'no-store' });
+        if (!resp.ok) return null;
+        payload = await resp.json();
+        if (payload && payload.title) COMING_SOON.title = payload.title;
+        if (payload && payload.imageType) COMING_SOON.imageType = payload.imageType;
+        if (payload && Number.isFinite(payload.cycleInterval)) COMING_SOON.cycleInterval = payload.cycleInterval;
+        comingSoonCache = { items: Array.isArray(payload.items) ? payload.items : [], fetchedAt: Date.now() };
+      } else if (Date.now() - comingSoonCache.fetchedAt > 15 * 60 * 1000) {
+        comingSoonCache = { items: await fetchComingSoonDirect(), fetchedAt: Date.now() };
+      }
+
+      syncDisplayModeText();
+      const items = comingSoonCache.items;
+      if (!items.length) return null;
+      const intervalMs = Math.max(2, Number(COMING_SOON.cycleInterval) || 8) * 1000;
+      const index = Math.floor(Date.now() / intervalMs) % items.length;
+      return buildComingSoonMediaData(items[index]);
+    }
+
+    async function fetchComingSoonDirect() {
+      const start = new Date(Date.now() - (Number(COMING_SOON.daysOffset) || 0) * 86400000);
+      const end = new Date(Date.now() + 90 * 86400000);
+      const startDate = start.toISOString().split('T')[0];
+      const endDate = end.toISOString().split('T')[0];
+      const fetches = [];
+
+      if (COMING_SOON.radarrUrl && COMING_SOON.radarrApiKey) {
+        const base = COMING_SOON.radarrUrl.replace(/\/$/, '');
+        fetches.push(fetch(`${base}/api/v3/calendar?start=${startDate}&end=${endDate}&unmonitored=false`, {
+          headers: { 'X-Api-Key': COMING_SOON.radarrApiKey }
+        }).then(r => r.ok ? r.json() : []));
+      } else fetches.push(Promise.resolve([]));
+
+      if (COMING_SOON.sonarrUrl && COMING_SOON.sonarrApiKey) {
+        const base = COMING_SOON.sonarrUrl.replace(/\/$/, '');
+        fetches.push(fetch(`${base}/api/v3/calendar?start=${startDate}&end=${endDate}&unmonitored=false&includeSeries=true`, {
+          headers: { 'X-Api-Key': COMING_SOON.sonarrApiKey }
+        }).then(r => r.ok ? r.json() : []));
+      } else fetches.push(Promise.resolve([]));
+
+      const [radarr, sonarr] = await Promise.all(fetches);
+      return interleaveComingSoonItems(
+        mapRadarrComingSoon(radarr).slice(0, COMING_SOON.moviesCount),
+        mapSonarrComingSoon(sonarr).slice(0, COMING_SOON.showsCount),
+      );
+    }
+
+    function mapRadarrComingSoon(items) {
+      const base = COMING_SOON.radarrUrl.replace(/\/$/, '');
+      const start = new Date(Date.now() - (Number(COMING_SOON.daysOffset) || 0) * 86400000);
+      start.setHours(0, 0, 0, 0);
+      return (Array.isArray(items) ? items : [])
+        .filter(m => !m.hasFile && m.digitalRelease && new Date(m.digitalRelease) >= start)
+        .sort((a, b) => new Date(a.digitalRelease) - new Date(b.digitalRelease))
+        .map(m => ({
+          type: 'movie',
+          typeLabel: 'Movie',
+          title: m.title || 'Untitled Movie',
+          subtitle: [m.year, Array.isArray(m.genres) ? m.genres.join(' / ') : ''].filter(Boolean).join(' / '),
+          releaseDate: m.digitalRelease,
+          countdown: formatComingSoonCountdown(m.digitalRelease),
+          releaseLabel: formatComingSoonDate(m.digitalRelease),
+          overview: m.overview || '',
+          posterUrl: coverImage(m.images, 'poster'),
+          fanartUrl: coverImage(m.images, 'fanart'),
+          localPosterUrl: m.id ? `${base}/api/v3/MediaCover/${m.id}/poster.jpg?apikey=${encodeURIComponent(COMING_SOON.radarrApiKey)}` : '',
+          localFanartUrl: m.id ? `${base}/api/v3/MediaCover/${m.id}/fanart.jpg?apikey=${encodeURIComponent(COMING_SOON.radarrApiKey)}` : '',
+        }));
+    }
+
+    function mapSonarrComingSoon(items) {
+      const base = COMING_SOON.sonarrUrl.replace(/\/$/, '');
+      const start = new Date(Date.now() - (Number(COMING_SOON.daysOffset) || 0) * 86400000);
+      start.setHours(0, 0, 0, 0);
+      const seen = new Set();
+      return (Array.isArray(items) ? items : [])
+        .filter(ep => !ep.hasFile && ep.airDateUtc && new Date(ep.airDateUtc) >= start)
+        .sort((a, b) => new Date(a.airDateUtc) - new Date(b.airDateUtc))
+        .filter(ep => {
+          const id = ep.seriesId || ep.series?.id || ep.series?.title || ep.title;
+          if (seen.has(id)) return false;
+          seen.add(id);
+          return true;
+        })
+        .map(ep => {
+          const series = ep.series || {};
+          const season = String(ep.seasonNumber || 0).padStart(2, '0');
+          const episode = String(ep.episodeNumber || 0).padStart(2, '0');
+          const releaseDate = ep.airDate || (ep.airDateUtc ? ep.airDateUtc.split('T')[0] : '');
+          const sid = series.id || ep.seriesId;
+          return {
+            type: 'tv',
+            typeLabel: 'TV',
+            title: series.title || ep.title || 'Untitled Series',
+            subtitle: `S${season}E${episode}${ep.title ? ` / ${ep.title}` : ''}`,
+            releaseDate,
+            countdown: formatComingSoonCountdown(releaseDate),
+            releaseLabel: formatComingSoonDate(releaseDate),
+            overview: ep.overview || '',
+            posterUrl: coverImage(series.images, 'poster'),
+            fanartUrl: coverImage(series.images, 'fanart'),
+            localPosterUrl: sid ? `${base}/api/v3/MediaCover/${sid}/poster.jpg?apikey=${encodeURIComponent(COMING_SOON.sonarrApiKey)}` : '',
+            localFanartUrl: sid ? `${base}/api/v3/MediaCover/${sid}/fanart.jpg?apikey=${encodeURIComponent(COMING_SOON.sonarrApiKey)}` : '',
+          };
+        });
+    }
+
+    function buildComingSoonMediaData(item) {
+      const useFanart = COMING_SOON.imageType === 'fanart';
+      const artwork = useFanart
+        ? (item.fanartUrl || item.localFanartUrl || item.posterUrl || item.localPosterUrl || '')
+        : (item.posterUrl || item.localPosterUrl || item.fanartUrl || item.localFanartUrl || '');
+      return {
+        title: item.title || 'Coming Soon',
+        subtitle: item.subtitle || '',
+        contentType: item.type === 'tv' ? 'episode' : 'movie',
+        artwork,
+        playerName: [item.countdown, item.releaseLabel].filter(Boolean).join(' / '),
+        state: 'playing',
+        duration: 0,
+        position: 0,
+        positionUpdatedAt: '',
+        summary: item.overview || '',
+        ratingKey: '',
+        comingSoon: true,
+        typeLabel: item.typeLabel || (item.type === 'tv' ? 'TV' : 'Movie'),
+        releaseLabel: item.releaseLabel || '',
+        countdown: item.countdown || '',
+      };
+    }
+
+    function interleaveComingSoonItems(movies, shows) {
+      const out = [];
+      const max = Math.max(movies.length, shows.length);
+      for (let i = 0; i < max; i++) {
+        if (i < movies.length) out.push(movies[i]);
+        if (i < shows.length) out.push(shows[i]);
+      }
+      return out;
+    }
+
+    function coverImage(images, type) {
+      if (!Array.isArray(images)) return '';
+      return images.find(i => i && i.coverType === type)?.remoteUrl || '';
+    }
+
+    function formatComingSoonCountdown(dateStr) {
+      const target = new Date(String(dateStr).substring(0, 10) + 'T00:00:00');
+      if (Number.isNaN(target.getTime())) return '';
+      const today = new Date();
+      today.setHours(0, 0, 0, 0);
+      const diff = Math.round((target - today) / 86400000);
+      if (diff < 0) return 'Available';
+      if (diff === 0) return 'Today';
+      if (diff === 1) return 'Tomorrow';
+      if (diff < 7) return `In ${diff} days`;
+      if (diff < 14) return 'In 1 week';
+      if (diff < 30) return `In ${Math.round(diff / 7)} weeks`;
+      if (diff < 60) return 'In 1 month';
+      return `In ${Math.round(diff / 30)} months`;
+    }
+
+    function formatComingSoonDate(dateStr) {
+      const d = new Date(dateStr);
+      if (Number.isNaN(d.getTime())) return '';
+      return d.toLocaleDateString(undefined, { day: 'numeric', month: 'short', year: 'numeric' });
+    }
+
     // ===== FETCH NOW-SHOWING DATA FROM HA =====
     async function fetchNowShowingData() {
+      if (DISPLAY_MODE === 'coming_soon') return fetchComingSoonData();
+
       // Unified-server path: /api/state is already normalised.
       await serverModeReady;
       if (SERVER_MODE) {
@@ -3034,6 +3481,7 @@
 
     function isBackendPlayer(state, rule) {
       if (!state || typeof state.entity_id !== 'string') return false;
+      if ((rule.requiredAttributes || []).some(name => !(state.attributes || {})[name])) return false;
       return state.entity_id.startsWith(rule.entityPrefix)
         || rule.exactEntities.includes(state.entity_id)
         || (rule.entityIncludes || []).some(token => state.entity_id.includes(token));
@@ -3366,18 +3814,20 @@
         subtitleText.textContent = sub;
       } else {
         titleText.textContent = data.title;
-        subtitleText.textContent = '';
+        subtitleText.textContent = data.comingSoon ? (data.subtitle || data.releaseLabel || '') : '';
       }
 
       // Media type label
-      let typeLabel = 'Movie';
-      if (data.contentType === 'tvshow' || data.contentType === 'episode' || data.seriesTitle) {
+      let typeLabel = data.comingSoon ? (data.typeLabel || 'Coming Soon') : 'Movie';
+      if (!data.comingSoon && (data.contentType === 'tvshow' || data.contentType === 'episode' || data.seriesTitle)) {
         typeLabel = 'TV Series';
-      } else if (data.contentType === 'music') {
+      } else if (!data.comingSoon && data.contentType === 'music') {
         typeLabel = 'Music';
       }
 
-      if (data.state === 'paused') {
+      if (data.comingSoon && data.countdown) {
+        typeLabel += ' / ' + data.countdown;
+      } else if (data.state === 'paused') {
         typeLabel += ' · Paused';
       }
 
@@ -3462,6 +3912,7 @@
       // flash the default UI and then repaint.
       await loadVisualConfig();
       applyVisualToggles();
+      syncDisplayModeText();
       poll();
       setInterval(poll, POLL_INTERVAL);
     }


### PR DESCRIPTION
## Summary
- Adds display_mode=coming_soon with Radarr/Sonarr upcoming-release fetching, /api/coming-soon, cache/config handling, add-on/Docker env wiring, and docs.
- Updates the kiosk setup UI so Coming Soon is selectable, Radarr/Sonarr options are configurable, and the Players section can choose Plex, Jellyfin, Emby, Kodi, Apple TV, generic Streaming Device, or Kaleidescape with a player entity picker.
- Adds a generic streaming backend for Roku/Google TV/Android TV-style media_player.* entities exposing app_name, carrying through media_title, entity_picture, and dashboard-icons app badges.

## Validation
- node -e frontend script parse check passed.
- git diff --check passed, with only existing CRLF conversion warnings.
- npm.cmd test was not run in this session because the local escalation approval quota blocked the test command.

Closes #33.
Refs #77.