### PR TITLE
feat: include inCinemas as Coming Soon release-date fallback (#87)

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,7 +358,7 @@ useful as a Fully Kiosk screensaver URL or as a target for HA automations.
 | Show count | `coming_soon_shows_count` | `COMING_SOON_SHOWS_COUNT` | `comingSoonShowsCount` | `0` to `50` |
 | Cycle interval | `coming_soon_cycle_interval` | `COMING_SOON_CYCLE_INTERVAL` | `comingSoonCycleInterval` | Seconds, `2` to `300` |
 | Days offset | `coming_soon_days_offset` | `COMING_SOON_DAYS_OFFSET` | `comingSoonDaysOffset` | Include recent past releases |
-| Look-ahead days | `coming_soon_lookahead_days` | `COMING_SOON_LOOKAHEAD_DAYS` | `comingSoonLookaheadDays` | Forward window, default `90`, range `1`–`365`. Radarr matches `digitalRelease` or `physicalRelease` |
+| Look-ahead days | `coming_soon_lookahead_days` | `COMING_SOON_LOOKAHEAD_DAYS` | `comingSoonLookaheadDays` | Forward window, default `90`, range `1`–`365`. Radarr matches `digitalRelease`, `physicalRelease`, or `inCinemas` (earliest qualifying date wins) |
 | Image type | `coming_soon_image_type` | `COMING_SOON_IMAGE_TYPE` | `comingSoonImageType` | `poster`, `fanart` |
 
 ### Using Now Showing And Coming Soon Together

--- a/addons/plex-now-showing/CHANGELOG.md
+++ b/addons/plex-now-showing/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to the Now Showing add-on will be documented here.
 The project follows [Semantic Versioning](https://semver.org/).
 
+## Unreleased
+
+### Changed
+- Radarr Coming Soon eligibility now also accepts `inCinemas` as a
+  release-date fallback alongside `digitalRelease` and `physicalRelease`.
+  When multiple dates are populated, the earliest qualifying date inside
+  the configured look-ahead window is selected. `hasFile === false` and
+  monitored filtering are unchanged, so already-imported movies still
+  drop out (closes #87).
+
 ## 2.1.1 - 2026-05-08
 
 ### Added
@@ -13,8 +23,7 @@ The project follows [Semantic Versioning](https://semver.org/).
   (closes #85, PR #86).
 - Radarr eligibility now includes `physicalRelease` alongside
   `digitalRelease`. When both are present, the earliest qualifying date
-  inside the look-ahead window is selected. `inCinemas` is intentionally
-  still **not** used as a release-date fallback.
+  inside the look-ahead window is selected.
 
 ## 2.1.0 - 2026-05-03
 

--- a/addons/plex-now-showing/DOCS.md
+++ b/addons/plex-now-showing/DOCS.md
@@ -43,7 +43,7 @@ probe of `/api`) and switches to `/api/state`. Plex-only metadata calls use
 | `coming_soon_shows_count` | `5` | Number of Sonarr series to include. |
 | `coming_soon_cycle_interval` | `8` | Seconds each upcoming title stays on screen. |
 | `coming_soon_days_offset` | `0` | Include releases from this many days in the past. |
-| `coming_soon_lookahead_days` | `90` | Forward window (days) for upcoming releases. Radarr considers `digitalRelease` and `physicalRelease`; the earliest qualifying date inside the window wins. |
+| `coming_soon_lookahead_days` | `90` | Forward window (days) for upcoming releases. Radarr considers `digitalRelease`, `physicalRelease`, and `inCinemas`; the earliest qualifying date inside the window wins. |
 | `coming_soon_image_type` | `poster` | `poster` or `fanart`. |
 | `proxy_secret` | _empty_ | If set, requests to `/api/*` must carry `X-Proxy-Secret`. |
 | `allowed_origins` | `[]` | Comma-joined allowlist for the `Origin` header on `/api/*`. Leave empty for Ingress-only. |

--- a/addons/plex-now-showing/translations/en.yaml
+++ b/addons/plex-now-showing/translations/en.yaml
@@ -89,8 +89,8 @@ configuration:
     name: Coming Soon look-ahead days
     description: >-
       Forward window for upcoming releases. Defaults to 90 days; raise it if
-      Coming Soon isn't filling up because qualifying digital/physical
-      release dates fall further out.
+      Coming Soon isn't filling up because qualifying digital, physical, or
+      cinema release dates fall further out.
   coming_soon_image_type:
     name: Coming Soon image type
     description: Use portrait poster art or landscape fanart/backdrop art.

--- a/server/src/comingSoon.js
+++ b/server/src/comingSoon.js
@@ -63,12 +63,10 @@ async function fetchRadarrItems({ config, fetchImpl, start, end, now }) {
     });
 }
 
-// Return the earliest of digitalRelease/physicalRelease that falls inside the
-// [start, end] look-ahead window, or null if neither qualifies. inCinemas is
-// deliberately not considered — theatrical dates aren't a "coming home soon"
-// signal for a Plex/Radarr workflow.
+// Return the earliest of digitalRelease/physicalRelease/inCinemas that falls
+// inside the [start, end] look-ahead window, or null if none qualify (#87).
 function pickRadarrReleaseDate(item, start, end) {
-  const candidates = [item.digitalRelease, item.physicalRelease]
+  const candidates = [item.digitalRelease, item.physicalRelease, item.inCinemas]
     .filter(Boolean)
     .map(d => ({ raw: d, ts: new Date(d).getTime() }))
     .filter(({ ts }) => Number.isFinite(ts) && ts >= start.getTime() && ts <= end.getTime());

--- a/server/test/comingSoon.test.js
+++ b/server/test/comingSoon.test.js
@@ -198,7 +198,7 @@ test('Radarr falls back to digitalRelease when physicalRelease is outside the wi
   assert.equal(item.releaseDate, '2026-06-01T00:00:00Z');
 });
 
-test('inCinemas is not used as a fallback', async () => {
+test('Radarr falls back to inCinemas when only inCinemas is set and within window (#87)', async () => {
   const fetchImpl = async (url) => {
     if (url.includes('radarr')) {
       return response([
@@ -207,6 +207,107 @@ test('inCinemas is not used as a fallback', async () => {
           title: 'Theatrical Only',
           inCinemas: '2026-05-20T00:00:00Z',
           hasFile: false,
+        },
+      ]);
+    }
+    return response([]);
+  };
+
+  const items = await fetchComingSoonItems({
+    config: {
+      comingSoon: {
+        radarrUrl: 'http://radarr.local:7878',
+        radarrApiKey: 'rk',
+        moviesCount: 5,
+        showsCount: 5,
+        lookaheadDays: 90,
+      },
+    },
+    fetchImpl,
+    now: new Date('2026-05-02T12:00:00Z'),
+  });
+
+  assert.equal(items.length, 1);
+  assert.equal(items[0].title, 'Theatrical Only');
+  assert.equal(items[0].releaseDate, '2026-05-20T00:00:00Z');
+});
+
+test('Radarr ignores inCinemas when it falls outside the look-ahead window (#87)', async () => {
+  const fetchImpl = async (url) => {
+    if (url.includes('radarr')) {
+      return response([
+        {
+          id: 35,
+          title: 'Cinema Far Future',
+          inCinemas: '2027-06-01T00:00:00Z',
+          hasFile: false,
+        },
+      ]);
+    }
+    return response([]);
+  };
+
+  const items = await fetchComingSoonItems({
+    config: {
+      comingSoon: {
+        radarrUrl: 'http://radarr.local:7878',
+        radarrApiKey: 'rk',
+        moviesCount: 5,
+        showsCount: 5,
+        lookaheadDays: 90,
+      },
+    },
+    fetchImpl,
+    now: new Date('2026-05-02T12:00:00Z'),
+  });
+
+  assert.deepEqual(items, []);
+});
+
+test('Radarr picks the earliest of digital/physical/inCinemas inside the window (#87)', async () => {
+  const fetchImpl = async (url) => {
+    if (url.includes('radarr')) {
+      return response([
+        {
+          id: 36,
+          title: 'All Three Dates',
+          inCinemas: '2026-05-15T00:00:00Z',
+          digitalRelease: '2026-07-01T00:00:00Z',
+          physicalRelease: '2026-06-15T00:00:00Z',
+          hasFile: false,
+        },
+      ]);
+    }
+    return response([]);
+  };
+
+  const [item] = await fetchComingSoonItems({
+    config: {
+      comingSoon: {
+        radarrUrl: 'http://radarr.local:7878',
+        radarrApiKey: 'rk',
+        moviesCount: 5,
+        showsCount: 5,
+        lookaheadDays: 90,
+      },
+    },
+    fetchImpl,
+    now: new Date('2026-05-02T12:00:00Z'),
+  });
+
+  assert.equal(item.title, 'All Three Dates');
+  assert.equal(item.releaseDate, '2026-05-15T00:00:00Z');
+});
+
+test('Radarr inCinemas movie with hasFile=true is still excluded (#87)', async () => {
+  const fetchImpl = async (url) => {
+    if (url.includes('radarr')) {
+      return response([
+        {
+          id: 37,
+          title: 'Cinema But Downloaded',
+          inCinemas: '2026-05-20T00:00:00Z',
+          hasFile: true,
         },
       ]);
     }

--- a/www/now_showing.html
+++ b/www/now_showing.html
@@ -4056,12 +4056,12 @@
       const lookaheadDays = Number(COMING_SOON.lookaheadDays);
       const lookahead = Number.isFinite(lookaheadDays) && lookaheadDays >= 1 ? lookaheadDays : 90;
       const end = new Date(Date.now() + lookahead * 86400000);
-      // #85: accept digitalRelease OR physicalRelease (not inCinemas), pick the
+      // #87: accept digitalRelease, physicalRelease, or inCinemas; pick the
       // earliest qualifying date inside the window.
       const pickReleaseDate = (m) => {
         const startMs = start.getTime();
         const endMs = end.getTime();
-        const candidates = [m.digitalRelease, m.physicalRelease]
+        const candidates = [m.digitalRelease, m.physicalRelease, m.inCinemas]
           .filter(Boolean)
           .map(d => ({ raw: d, ts: new Date(d).getTime() }))
           .filter(({ ts }) => Number.isFinite(ts) && ts >= startMs && ts <= endMs)


### PR DESCRIPTION
## Summary
- Radarr Coming Soon eligibility now also accepts `inCinemas` as a release-date fallback alongside `digitalRelease` and `physicalRelease`.
- A movie with only `inCinemas` populated now appears in Coming Soon when monitored, not yet downloaded, and the cinema date is inside the configured look-ahead window.
- When multiple dates are populated, the earliest qualifying date inside the window wins — matching the existing digital/physical tie-break.
- `hasFile === false` filtering and monitored/unmonitored handling are unchanged, so already-imported movies still drop out and unmonitored ones stay excluded.

Closes #87.

## Files changed
- `server/src/comingSoon.js` — `pickRadarrReleaseDate` now considers `inCinemas` in addition to digital/physical; comment updated.
- `server/test/comingSoon.test.js` — replaced the "inCinemas is not used" negative test with four new cases: cinema-only inside the window qualifies, cinema outside the window is ignored, earliest of digital/physical/cinema wins, and `hasFile=true` cinema movies are still excluded.
- `www/now_showing.html` — frontend `pickReleaseDate` mirrors the server change.
- `README.md`, `addons/plex-now-showing/DOCS.md`, `addons/plex-now-showing/translations/en.yaml` — docs/UI text now mention `inCinemas` as one of the qualifying dates.
- `addons/plex-now-showing/CHANGELOG.md` — new **Unreleased** entry; the 2.1.1 entry no longer claims `inCinemas` is "intentionally not used".

## Test plan
- [x] `cd server && node --test test/` — all 142 tests pass (including 4 new `#87` cases in `test/comingSoon.test.js`).
- [x] Verified the new selection logic preserves the look-ahead window: `inCinemas` more than `lookaheadDays` in the future is filtered out (see "Radarr ignores inCinemas when it falls outside the look-ahead window" test).
- [x] Verified `hasFile === false` still gates: a movie with `inCinemas` set and `hasFile=true` is excluded.
- [ ] Manual: load Coming Soon against a real Radarr instance with at least one cinema-only release inside the window — pending operator verification.

## Caveats
- Radarr's `unmonitored=false` calendar flag (already in the request URL) is what enforces the monitored-only constraint; this PR does not change that behaviour, so unmonitored cinema-only movies still won't appear.
- No release was bumped — this is just the fix landing on `main` per the issue's guidance not to publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)