### PR TITLE
docs(addon): surface 2.1.2 and 2.1.1 highlights on add-on page

### DIFF
--- a/addons/plex-now-showing/README.md
+++ b/addons/plex-now-showing/README.md
@@ -4,6 +4,25 @@ Cinema-style now-playing and coming-soon kiosk for Home Assistant, installed
 straight from the Home Assistant add-on store. One click, no long-lived access
 token, no Docker command line.
 
+## What's new in 2.1.2
+
+- Radarr Coming Soon eligibility now also accepts `inCinemas` as a release-date
+  fallback alongside `digitalRelease` and `physicalRelease`. When more than one
+  date is populated, the earliest qualifying date inside the configured
+  look-ahead window wins.
+- Already-downloaded movies still drop out (`hasFile === false` and monitored
+  filtering are unchanged), and the configurable
+  `coming_soon_lookahead_days` window is still respected.
+
+## What's new in 2.1.1
+
+- Configurable Coming Soon look-ahead via `coming_soon_lookahead_days`
+  (1–365 days, default **90**), so Coming Soon can reach further out without
+  changing existing installs.
+- Radarr eligibility began including `physicalRelease` alongside
+  `digitalRelease`, with the earliest qualifying date inside the window
+  selected.
+
 ## What's new in 2.1.0
 
 - The add-on is now presented as **Now Showing**.


### PR DESCRIPTION
## Summary

The Home Assistant add-on store renders `addons/plex-now-showing/README.md` on the add-on's page. Its "What's new" section was still pinned to **2.1.0**, hiding the Coming Soon improvements shipped in 2.1.1 and 2.1.2.

This PR adds concise sections above the existing 2.1.0 block.

### 2.1.2 highlights
- `inCinemas` is now accepted as a Coming Soon release-date fallback alongside `digitalRelease` and `physicalRelease`.
- When more than one date is populated, the **earliest qualifying date** inside the configured look-ahead window wins.
- `hasFile === false` and monitored filtering are unchanged, so already-downloaded movies still drop out.
- The configurable `coming_soon_lookahead_days` window is still respected.

### 2.1.1 highlights
- Configurable Coming Soon look-ahead via `coming_soon_lookahead_days` (1–365 days, default **90**).
- `physicalRelease` joined `digitalRelease` as an eligible Radarr release date, with the earliest qualifying date inside the window selected.

The 2.1.0 block is left intact so users upgrading from older installs still see the original release notes.

## Files changed
- `addons/plex-now-showing/README.md` — added "What's new in 2.1.2" and "What's new in 2.1.1" sections above the existing 2.1.0 section.

## Note on already-published v2.1.2
Home Assistant fetches add-on README/CHANGELOG/DOCS from the published repository ref. Since the **already-tagged v2.1.2 release** was cut from a commit that did not contain this README update, HA installations pinned to v2.1.2 will continue to show the old "What's new in 2.1.0" text **until another release is cut** (e.g. 2.1.3 or a re-tag). This PR intentionally does **not** force-push or move existing tags. The CHANGELOG.md already contains the 2.1.2 entry, so users using the add-on store's Changelog tab on `main`/HEAD will see the change immediately.

## Testing
- [x] Manual diff review of the new README content.
- [x] No add-on `config.yaml` changes, so the existing `Lint add-on config` workflow is unaffected.
- [x] No code paths touched.