### PR TITLE
feat: prefer home release date for Coming Soon footer; label cinema-only

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,7 +358,7 @@ useful as a Fully Kiosk screensaver URL or as a target for HA automations.
 | Show count | `coming_soon_shows_count` | `COMING_SOON_SHOWS_COUNT` | `comingSoonShowsCount` | `0` to `50` |
 | Cycle interval | `coming_soon_cycle_interval` | `COMING_SOON_CYCLE_INTERVAL` | `comingSoonCycleInterval` | Seconds, `2` to `300` |
 | Days offset | `coming_soon_days_offset` | `COMING_SOON_DAYS_OFFSET` | `comingSoonDaysOffset` | Include recent past releases |
-| Look-ahead days | `coming_soon_lookahead_days` | `COMING_SOON_LOOKAHEAD_DAYS` | `comingSoonLookaheadDays` | Forward window, default `90`, range `1`–`365`. Radarr matches `digitalRelease`, `physicalRelease`, or `inCinemas` (earliest qualifying date wins) |
+| Look-ahead days | `coming_soon_lookahead_days` | `COMING_SOON_LOOKAHEAD_DAYS` | `comingSoonLookaheadDays` | Forward window, default `90`, range `1`–`365`. Radarr eligibility accepts `digitalRelease`, `physicalRelease`, or `inCinemas`. The displayed footer date prefers the earliest qualifying home-release date; cinema-only items are labelled `In cinemas: <date>` so the footer is not mistaken for home availability. |
 | Image type | `coming_soon_image_type` | `COMING_SOON_IMAGE_TYPE` | `comingSoonImageType` | `poster`, `fanart` |
 
 ### Using Now Showing And Coming Soon Together

--- a/server/src/comingSoon.js
+++ b/server/src/comingSoon.js
@@ -40,20 +40,24 @@ async function fetchRadarrItems({ config, fetchImpl, start, end, now }) {
   }
   const data = await resp.json();
   return (Array.isArray(data) ? data : [])
-    .map(item => ({ item, releaseDate: pickRadarrReleaseDate(item, start, end) }))
-    .filter(({ item, releaseDate }) => !item.hasFile && releaseDate)
-    .sort((a, b) => new Date(a.releaseDate) - new Date(b.releaseDate))
-    .map(({ item, releaseDate }) => {
+    .map(item => ({ item, picked: pickRadarrReleaseDate(item, start, end) }))
+    .filter(({ item, picked }) => !item.hasFile && picked)
+    .sort((a, b) => new Date(a.picked.releaseDate) - new Date(b.picked.releaseDate))
+    .map(({ item, picked }) => {
       const id = item.id || item.movieId || '';
       const genres = Array.isArray(item.genres) ? item.genres.filter(Boolean).join(' / ') : '';
+      const { releaseDate, releaseType } = picked;
+      const baseLabel = formatReleaseDate(releaseDate);
+      const releaseLabel = releaseType === 'cinema' && baseLabel ? `In cinemas: ${baseLabel}` : baseLabel;
       return {
         type: 'movie',
         typeLabel: 'Movie',
         title: item.title || 'Untitled Movie',
         subtitle: [item.year, genres].filter(Boolean).join(' / '),
         releaseDate,
+        releaseType,
         countdown: formatCountdown(releaseDate, now),
-        releaseLabel: formatReleaseDate(releaseDate),
+        releaseLabel,
         overview: item.overview || '',
         posterUrl: imageUrl(item.images, 'poster'),
         fanartUrl: imageUrl(item.images, 'fanart'),
@@ -63,16 +67,45 @@ async function fetchRadarrItems({ config, fetchImpl, start, end, now }) {
     });
 }
 
-// Return the earliest of digitalRelease/physicalRelease/inCinemas that falls
-// inside the [start, end] look-ahead window, or null if none qualify (#87).
+// Pick the visible release date for a Radarr movie.
+//
+// Eligibility (#87): inCinemas keeps a monitored, not-yet-downloaded movie in
+// the rotation when no home-release date is known.
+//
+// Display preference (#90): home-release dates (digitalRelease /
+// physicalRelease) are clearer for a Coming Soon footer because the rotation
+// is primarily a home-library availability display. We pick the earliest
+// qualifying home date; only when neither qualifies do we fall back to
+// inCinemas, and we tag releaseType: 'cinema' so the UI can label it as a
+// theatrical date rather than imply digital/physical availability.
+//
+// TMDB feasibility note: when Radarr lacks digital/physical metadata, TMDB's
+// /movie/{id}/release_dates endpoint exposes typed release dates (theatrical,
+// digital, physical, etc.) per region and could be used as a fallback. That
+// would require a TMDB API token, configurable region, and result caching, so
+// it's intentionally out of scope here. IMDb has no equivalent simple public
+// API and is not a practical alternative.
 function pickRadarrReleaseDate(item, start, end) {
-  const candidates = [item.digitalRelease, item.physicalRelease, item.inCinemas]
-    .filter(Boolean)
-    .map(d => ({ raw: d, ts: new Date(d).getTime() }))
-    .filter(({ ts }) => Number.isFinite(ts) && ts >= start.getTime() && ts <= end.getTime());
-  if (!candidates.length) return null;
-  candidates.sort((a, b) => a.ts - b.ts);
-  return candidates[0].raw;
+  const startMs = start.getTime();
+  const endMs = end.getTime();
+  const inWindow = (raw) => {
+    if (!raw) return null;
+    const ts = new Date(raw).getTime();
+    return Number.isFinite(ts) && ts >= startMs && ts <= endMs ? ts : null;
+  };
+  const homeCandidates = [
+    { raw: item.digitalRelease, ts: inWindow(item.digitalRelease) },
+    { raw: item.physicalRelease, ts: inWindow(item.physicalRelease) },
+  ].filter(c => c.ts !== null);
+  if (homeCandidates.length) {
+    homeCandidates.sort((a, b) => a.ts - b.ts);
+    return { releaseDate: homeCandidates[0].raw, releaseType: 'home' };
+  }
+  const cinemaTs = inWindow(item.inCinemas);
+  if (cinemaTs !== null) {
+    return { releaseDate: item.inCinemas, releaseType: 'cinema' };
+  }
+  return null;
 }
 
 async function fetchSonarrItems({ config, fetchImpl, start, end, now }) {
@@ -113,6 +146,7 @@ async function fetchSonarrItems({ config, fetchImpl, start, end, now }) {
         title: series.title || item.title || 'Untitled Series',
         subtitle: episodeLabel,
         releaseDate,
+        releaseType: 'air',
         countdown: formatCountdown(releaseDate, now),
         releaseLabel: formatReleaseDate(releaseDate),
         overview: item.overview || '',

--- a/server/test/comingSoon.test.js
+++ b/server/test/comingSoon.test.js
@@ -230,6 +230,7 @@ test('Radarr falls back to inCinemas when only inCinemas is set and within windo
   assert.equal(items.length, 1);
   assert.equal(items[0].title, 'Theatrical Only');
   assert.equal(items[0].releaseDate, '2026-05-20T00:00:00Z');
+  assert.equal(items[0].releaseType, 'cinema');
 });
 
 test('Radarr ignores inCinemas when it falls outside the look-ahead window (#87)', async () => {
@@ -264,7 +265,7 @@ test('Radarr ignores inCinemas when it falls outside the look-ahead window (#87)
   assert.deepEqual(items, []);
 });
 
-test('Radarr picks the earliest of digital/physical/inCinemas inside the window (#87)', async () => {
+test('Radarr prefers earliest qualifying home date even when inCinemas is earlier (#90)', async () => {
   const fetchImpl = async (url) => {
     if (url.includes('radarr')) {
       return response([
@@ -296,7 +297,115 @@ test('Radarr picks the earliest of digital/physical/inCinemas inside the window 
   });
 
   assert.equal(item.title, 'All Three Dates');
-  assert.equal(item.releaseDate, '2026-05-15T00:00:00Z');
+  // Cinema date is earliest, but display prefers the earliest home date.
+  assert.equal(item.releaseDate, '2026-06-15T00:00:00Z');
+  assert.equal(item.releaseType, 'home');
+  assert.equal(item.releaseLabel, '15th of June 2026');
+});
+
+test('Radarr labels cinema-only fallback so the footer is not misleading (#90)', async () => {
+  const fetchImpl = async (url) => {
+    if (url.includes('radarr')) {
+      return response([
+        {
+          id: 50,
+          title: 'Theatrical Only',
+          inCinemas: '2026-05-20T00:00:00Z',
+          hasFile: false,
+        },
+      ]);
+    }
+    return response([]);
+  };
+
+  const [item] = await fetchComingSoonItems({
+    config: {
+      comingSoon: {
+        radarrUrl: 'http://radarr.local:7878',
+        radarrApiKey: 'rk',
+        moviesCount: 5,
+        showsCount: 5,
+        lookaheadDays: 90,
+      },
+    },
+    fetchImpl,
+    now: new Date('2026-05-02T12:00:00Z'),
+  });
+
+  assert.equal(item.releaseType, 'cinema');
+  assert.equal(item.releaseDate, '2026-05-20T00:00:00Z');
+  assert.equal(item.releaseLabel, 'In cinemas: 20th of May 2026');
+});
+
+test('Radarr falls back to in-window cinema when home dates are out of window (#90)', async () => {
+  const fetchImpl = async (url) => {
+    if (url.includes('radarr')) {
+      return response([
+        {
+          id: 51,
+          title: 'Cinema Now Home Later',
+          inCinemas: '2026-05-25T00:00:00Z',
+          digitalRelease: '2027-06-01T00:00:00Z',
+          physicalRelease: '2027-08-01T00:00:00Z',
+          hasFile: false,
+        },
+      ]);
+    }
+    return response([]);
+  };
+
+  const [item] = await fetchComingSoonItems({
+    config: {
+      comingSoon: {
+        radarrUrl: 'http://radarr.local:7878',
+        radarrApiKey: 'rk',
+        moviesCount: 5,
+        showsCount: 5,
+        lookaheadDays: 90,
+      },
+    },
+    fetchImpl,
+    now: new Date('2026-05-02T12:00:00Z'),
+  });
+
+  assert.equal(item.releaseType, 'cinema');
+  assert.equal(item.releaseDate, '2026-05-25T00:00:00Z');
+  assert.equal(item.releaseLabel, 'In cinemas: 25th of May 2026');
+});
+
+test('Radarr uses home date even when cinema is in-window and home is also in-window but later (#90)', async () => {
+  const fetchImpl = async (url) => {
+    if (url.includes('radarr')) {
+      return response([
+        {
+          id: 52,
+          title: 'Home Later Same Window',
+          inCinemas: '2026-05-15T00:00:00Z',
+          digitalRelease: '2026-07-20T00:00:00Z',
+          hasFile: false,
+        },
+      ]);
+    }
+    return response([]);
+  };
+
+  const [item] = await fetchComingSoonItems({
+    config: {
+      comingSoon: {
+        radarrUrl: 'http://radarr.local:7878',
+        radarrApiKey: 'rk',
+        moviesCount: 5,
+        showsCount: 5,
+        lookaheadDays: 90,
+      },
+    },
+    fetchImpl,
+    now: new Date('2026-05-02T12:00:00Z'),
+  });
+
+  assert.equal(item.releaseType, 'home');
+  assert.equal(item.releaseDate, '2026-07-20T00:00:00Z');
+  assert.equal(item.releaseLabel, '20th of July 2026');
 });
 
 test('Radarr inCinemas movie with hasFile=true is still excluded (#87)', async () => {

--- a/www/now_showing.html
+++ b/www/now_showing.html
@@ -4056,36 +4056,56 @@
       const lookaheadDays = Number(COMING_SOON.lookaheadDays);
       const lookahead = Number.isFinite(lookaheadDays) && lookaheadDays >= 1 ? lookaheadDays : 90;
       const end = new Date(Date.now() + lookahead * 86400000);
-      // #87: accept digitalRelease, physicalRelease, or inCinemas; pick the
-      // earliest qualifying date inside the window.
+      // Eligibility (#87): inCinemas keeps a monitored, not-downloaded movie
+      // in the rotation when no home-release date is known.
+      // Display preference (#90): prefer the earliest qualifying home-release
+      // date (digitalRelease / physicalRelease); only fall back to inCinemas
+      // when neither qualifies, and tag it so the UI labels it as a cinema
+      // date rather than imply home availability.
       const pickReleaseDate = (m) => {
         const startMs = start.getTime();
         const endMs = end.getTime();
-        const candidates = [m.digitalRelease, m.physicalRelease, m.inCinemas]
-          .filter(Boolean)
-          .map(d => ({ raw: d, ts: new Date(d).getTime() }))
-          .filter(({ ts }) => Number.isFinite(ts) && ts >= startMs && ts <= endMs)
-          .sort((a, b) => a.ts - b.ts);
-        return candidates.length ? candidates[0].raw : null;
+        const inWindow = (raw) => {
+          if (!raw) return null;
+          const ts = new Date(raw).getTime();
+          return Number.isFinite(ts) && ts >= startMs && ts <= endMs ? ts : null;
+        };
+        const home = [
+          { raw: m.digitalRelease, ts: inWindow(m.digitalRelease) },
+          { raw: m.physicalRelease, ts: inWindow(m.physicalRelease) },
+        ].filter(c => c.ts !== null);
+        if (home.length) {
+          home.sort((a, b) => a.ts - b.ts);
+          return { releaseDate: home[0].raw, releaseType: 'home' };
+        }
+        const cinemaTs = inWindow(m.inCinemas);
+        if (cinemaTs !== null) return { releaseDate: m.inCinemas, releaseType: 'cinema' };
+        return null;
       };
       return (Array.isArray(items) ? items : [])
-        .map(m => ({ m, releaseDate: pickReleaseDate(m) }))
-        .filter(({ m, releaseDate }) => !m.hasFile && releaseDate)
-        .sort((a, b) => new Date(a.releaseDate) - new Date(b.releaseDate))
-        .map(({ m, releaseDate }) => ({
-          type: 'movie',
-          typeLabel: 'Movie',
-          title: m.title || 'Untitled Movie',
-          subtitle: [m.year, Array.isArray(m.genres) ? m.genres.join(' / ') : ''].filter(Boolean).join(' / '),
-          releaseDate,
-          countdown: formatComingSoonCountdown(releaseDate),
-          releaseLabel: formatComingSoonDate(releaseDate),
-          overview: m.overview || '',
-          posterUrl: coverImage(m.images, 'poster'),
-          fanartUrl: coverImage(m.images, 'fanart'),
-          localPosterUrl: m.id ? `${base}/api/v3/MediaCover/${m.id}/poster.jpg?apikey=${encodeURIComponent(COMING_SOON.radarrApiKey)}` : '',
-          localFanartUrl: m.id ? `${base}/api/v3/MediaCover/${m.id}/fanart.jpg?apikey=${encodeURIComponent(COMING_SOON.radarrApiKey)}` : '',
-        }));
+        .map(m => ({ m, picked: pickReleaseDate(m) }))
+        .filter(({ m, picked }) => !m.hasFile && picked)
+        .sort((a, b) => new Date(a.picked.releaseDate) - new Date(b.picked.releaseDate))
+        .map(({ m, picked }) => {
+          const { releaseDate, releaseType } = picked;
+          const baseLabel = formatComingSoonDate(releaseDate);
+          const releaseLabel = releaseType === 'cinema' && baseLabel ? `In cinemas: ${baseLabel}` : baseLabel;
+          return {
+            type: 'movie',
+            typeLabel: 'Movie',
+            title: m.title || 'Untitled Movie',
+            subtitle: [m.year, Array.isArray(m.genres) ? m.genres.join(' / ') : ''].filter(Boolean).join(' / '),
+            releaseDate,
+            releaseType,
+            countdown: formatComingSoonCountdown(releaseDate),
+            releaseLabel,
+            overview: m.overview || '',
+            posterUrl: coverImage(m.images, 'poster'),
+            fanartUrl: coverImage(m.images, 'fanart'),
+            localPosterUrl: m.id ? `${base}/api/v3/MediaCover/${m.id}/poster.jpg?apikey=${encodeURIComponent(COMING_SOON.radarrApiKey)}` : '',
+            localFanartUrl: m.id ? `${base}/api/v3/MediaCover/${m.id}/fanart.jpg?apikey=${encodeURIComponent(COMING_SOON.radarrApiKey)}` : '',
+          };
+        });
     }
 
     function mapSonarrComingSoon(items) {
@@ -4152,6 +4172,7 @@
         comingSoon: true,
         typeLabel: item.typeLabel || (item.type === 'tv' ? 'TV' : 'Movie'),
         releaseLabel: item.releaseLabel || '',
+        releaseType: item.releaseType || '',
         countdown: item.countdown || '',
       };
     }


### PR DESCRIPTION
## Summary
Closes #90.

After PR #88 added `inCinemas` as a Coming Soon eligibility fallback, titles with only theatrical metadata started appearing in the rotation but the footer date implied home (digital/physical) availability — which is misleading for a Coming Soon screen that is primarily a home-library availability display.

This PR keeps the eligibility behaviour from #87/#88 but separates *eligibility* from the *visible* date:

- **Eligibility** (unchanged): a Radarr movie is still eligible if `digitalRelease`, `physicalRelease`, or `inCinemas` falls inside the configured look-ahead window AND `hasFile === false`.
- **Display** (new): the visible footer/release date now prefers the earliest qualifying home-release date (`digitalRelease` / `physicalRelease`). Only when neither home date qualifies do we fall back to `inCinemas`, and the item is tagged `releaseType: 'cinema'` with a label prefix `In cinemas: <date>` so the footer is not mistaken for a home-availability date.
- `hasFile` filtering, monitored filtering, and the configurable look-ahead window are unchanged.

Both paths get the same treatment so HACS-only and server mode stay consistent:
- `server/src/comingSoon.js` — Node-side mapping for HACS+server mode (`/api/coming-soon`).
- `www/now_showing.html` — direct Radarr fetch path for HACS-only mode.

### TMDB / IMDb feasibility (investigation, not implemented)
Per the issue's metadata-fallback question:
- **TMDB** does expose a usable `release_dates` endpoint (`/movie/{tmdb_id}/release_dates`) with typed entries (theatrical, digital, physical, …) per region. Using it as a fallback when Radarr lacks digital/physical metadata would require a TMDB API token, configurable region, a TMDB id (Radarr already exposes `tmdbId` per movie), and result caching to avoid hammering the API. It's intentionally out of scope here so this PR stays focused on display labelling, but a code comment in `pickRadarrReleaseDate` notes the path so a follow-up can pick it up.
- **IMDb** has no simple official public API comparable to TMDB's. It is not a practical fallback for an add-on of this size.

If a follow-up wires TMDB in, the natural touch points are: a new `tmdbApiKey` / `tmdbRegion` config, a small in-memory cache keyed by `tmdbId`, and a third source merged into `pickRadarrReleaseDate` after the Radarr home dates but before the cinema fallback.

## Files changed
- `server/src/comingSoon.js` — split eligibility vs. display in `pickRadarrReleaseDate`; tag `releaseType` and prefix cinema-only `releaseLabel`. Sonarr items get `releaseType: 'air'` for parity.
- `www/now_showing.html` — same logic in the frontend `mapRadarrComingSoon` path; `releaseType` propagated through `buildComingSoonMediaData`.
- `server/test/comingSoon.test.js` — replaces the previous "earliest of all three wins" test with #90-aligned behaviour, plus new coverage for the cinema label, home-out-of-window/cinema-in-window fallback, and home-later-than-cinema preference. The existing cinema-only test now also asserts `releaseType: 'cinema'`. `hasFile` exclusion test is preserved.
- `README.md` — clarifies that the visible footer prefers home dates and labels cinema-only items as `In cinemas: <date>`.

## Testing
- `node --test server/test/*.js` — **145/145 pass** (includes 14 Coming Soon tests, of which 4 are new for #90 and 1 was rewritten).

## Caveats / out of scope
- No TMDB/IMDb integration in this PR — feasibility documented above and as an inline comment near `pickRadarrReleaseDate`.
- No version bump or release prep — coordinating with PR #89 (docs-only addon page update) and any future release commit.
- Sonarr items keep their existing single-source date (`airDate` / `airDateUtc`); no behaviour change there beyond the new `releaseType: 'air'` tag, which is currently unused by the UI but kept consistent for any future per-type styling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)