### PR TITLE
Add configurable Coming Soon look-ahead

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,6 +358,7 @@ useful as a Fully Kiosk screensaver URL or as a target for HA automations.
 | Show count | `coming_soon_shows_count` | `COMING_SOON_SHOWS_COUNT` | `comingSoonShowsCount` | `0` to `50` |
 | Cycle interval | `coming_soon_cycle_interval` | `COMING_SOON_CYCLE_INTERVAL` | `comingSoonCycleInterval` | Seconds, `2` to `300` |
 | Days offset | `coming_soon_days_offset` | `COMING_SOON_DAYS_OFFSET` | `comingSoonDaysOffset` | Include recent past releases |
+| Look-ahead days | `coming_soon_lookahead_days` | `COMING_SOON_LOOKAHEAD_DAYS` | `comingSoonLookaheadDays` | Forward window, default `90`, range `1`–`365`. Radarr matches `digitalRelease` or `physicalRelease` |
 | Image type | `coming_soon_image_type` | `COMING_SOON_IMAGE_TYPE` | `comingSoonImageType` | `poster`, `fanart` |
 
 ### Using Now Showing And Coming Soon Together

--- a/addons/plex-now-showing/DOCS.md
+++ b/addons/plex-now-showing/DOCS.md
@@ -43,6 +43,7 @@ probe of `/api`) and switches to `/api/state`. Plex-only metadata calls use
 | `coming_soon_shows_count` | `5` | Number of Sonarr series to include. |
 | `coming_soon_cycle_interval` | `8` | Seconds each upcoming title stays on screen. |
 | `coming_soon_days_offset` | `0` | Include releases from this many days in the past. |
+| `coming_soon_lookahead_days` | `90` | Forward window (days) for upcoming releases. Radarr considers `digitalRelease` and `physicalRelease`; the earliest qualifying date inside the window wins. |
 | `coming_soon_image_type` | `poster` | `poster` or `fanart`. |
 | `proxy_secret` | _empty_ | If set, requests to `/api/*` must carry `X-Proxy-Secret`. |
 | `allowed_origins` | `[]` | Comma-joined allowlist for the `Origin` header on `/api/*`. Leave empty for Ingress-only. |

--- a/addons/plex-now-showing/config.yaml
+++ b/addons/plex-now-showing/config.yaml
@@ -62,6 +62,7 @@ options:
   coming_soon_shows_count: 5
   coming_soon_cycle_interval: 8
   coming_soon_days_offset: 0
+  coming_soon_lookahead_days: 90
   coming_soon_image_type: poster
   proxy_secret: ""
   allowed_origins: []
@@ -124,6 +125,7 @@ schema:
   coming_soon_shows_count: "int(0,50)"
   coming_soon_cycle_interval: "int(2,300)"
   coming_soon_days_offset: "int(0,365)"
+  coming_soon_lookahead_days: "int(1,365)"
   coming_soon_image_type: "list(poster|fanart)"
   proxy_secret: "password?"
   allowed_origins:

--- a/addons/plex-now-showing/rootfs/etc/services.d/plex-now-showing/run
+++ b/addons/plex-now-showing/rootfs/etc/services.d/plex-now-showing/run
@@ -50,6 +50,7 @@ export_opt COMING_SOON_MOVIES_COUNT coming_soon_movies_count
 export_opt COMING_SOON_SHOWS_COUNT  coming_soon_shows_count
 export_opt COMING_SOON_CYCLE_INTERVAL coming_soon_cycle_interval
 export_opt COMING_SOON_DAYS_OFFSET coming_soon_days_offset
+export_opt COMING_SOON_LOOKAHEAD_DAYS coming_soon_lookahead_days
 export_opt COMING_SOON_IMAGE_TYPE  coming_soon_image_type
 
 # allowed_origins is a list → join with commas for the server's parser.

--- a/addons/plex-now-showing/translations/en.yaml
+++ b/addons/plex-now-showing/translations/en.yaml
@@ -85,6 +85,12 @@ configuration:
   coming_soon_days_offset:
     name: Coming Soon days offset
     description: Include releases from this many days in the past.
+  coming_soon_lookahead_days:
+    name: Coming Soon look-ahead days
+    description: >-
+      Forward window for upcoming releases. Defaults to 90 days; raise it if
+      Coming Soon isn't filling up because qualifying digital/physical
+      release dates fall further out.
   coming_soon_image_type:
     name: Coming Soon image type
     description: Use portrait poster art or landscape fanart/backdrop art.

--- a/server/README.md
+++ b/server/README.md
@@ -68,6 +68,7 @@ For HA Container users running via Docker Compose. Set:
 | `COMING_SOON_SHOWS_COUNT` | `5` | Number of Sonarr series to include |
 | `COMING_SOON_CYCLE_INTERVAL` | `8` | Seconds per upcoming title |
 | `COMING_SOON_DAYS_OFFSET` | `0` | Include releases from this many days in the past |
+| `COMING_SOON_LOOKAHEAD_DAYS` | `90` | Forward window (days). Radarr matches `digitalRelease` or `physicalRelease`; widen if the rotation isn't filling up |
 | `COMING_SOON_IMAGE_TYPE` | `poster` | `poster` or `fanart` |
 | `PROXY_SECRET` | – | If set, requests to `/api/*` must carry `X-Proxy-Secret` |
 | `ALLOWED_ORIGINS` | – | Comma-separated allowlist for `Origin` on `/api/*` |

--- a/server/src/comingSoon.js
+++ b/server/src/comingSoon.js
@@ -1,4 +1,5 @@
 const DAY_MS = 86400000;
+const DEFAULT_LOOKAHEAD_DAYS = 90;
 
 export function hasComingSoonSource(config = {}) {
   const c = config.comingSoon || {};
@@ -12,8 +13,9 @@ export async function fetchComingSoonItems({
 } = {}) {
   const c = config?.comingSoon || {};
   const offsetDays = numberOr(c.daysOffset, 0);
+  const lookaheadDays = numberOr(c.lookaheadDays, DEFAULT_LOOKAHEAD_DAYS);
   const start = startOfDay(new Date(now.getTime() - offsetDays * DAY_MS));
-  const end = new Date(now.getTime() + 90 * DAY_MS);
+  const end = new Date(now.getTime() + lookaheadDays * DAY_MS);
 
   const [movies, shows] = await Promise.all([
     fetchRadarrItems({ config: c, fetchImpl, start, end, now }),
@@ -38,9 +40,10 @@ async function fetchRadarrItems({ config, fetchImpl, start, end, now }) {
   }
   const data = await resp.json();
   return (Array.isArray(data) ? data : [])
-    .filter(item => !item.hasFile && item.digitalRelease && new Date(item.digitalRelease) >= start)
-    .sort((a, b) => new Date(a.digitalRelease) - new Date(b.digitalRelease))
-    .map(item => {
+    .map(item => ({ item, releaseDate: pickRadarrReleaseDate(item, start, end) }))
+    .filter(({ item, releaseDate }) => !item.hasFile && releaseDate)
+    .sort((a, b) => new Date(a.releaseDate) - new Date(b.releaseDate))
+    .map(({ item, releaseDate }) => {
       const id = item.id || item.movieId || '';
       const genres = Array.isArray(item.genres) ? item.genres.filter(Boolean).join(' / ') : '';
       return {
@@ -48,9 +51,9 @@ async function fetchRadarrItems({ config, fetchImpl, start, end, now }) {
         typeLabel: 'Movie',
         title: item.title || 'Untitled Movie',
         subtitle: [item.year, genres].filter(Boolean).join(' / '),
-        releaseDate: item.digitalRelease,
-        countdown: formatCountdown(item.digitalRelease, now),
-        releaseLabel: formatReleaseDate(item.digitalRelease),
+        releaseDate,
+        countdown: formatCountdown(releaseDate, now),
+        releaseLabel: formatReleaseDate(releaseDate),
         overview: item.overview || '',
         posterUrl: imageUrl(item.images, 'poster'),
         fanartUrl: imageUrl(item.images, 'fanart'),
@@ -58,6 +61,20 @@ async function fetchRadarrItems({ config, fetchImpl, start, end, now }) {
         localFanartUrl: id ? `${base}/api/v3/MediaCover/${id}/fanart.jpg?apikey=${encodeURIComponent(config.radarrApiKey)}` : '',
       };
     });
+}
+
+// Return the earliest of digitalRelease/physicalRelease that falls inside the
+// [start, end] look-ahead window, or null if neither qualifies. inCinemas is
+// deliberately not considered — theatrical dates aren't a "coming home soon"
+// signal for a Plex/Radarr workflow.
+function pickRadarrReleaseDate(item, start, end) {
+  const candidates = [item.digitalRelease, item.physicalRelease]
+    .filter(Boolean)
+    .map(d => ({ raw: d, ts: new Date(d).getTime() }))
+    .filter(({ ts }) => Number.isFinite(ts) && ts >= start.getTime() && ts <= end.getTime());
+  if (!candidates.length) return null;
+  candidates.sort((a, b) => a.ts - b.ts);
+  return candidates[0].raw;
 }
 
 async function fetchSonarrItems({ config, fetchImpl, start, end, now }) {
@@ -73,7 +90,11 @@ async function fetchSonarrItems({ config, fetchImpl, start, end, now }) {
   const data = await resp.json();
   const seenSeries = new Set();
   return (Array.isArray(data) ? data : [])
-    .filter(item => !item.hasFile && item.airDateUtc && new Date(item.airDateUtc) >= start)
+    .filter(item => {
+      if (item.hasFile || !item.airDateUtc) return false;
+      const ts = new Date(item.airDateUtc).getTime();
+      return Number.isFinite(ts) && ts >= start.getTime() && ts <= end.getTime();
+    })
     .sort((a, b) => new Date(a.airDateUtc) - new Date(b.airDateUtc))
     .filter(item => {
       const id = item.seriesId || item.series?.id || item.series?.title || item.title;

--- a/server/src/config.js
+++ b/server/src/config.js
@@ -59,6 +59,10 @@ export function loadConfig(env = process.env) {
       showsCount: parseIntClamped(env.COMING_SOON_SHOWS_COUNT, 5, 0, 50),
       cycleInterval: parseIntClamped(env.COMING_SOON_CYCLE_INTERVAL, 8, 2, 300),
       daysOffset: parseIntClamped(env.COMING_SOON_DAYS_OFFSET, 0, 0, 365),
+      // Forward window for upcoming releases (#85). Default preserves the
+      // pre-#85 hard-coded 90-day horizon. Lower bound of 1 keeps the window
+      // meaningful; upper bound of 365 mirrors daysOffset.
+      lookaheadDays: parseIntClamped(env.COMING_SOON_LOOKAHEAD_DAYS, 90, 1, 365),
       imageType: parseEnum(env.COMING_SOON_IMAGE_TYPE, ['poster', 'fanart'], 'poster'),
     },
     // Fully Kiosk auto-switcher (#48). Disabled by default; users who prefer

--- a/server/src/routes/config.js
+++ b/server/src/routes/config.js
@@ -25,6 +25,7 @@ export function configRoute({ config }) {
         showsCount: config.comingSoon?.showsCount ?? 5,
         cycleInterval: config.comingSoon?.cycleInterval ?? 8,
         daysOffset: config.comingSoon?.daysOffset ?? 0,
+        lookaheadDays: config.comingSoon?.lookaheadDays ?? 90,
         imageType: config.comingSoon?.imageType || 'poster',
       },
       visual: {

--- a/server/test/comingSoon.test.js
+++ b/server/test/comingSoon.test.js
@@ -96,3 +96,220 @@ test('format helpers match coming-soon-card style', () => {
   assert.equal(formatCountdown('2026-05-08', now), 'In 6 days');
   assert.equal(formatReleaseDate('2026-05-10'), '10th of May 2026');
 });
+
+test('Radarr matches physicalRelease when only physicalRelease is set', async () => {
+  const fetchImpl = async (url) => {
+    if (url.includes('radarr')) {
+      return response([
+        {
+          id: 30,
+          title: 'Physical Only',
+          year: 2026,
+          physicalRelease: '2026-06-01T00:00:00Z',
+          hasFile: false,
+        },
+      ]);
+    }
+    return response([]);
+  };
+
+  const items = await fetchComingSoonItems({
+    config: {
+      comingSoon: {
+        radarrUrl: 'http://radarr.local:7878',
+        radarrApiKey: 'rk',
+        moviesCount: 5,
+        showsCount: 5,
+        lookaheadDays: 90,
+      },
+    },
+    fetchImpl,
+    now: new Date('2026-05-02T12:00:00Z'),
+  });
+
+  assert.equal(items.length, 1);
+  assert.equal(items[0].title, 'Physical Only');
+  assert.equal(items[0].releaseDate, '2026-06-01T00:00:00Z');
+});
+
+test('Radarr prefers earliest qualifying release when both digital and physical are set', async () => {
+  const fetchImpl = async (url) => {
+    if (url.includes('radarr')) {
+      return response([
+        {
+          id: 31,
+          title: 'Both Dates',
+          digitalRelease: '2026-07-01T00:00:00Z',
+          physicalRelease: '2026-06-15T00:00:00Z',
+          hasFile: false,
+        },
+      ]);
+    }
+    return response([]);
+  };
+
+  const [item] = await fetchComingSoonItems({
+    config: {
+      comingSoon: {
+        radarrUrl: 'http://radarr.local:7878',
+        radarrApiKey: 'rk',
+        moviesCount: 5,
+        showsCount: 5,
+        lookaheadDays: 90,
+      },
+    },
+    fetchImpl,
+    now: new Date('2026-05-02T12:00:00Z'),
+  });
+
+  assert.equal(item.releaseDate, '2026-06-15T00:00:00Z');
+});
+
+test('Radarr falls back to digitalRelease when physicalRelease is outside the window', async () => {
+  const fetchImpl = async (url) => {
+    if (url.includes('radarr')) {
+      return response([
+        {
+          id: 32,
+          title: 'Physical Far Future',
+          digitalRelease: '2026-06-01T00:00:00Z',
+          physicalRelease: '2027-06-01T00:00:00Z',
+          hasFile: false,
+        },
+      ]);
+    }
+    return response([]);
+  };
+
+  const [item] = await fetchComingSoonItems({
+    config: {
+      comingSoon: {
+        radarrUrl: 'http://radarr.local:7878',
+        radarrApiKey: 'rk',
+        moviesCount: 5,
+        showsCount: 5,
+        lookaheadDays: 90,
+      },
+    },
+    fetchImpl,
+    now: new Date('2026-05-02T12:00:00Z'),
+  });
+
+  assert.equal(item.releaseDate, '2026-06-01T00:00:00Z');
+});
+
+test('inCinemas is not used as a fallback', async () => {
+  const fetchImpl = async (url) => {
+    if (url.includes('radarr')) {
+      return response([
+        {
+          id: 33,
+          title: 'Theatrical Only',
+          inCinemas: '2026-05-20T00:00:00Z',
+          hasFile: false,
+        },
+      ]);
+    }
+    return response([]);
+  };
+
+  const items = await fetchComingSoonItems({
+    config: {
+      comingSoon: {
+        radarrUrl: 'http://radarr.local:7878',
+        radarrApiKey: 'rk',
+        moviesCount: 5,
+        showsCount: 5,
+        lookaheadDays: 90,
+      },
+    },
+    fetchImpl,
+    now: new Date('2026-05-02T12:00:00Z'),
+  });
+
+  assert.deepEqual(items, []);
+});
+
+test('hasFile movies are still excluded with the new release-date logic', async () => {
+  const fetchImpl = async (url) => {
+    if (url.includes('radarr')) {
+      return response([
+        {
+          id: 34,
+          title: 'Already Downloaded',
+          digitalRelease: '2026-06-01T00:00:00Z',
+          physicalRelease: '2026-06-15T00:00:00Z',
+          hasFile: true,
+        },
+      ]);
+    }
+    return response([]);
+  };
+
+  const items = await fetchComingSoonItems({
+    config: {
+      comingSoon: {
+        radarrUrl: 'http://radarr.local:7878',
+        radarrApiKey: 'rk',
+        moviesCount: 5,
+        showsCount: 5,
+        lookaheadDays: 90,
+      },
+    },
+    fetchImpl,
+    now: new Date('2026-05-02T12:00:00Z'),
+  });
+
+  assert.deepEqual(items, []);
+});
+
+test('configurable lookaheadDays widens the request window', async () => {
+  const calls = [];
+  const fetchImpl = async (url) => {
+    calls.push(url);
+    if (url.includes('radarr')) {
+      return response([
+        {
+          id: 40,
+          title: 'Far Future',
+          digitalRelease: '2026-09-15T00:00:00Z',
+          hasFile: false,
+        },
+      ]);
+    }
+    return response([]);
+  };
+
+  // Default 90-day window: the 2026-09-15 release falls outside.
+  const defaultRun = await fetchComingSoonItems({
+    config: {
+      comingSoon: {
+        radarrUrl: 'http://radarr.local:7878',
+        radarrApiKey: 'rk',
+        moviesCount: 5,
+        showsCount: 5,
+      },
+    },
+    fetchImpl,
+    now: new Date('2026-05-02T12:00:00Z'),
+  });
+  assert.deepEqual(defaultRun, []);
+  assert.ok(calls[0].includes('end=2026-07-31'));
+
+  // Widened to 180 days: the same release qualifies.
+  const widened = await fetchComingSoonItems({
+    config: {
+      comingSoon: {
+        radarrUrl: 'http://radarr.local:7878',
+        radarrApiKey: 'rk',
+        moviesCount: 5,
+        showsCount: 5,
+        lookaheadDays: 180,
+      },
+    },
+    fetchImpl,
+    now: new Date('2026-05-02T12:00:00Z'),
+  });
+  assert.equal(widened.length, 1);
+  assert.equal(widened[0].title, 'Far Future');
+});

--- a/server/test/config.test.js
+++ b/server/test/config.test.js
@@ -106,6 +106,7 @@ test('coming soon config parses source settings and validates required source', 
     COMING_SOON_SHOWS_COUNT: '3',
     COMING_SOON_CYCLE_INTERVAL: '12',
     COMING_SOON_DAYS_OFFSET: '2',
+    COMING_SOON_LOOKAHEAD_DAYS: '180',
     COMING_SOON_IMAGE_TYPE: 'fanart',
   });
 
@@ -117,7 +118,25 @@ test('coming soon config parses source settings and validates required source', 
   assert.equal(config.comingSoon.showsCount, 3);
   assert.equal(config.comingSoon.cycleInterval, 12);
   assert.equal(config.comingSoon.daysOffset, 2);
+  assert.equal(config.comingSoon.lookaheadDays, 180);
   assert.equal(config.comingSoon.imageType, 'fanart');
+});
+
+test('coming soon lookaheadDays defaults to 90 and clamps out-of-range values', () => {
+  const { config: defaults } = loadConfig({ SUPERVISOR_TOKEN: 'x' });
+  assert.equal(defaults.comingSoon.lookaheadDays, 90);
+
+  const { config: clamped } = loadConfig({
+    SUPERVISOR_TOKEN: 'x',
+    COMING_SOON_LOOKAHEAD_DAYS: '9999',
+  });
+  assert.equal(clamped.comingSoon.lookaheadDays, 365);
+
+  const { config: floor } = loadConfig({
+    SUPERVISOR_TOKEN: 'x',
+    COMING_SOON_LOOKAHEAD_DAYS: '0',
+  });
+  assert.equal(floor.comingSoon.lookaheadDays, 1);
 });
 
 test('visual toggles all default to false', () => {

--- a/server/test/routes.test.js
+++ b/server/test/routes.test.js
@@ -43,6 +43,7 @@ function baseConfig(overrides = {}) {
       showsCount: 5,
       cycleInterval: 8,
       daysOffset: 0,
+      lookaheadDays: 90,
       imageType: 'poster',
     },
     visual: { progressBar: false, ratingsBadges: false, genreChips: false, infoPanelMode: 'on_tap' },
@@ -131,6 +132,7 @@ test('GET /api/config defaults every visual toggle off', async () => {
         showsCount: 5,
         cycleInterval: 8,
         daysOffset: 0,
+        lookaheadDays: 90,
         imageType: 'poster',
       },
       visual: {
@@ -197,6 +199,7 @@ test('GET /api/coming-soon returns configured upcoming items', async () => {
       showsCount: 5,
       cycleInterval: 8,
       daysOffset: 0,
+      lookaheadDays: 90,
       imageType: 'poster',
     },
   }), haClient);

--- a/www/now_showing.config.example.js
+++ b/www/now_showing.config.example.js
@@ -31,6 +31,7 @@ window.NOW_SHOWING_CONFIG = {
   comingSoonShowsCount: 5,
   comingSoonCycleInterval: 8,
   comingSoonDaysOffset: 0,
+  comingSoonLookaheadDays: 90, // forward window in days; widen if Coming Soon doesn't fill up
   comingSoonImageType: 'poster',
 
   // Plex filtering

--- a/www/now_showing.html
+++ b/www/now_showing.html
@@ -1687,6 +1687,11 @@
               <label for="cfgComingSoonDaysOffset">Days Offset</label>
               <input id="cfgComingSoonDaysOffset" type="number" min="0" max="365" step="1" inputmode="numeric" autocomplete="off">
             </div>
+            <div class="setup-field">
+              <label for="cfgComingSoonLookaheadDays">Look-ahead Days</label>
+              <input id="cfgComingSoonLookaheadDays" type="number" min="1" max="365" step="1" inputmode="numeric" autocomplete="off">
+              <div class="hint">Forward window for upcoming releases. Default 90.</div>
+            </div>
           </div>
         </details>
 
@@ -2163,6 +2168,7 @@
       showsCount: readIntClamped('comingSoonShowsCount', 5, 0, 50),
       cycleInterval: readIntClamped('comingSoonCycleInterval', 8, 2, 300),
       daysOffset: readIntClamped('comingSoonDaysOffset', 0, 0, 365),
+      lookaheadDays: readIntClamped('comingSoonLookaheadDays', 90, 1, 365),
       imageType: readConfig('comingSoonImageType', { aliases: ['coming_soon_image_type'], defaultValue: 'poster' }) === 'fanart' ? 'fanart' : 'poster',
     };
 
@@ -2352,6 +2358,7 @@
           if (Number.isFinite(cs.showsCount)) COMING_SOON.showsCount = cs.showsCount;
           if (Number.isFinite(cs.cycleInterval)) COMING_SOON.cycleInterval = cs.cycleInterval;
           if (Number.isFinite(cs.daysOffset)) COMING_SOON.daysOffset = cs.daysOffset;
+          if (Number.isFinite(cs.lookaheadDays)) COMING_SOON.lookaheadDays = cs.lookaheadDays;
           if (cs.imageType === 'poster' || cs.imageType === 'fanart') COMING_SOON.imageType = cs.imageType;
         }
         const v = body && body.visual;
@@ -2602,6 +2609,7 @@
       ['comingSoonShowsCount', 'cfgComingSoonShowsCount', '5'],
       ['comingSoonCycleInterval', 'cfgComingSoonCycleInterval', '8'],
       ['comingSoonDaysOffset', 'cfgComingSoonDaysOffset', '0'],
+      ['comingSoonLookaheadDays', 'cfgComingSoonLookaheadDays', '90'],
       ['comingSoonImageType', 'cfgComingSoonImageType', 'poster'],
       ['visualTheme', 'cfgVisualTheme', 'classic-gold'],
       ['visualFrameStyle', 'cfgVisualFrameStyle', 'bulbs'],
@@ -2643,6 +2651,7 @@
       comingSoonShowsCount: { min: 0, max: 50, fallback: 5, float: false },
       comingSoonCycleInterval: { min: 2, max: 300, fallback: 8, float: false },
       comingSoonDaysOffset: { min: 0, max: 365, fallback: 0, float: false },
+      comingSoonLookaheadDays: { min: 1, max: 365, fallback: 90, float: false },
       visualCornerRadiusPx: { min: 0, max: 48, fallback: 0, float: false },
     };
     const ACCENT_PICKER_DEFAULT = '#c8a032';
@@ -4011,8 +4020,10 @@
     }
 
     async function fetchComingSoonDirect() {
+      const lookaheadDays = Number(COMING_SOON.lookaheadDays);
+      const lookahead = Number.isFinite(lookaheadDays) && lookaheadDays >= 1 ? lookaheadDays : 90;
       const start = new Date(Date.now() - (Number(COMING_SOON.daysOffset) || 0) * 86400000);
-      const end = new Date(Date.now() + 90 * 86400000);
+      const end = new Date(Date.now() + lookahead * 86400000);
       const startDate = start.toISOString().split('T')[0];
       const endDate = end.toISOString().split('T')[0];
       const fetches = [];
@@ -4042,17 +4053,33 @@
       const base = COMING_SOON.radarrUrl.replace(/\/$/, '');
       const start = new Date(Date.now() - (Number(COMING_SOON.daysOffset) || 0) * 86400000);
       start.setHours(0, 0, 0, 0);
+      const lookaheadDays = Number(COMING_SOON.lookaheadDays);
+      const lookahead = Number.isFinite(lookaheadDays) && lookaheadDays >= 1 ? lookaheadDays : 90;
+      const end = new Date(Date.now() + lookahead * 86400000);
+      // #85: accept digitalRelease OR physicalRelease (not inCinemas), pick the
+      // earliest qualifying date inside the window.
+      const pickReleaseDate = (m) => {
+        const startMs = start.getTime();
+        const endMs = end.getTime();
+        const candidates = [m.digitalRelease, m.physicalRelease]
+          .filter(Boolean)
+          .map(d => ({ raw: d, ts: new Date(d).getTime() }))
+          .filter(({ ts }) => Number.isFinite(ts) && ts >= startMs && ts <= endMs)
+          .sort((a, b) => a.ts - b.ts);
+        return candidates.length ? candidates[0].raw : null;
+      };
       return (Array.isArray(items) ? items : [])
-        .filter(m => !m.hasFile && m.digitalRelease && new Date(m.digitalRelease) >= start)
-        .sort((a, b) => new Date(a.digitalRelease) - new Date(b.digitalRelease))
-        .map(m => ({
+        .map(m => ({ m, releaseDate: pickReleaseDate(m) }))
+        .filter(({ m, releaseDate }) => !m.hasFile && releaseDate)
+        .sort((a, b) => new Date(a.releaseDate) - new Date(b.releaseDate))
+        .map(({ m, releaseDate }) => ({
           type: 'movie',
           typeLabel: 'Movie',
           title: m.title || 'Untitled Movie',
           subtitle: [m.year, Array.isArray(m.genres) ? m.genres.join(' / ') : ''].filter(Boolean).join(' / '),
-          releaseDate: m.digitalRelease,
-          countdown: formatComingSoonCountdown(m.digitalRelease),
-          releaseLabel: formatComingSoonDate(m.digitalRelease),
+          releaseDate,
+          countdown: formatComingSoonCountdown(releaseDate),
+          releaseLabel: formatComingSoonDate(releaseDate),
           overview: m.overview || '',
           posterUrl: coverImage(m.images, 'poster'),
           fanartUrl: coverImage(m.images, 'fanart'),
@@ -4065,9 +4092,16 @@
       const base = COMING_SOON.sonarrUrl.replace(/\/$/, '');
       const start = new Date(Date.now() - (Number(COMING_SOON.daysOffset) || 0) * 86400000);
       start.setHours(0, 0, 0, 0);
+      const lookaheadDays = Number(COMING_SOON.lookaheadDays);
+      const lookahead = Number.isFinite(lookaheadDays) && lookaheadDays >= 1 ? lookaheadDays : 90;
+      const end = new Date(Date.now() + lookahead * 86400000);
       const seen = new Set();
       return (Array.isArray(items) ? items : [])
-        .filter(ep => !ep.hasFile && ep.airDateUtc && new Date(ep.airDateUtc) >= start)
+        .filter(ep => {
+          if (ep.hasFile || !ep.airDateUtc) return false;
+          const ts = new Date(ep.airDateUtc).getTime();
+          return Number.isFinite(ts) && ts >= start.getTime() && ts <= end.getTime();
+        })
         .sort((a, b) => new Date(a.airDateUtc) - new Date(b.airDateUtc))
         .filter(ep => {
           const id = ep.seriesId || ep.series?.id || ep.series?.title || ep.title;


### PR DESCRIPTION
## Summary

Closes #85.

- Adds a new `coming_soon_lookahead_days` option (env `COMING_SOON_LOOKAHEAD_DAYS`, frontend key `comingSoonLookaheadDays`) that replaces the previously hard-coded 90-day forward window. Range is 1–365, default is **90** so existing installs keep their current behaviour.
- Radarr eligibility now considers **both** `digitalRelease` and `physicalRelease`. When both are present, the earliest qualifying date inside the look-ahead window is selected. `inCinemas` is intentionally not used as a fallback.
- Existing filters are preserved: monitored-only (`unmonitored=false`) and `!hasFile`.
- The configured movie / show counts remain an upper bound — the look-ahead just controls how far out we look for *eligible* items.
- `/api/config` now exposes `comingSoon.lookaheadDays`, and the frontend's setup form, `/api/coming-soon` direct-fetch path, and Radarr/Sonarr mappers all honour it. The chosen release date (and the matching `countdown` / `releaseLabel`) is consistent everywhere.

### Files changed
- `server/src/comingSoon.js` — look-ahead config + earliest-of-digital/physical selector + Sonarr end-bound
- `server/src/config.js` — `lookaheadDays` parse + default 90, clamp 1–365
- `server/src/routes/config.js` — surface `lookaheadDays` on `/api/config`
- `addons/plex-now-showing/config.yaml` — option default + schema
- `addons/plex-now-showing/rootfs/etc/services.d/plex-now-showing/run` — env wiring
- `addons/plex-now-showing/translations/en.yaml` — UI label/description
- `addons/plex-now-showing/DOCS.md`, `server/README.md`, `README.md` — docs rows
- `www/now_showing.html` — config reader, `/api/config` consumer, setup form field, direct-fetch + Radarr/Sonarr mappers (digital + physical, look-ahead end bound)
- `www/now_showing.config.example.js` — example key
- `server/test/{comingSoon,config,routes}.test.js` — new + updated tests

## Test plan
- [x] `cd server && node --test test/` — **139 passed, 0 failed**, including new cases for:
  - physicalRelease-only eligibility
  - earliest-of-digital/physical selection
  - falling back to digitalRelease when physical is outside the window
  - rejecting `inCinemas`-only items
  - keeping the `hasFile` filter under the new logic
  - configurable `lookaheadDays` widening the window
  - `lookaheadDays` default + clamping
- [x] `node --check` on edited JS files
- [ ] Manual add-on UI smoke test (no add-on environment available in this run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)