### PR TITLE
feat: optional TMDB fallback for Coming Soon release dates (#91)

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,6 +360,9 @@ useful as a Fully Kiosk screensaver URL or as a target for HA automations.
 | Days offset | `coming_soon_days_offset` | `COMING_SOON_DAYS_OFFSET` | `comingSoonDaysOffset` | Include recent past releases |
 | Look-ahead days | `coming_soon_lookahead_days` | `COMING_SOON_LOOKAHEAD_DAYS` | `comingSoonLookaheadDays` | Forward window, default `90`, range `1`–`365`. Radarr eligibility accepts `digitalRelease`, `physicalRelease`, or `inCinemas`. The displayed footer date prefers the earliest qualifying home-release date; cinema-only items are labelled `In cinemas: <date>` so the footer is not mistaken for home availability. |
 | Image type | `coming_soon_image_type` | `COMING_SOON_IMAGE_TYPE` | `comingSoonImageType` | `poster`, `fanart` |
+| TMDB API key | `tmdb_api_key` | `TMDB_API_KEY` | Server only | Optional. When set, fills in digital/physical/theatrical release dates Radarr's calendar is missing. Both v3 keys and v4 read-tokens work. Empty disables the fallback completely. |
+| TMDB region | `tmdb_region` | `TMDB_REGION` | Server only | ISO 3166-1 country code for region-specific dates. Default `AU`. |
+| TMDB cache TTL | `tmdb_ttl_ms` | `TMDB_TTL_MS` | Server only | Cache window for TMDB lookups (ms). Default `21600000` (6 h). |
 
 ### Using Now Showing And Coming Soon Together
 

--- a/addons/plex-now-showing/DOCS.md
+++ b/addons/plex-now-showing/DOCS.md
@@ -45,6 +45,9 @@ probe of `/api`) and switches to `/api/state`. Plex-only metadata calls use
 | `coming_soon_days_offset` | `0` | Include releases from this many days in the past. |
 | `coming_soon_lookahead_days` | `90` | Forward window (days) for upcoming releases. Radarr considers `digitalRelease`, `physicalRelease`, and `inCinemas`; the earliest qualifying date inside the window wins. |
 | `coming_soon_image_type` | `poster` | `poster` or `fanart`. |
+| `tmdb_api_key` | _empty_ | Optional TMDB API key (v3 or v4). When set, fills in digital/physical/theatrical release dates Radarr's calendar is missing. Empty disables the fallback completely. |
+| `tmdb_region` | `AU` | ISO 3166-1 country code used to select region-specific release dates from TMDB. Falls back to whatever region TMDB lists first if there's no match. |
+| `tmdb_ttl_ms` | `21600000` | TMDB lookup cache TTL (ms). Default 6 h. |
 | `proxy_secret` | _empty_ | If set, requests to `/api/*` must carry `X-Proxy-Secret`. |
 | `allowed_origins` | `[]` | Comma-joined allowlist for the `Origin` header on `/api/*`. Leave empty for Ingress-only. |
 | `switcher_enabled` | `false` | Turn on the built-in Fully Kiosk auto-switcher. Use **this or the Blueprint (#47)** — not both. |
@@ -126,6 +129,32 @@ Assistant Blueprint import/download flow and can generate the equivalent
 add-on options / Docker env for the built-in Fully Kiosk switcher. The switcher
 itself runs server-side, so paste the generated values into the add-on options
 or Docker `.env`, then restart the add-on/container.
+
+### TMDB enrichment for Coming Soon (#91)
+
+Radarr's calendar sometimes returns a movie with only `inCinemas` (or no
+release dates at all in the look-ahead window). When that happens, the
+Coming Soon footer either falls back to a clearly labelled cinema date or
+drops the title entirely.
+
+Setting `tmdb_api_key` (and optionally `tmdb_region`) tells the server to
+ask The Movie Database for the missing dates. Radarr stays the primary
+source — TMDB is only consulted when Radarr lacks usable home-release
+metadata, and any TMDB digital/physical date that lands inside the
+look-ahead window upgrades the entry to a `home` release type. If only a
+TMDB theatrical date is available it's used as a labelled cinema fallback.
+
+Notes:
+
+- The kiosk works exactly as before with `tmdb_api_key` left blank — no
+  extra API calls are made, no warnings are logged.
+- Both v3 keys and v4 read-tokens are accepted; paste whichever you have.
+- Movies are matched by Radarr's `tmdbId` (always present in modern
+  Radarr installs) and fall back to `imdbId` via TMDB's `/find` endpoint.
+  Title-only matching is deliberately avoided.
+- Lookups are cached for `tmdb_ttl_ms` (default 6 h). Auth, rate-limit, and
+  network failures are logged and silently ignored — Coming Soon never
+  breaks because TMDB is unreachable.
 
 ### Using Now Showing and Coming Soon together
 

--- a/addons/plex-now-showing/config.yaml
+++ b/addons/plex-now-showing/config.yaml
@@ -64,6 +64,12 @@ options:
   coming_soon_days_offset: 0
   coming_soon_lookahead_days: 90
   coming_soon_image_type: poster
+  # Optional TMDB enrichment (#91) — fills in digital/physical/theatrical
+  # release dates Radarr's calendar doesn't have. Disabled by default; leave
+  # tmdb_api_key blank to keep Coming Soon fully Radarr-driven.
+  tmdb_api_key: ""
+  tmdb_region: AU
+  tmdb_ttl_ms: 21600000
   proxy_secret: ""
   allowed_origins: []
   # Fully Kiosk auto-switcher (#48) — disabled by default. Enable this OR the
@@ -127,6 +133,9 @@ schema:
   coming_soon_days_offset: "int(0,365)"
   coming_soon_lookahead_days: "int(1,365)"
   coming_soon_image_type: "list(poster|fanart)"
+  tmdb_api_key: "password?"
+  tmdb_region: "match(^[A-Za-z]{2}$)?"
+  tmdb_ttl_ms: "int(10000,86400000)"
   proxy_secret: "password?"
   allowed_origins:
     - "url?"

--- a/addons/plex-now-showing/rootfs/etc/services.d/plex-now-showing/run
+++ b/addons/plex-now-showing/rootfs/etc/services.d/plex-now-showing/run
@@ -52,6 +52,11 @@ export_opt COMING_SOON_CYCLE_INTERVAL coming_soon_cycle_interval
 export_opt COMING_SOON_DAYS_OFFSET coming_soon_days_offset
 export_opt COMING_SOON_LOOKAHEAD_DAYS coming_soon_lookahead_days
 export_opt COMING_SOON_IMAGE_TYPE  coming_soon_image_type
+# TMDB enrichment (#91). All optional; an empty TMDB_API_KEY disables the
+# fallback path completely (no API calls, no warnings).
+export_opt TMDB_API_KEY            tmdb_api_key
+export_opt TMDB_REGION             tmdb_region
+export_opt TMDB_TTL_MS             tmdb_ttl_ms
 
 # allowed_origins is a list → join with commas for the server's parser.
 if bashio::config.has_value 'allowed_origins'; then
@@ -113,6 +118,7 @@ bashio::log.info "Coming Soon cache TTL:    ${COMING_SOON_TTL_MS:-900000}"
 bashio::log.info "Coming Soon title:        ${COMING_SOON_TITLE:-Coming Soon}"
 bashio::log.info "Radarr configured:        $([[ -n "${RADARR_URL}" && -n "${RADARR_API_KEY}" ]] && echo yes || echo no)"
 bashio::log.info "Sonarr configured:        $([[ -n "${SONARR_URL}" && -n "${SONARR_API_KEY}" ]] && echo yes || echo no)"
+bashio::log.info "TMDB enrichment:          $([[ -n "${TMDB_API_KEY}" ]] && echo "yes (region=${TMDB_REGION:-AU})" || echo no)"
 bashio::log.info "Proxy secret:             $([[ -n "${PROXY_SECRET}" ]] && echo set || echo unset)"
 bashio::log.info "Allowed origins:          ${ALLOWED_ORIGINS:-<any (ingress-only)>}"
 bashio::log.info "Visual progress bar:      ${VISUAL_PROGRESS_BAR:-false}"

--- a/addons/plex-now-showing/translations/en.yaml
+++ b/addons/plex-now-showing/translations/en.yaml
@@ -94,6 +94,26 @@ configuration:
   coming_soon_image_type:
     name: Coming Soon image type
     description: Use portrait poster art or landscape fanart/backdrop art.
+  tmdb_api_key:
+    name: TMDB API key (optional)
+    description: >-
+      Optional The Movie Database API key used to fill in release dates
+      Radarr's calendar is missing. Both v3 keys and v4 read-tokens work.
+      Leave empty to keep Coming Soon fully Radarr-driven; nothing else
+      changes if you do. Sign up at https://www.themoviedb.org/settings/api.
+  tmdb_region:
+    name: TMDB region
+    description: >-
+      ISO 3166-1 country code (e.g. AU, US, GB) used to pick which regional
+      release dates TMDB returns. Defaults to AU. If TMDB has no entry for
+      this region we silently fall back to whatever region TMDB lists first
+      so Coming Soon still has something to show.
+  tmdb_ttl_ms:
+    name: TMDB cache TTL (ms)
+    description: >-
+      How long to cache TMDB release-date lookups before re-querying. The
+      default 21600000 (6 hours) is well within TMDB's daily quota even on
+      large libraries.
   proxy_secret:
     name: Proxy secret (optional)
     description: >-

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -53,6 +53,17 @@ COMING_SOON_DAYS_OFFSET=0
 COMING_SOON_IMAGE_TYPE=poster
 COMING_SOON_TTL_MS=900000
 
+# ---- Optional TMDB enrichment (#91) ---------------------------------------
+# When set, fills in digital/physical/theatrical release dates Radarr's
+# calendar is missing. Radarr stays the primary source. Leave TMDB_API_KEY
+# empty to keep Coming Soon fully Radarr-driven (no calls, no warnings).
+# Both v3 keys and v4 read-tokens work — paste whichever you have.
+TMDB_API_KEY=
+# ISO 3166-1 country code for region-specific dates. Defaults to AU.
+TMDB_REGION=AU
+# Cache TTL for TMDB lookups (ms). 6 h amortises the per-movie round-trip.
+TMDB_TTL_MS=21600000
+
 # ---- Visual toggles (V2 visual sprint) ------------------------------------
 # Each visual feature is opt-in. Defaults preserve the v1 look.
 # Slim gold progress bar along the bottom of the poster.

--- a/docker/docker-compose.example.yml
+++ b/docker/docker-compose.example.yml
@@ -71,6 +71,11 @@ services:
       VISUAL_ACCENT_COLOR: "${VISUAL_ACCENT_COLOR:-}"
       VISUAL_MARQUEE_BG_COLOR: "${VISUAL_MARQUEE_BG_COLOR:-}"
 
+      # ---- Optional TMDB enrichment (#91) ----
+      TMDB_API_KEY: "${TMDB_API_KEY:-}"
+      TMDB_REGION: "${TMDB_REGION:-AU}"
+      TMDB_TTL_MS: "${TMDB_TTL_MS:-21600000}"
+
       # ---- Optional hardening (recommended if exposed off-LAN) ----
       PROXY_SECRET: "${PROXY_SECRET:-}"
       ALLOWED_ORIGINS: "${ALLOWED_ORIGINS:-}"

--- a/server/src/comingSoon.js
+++ b/server/src/comingSoon.js
@@ -1,3 +1,5 @@
+import { fetchTmdbReleaseDates, hasTmdb } from './tmdb.js';
+
 const DAY_MS = 86400000;
 const DEFAULT_LOOKAHEAD_DAYS = 90;
 
@@ -9,6 +11,8 @@ export function hasComingSoonSource(config = {}) {
 export async function fetchComingSoonItems({
   config,
   fetchImpl = globalThis.fetch,
+  tmdbCache = null,
+  logger = defaultLogger,
   now = new Date(),
 } = {}) {
   const c = config?.comingSoon || {};
@@ -18,7 +22,7 @@ export async function fetchComingSoonItems({
   const end = new Date(now.getTime() + lookaheadDays * DAY_MS);
 
   const [movies, shows] = await Promise.all([
-    fetchRadarrItems({ config: c, fetchImpl, start, end, now }),
+    fetchRadarrItems({ config, fetchImpl, start, end, now, tmdbCache, logger }),
     fetchSonarrItems({ config: c, fetchImpl, start, end, now }),
   ]);
 
@@ -28,20 +32,51 @@ export async function fetchComingSoonItems({
   );
 }
 
-async function fetchRadarrItems({ config, fetchImpl, start, end, now }) {
-  if (!config.radarrUrl || !config.radarrApiKey) return [];
-  const base = trimSlash(config.radarrUrl);
+async function fetchRadarrItems({ config, fetchImpl, start, end, now, tmdbCache, logger }) {
+  const c = config?.comingSoon || {};
+  if (!c.radarrUrl || !c.radarrApiKey) return [];
+  const base = trimSlash(c.radarrUrl);
   const url = `${base}/api/v3/calendar?start=${dateOnly(start)}&end=${dateOnly(end)}&unmonitored=false`;
-  const resp = await fetchImpl(url, { headers: { 'X-Api-Key': config.radarrApiKey } });
+  const resp = await fetchImpl(url, { headers: { 'X-Api-Key': c.radarrApiKey } });
   if (!resp.ok) {
     const err = new Error(`Radarr calendar returned ${resp.status}`);
     err.status = resp.status;
     throw err;
   }
   const data = await resp.json();
-  return (Array.isArray(data) ? data : [])
-    .map(item => ({ item, picked: pickRadarrReleaseDate(item, start, end) }))
-    .filter(({ item, picked }) => !item.hasFile && picked)
+  // Skip downloaded movies up-front so we don't waste a TMDB lookup on them.
+  const eligible = (Array.isArray(data) ? data : []).filter(item => !item.hasFile);
+
+  // First pass: pick the best date Radarr alone can provide.
+  const radarrPicks = eligible.map(item => ({
+    item,
+    picked: pickRadarrReleaseDate(item, start, end),
+  }));
+
+  // Second pass: when TMDB enrichment is enabled, fill in dates Radarr
+  // doesn't have. Either the Radarr pick was null (no usable date in window)
+  // or it's a 'cinema' fallback that TMDB might be able to upgrade to a home
+  // date. Fetches are sequential so the cache warms naturally; per-movie
+  // lookups still take ~50ms each and the Coming Soon TTL keeps the
+  // amortised cost low.
+  if (hasTmdb(config)) {
+    for (const entry of radarrPicks) {
+      const upgraded = await maybeEnrichWithTmdb({
+        radarrItem: entry.item,
+        radarrPick: entry.picked,
+        config,
+        fetchImpl,
+        cache: tmdbCache,
+        logger,
+        start,
+        end,
+      });
+      if (upgraded) entry.picked = upgraded;
+    }
+  }
+
+  return radarrPicks
+    .filter(({ picked }) => picked)
     .sort((a, b) => new Date(a.picked.releaseDate) - new Date(b.picked.releaseDate))
     .map(({ item, picked }) => {
       const id = item.id || item.movieId || '';
@@ -61,10 +96,71 @@ async function fetchRadarrItems({ config, fetchImpl, start, end, now }) {
         overview: item.overview || '',
         posterUrl: imageUrl(item.images, 'poster'),
         fanartUrl: imageUrl(item.images, 'fanart'),
-        localPosterUrl: id ? `${base}/api/v3/MediaCover/${id}/poster.jpg?apikey=${encodeURIComponent(config.radarrApiKey)}` : '',
-        localFanartUrl: id ? `${base}/api/v3/MediaCover/${id}/fanart.jpg?apikey=${encodeURIComponent(config.radarrApiKey)}` : '',
+        localPosterUrl: id ? `${base}/api/v3/MediaCover/${id}/poster.jpg?apikey=${encodeURIComponent(c.radarrApiKey)}` : '',
+        localFanartUrl: id ? `${base}/api/v3/MediaCover/${id}/fanart.jpg?apikey=${encodeURIComponent(c.radarrApiKey)}` : '',
       };
     });
+}
+
+// Replace the chosen Radarr release date when TMDB has clearer home-release
+// metadata for the configured region (#91). Order of preference matches the
+// existing Coming Soon UX:
+//
+//   1. Earliest in-window home date (digital or physical) wins, regardless
+//      of whether Radarr already had a cinema fallback.
+//   2. If neither Radarr nor TMDB has a usable home date, use TMDB's
+//      theatrical release as a labelled cinema date — but only when Radarr
+//      didn't already supply an in-window cinema date itself.
+//
+// Returns null when TMDB has nothing better; the caller keeps the original
+// Radarr pick (or the original null result, if any) untouched.
+async function maybeEnrichWithTmdb({
+  radarrItem, radarrPick, config, fetchImpl, cache, logger, start, end,
+}) {
+  const radarrIsHome = radarrPick && radarrPick.releaseType === 'home';
+  // If Radarr already has the strongest signal we can offer, skip the call —
+  // saves a TMDB request on every movie that's already well-tagged.
+  if (radarrIsHome) return null;
+
+  let tmdbDates;
+  try {
+    tmdbDates = await fetchTmdbReleaseDates({
+      config, radarrItem, fetchImpl, cache, logger,
+    });
+  } catch (err) {
+    // fetchTmdbReleaseDates handles its own errors, but be belt-and-braces:
+    // a buggy TMDB response must never break the Coming Soon feed.
+    logger.warn(`[tmdb] enrichment threw: ${err.message}`);
+    return null;
+  }
+  if (!tmdbDates) return null;
+
+  const startMs = start.getTime();
+  const endMs = end.getTime();
+  const inWindowRaw = (raw) => {
+    if (!raw) return null;
+    const ts = new Date(raw).getTime();
+    return Number.isFinite(ts) && ts >= startMs && ts <= endMs ? raw : null;
+  };
+
+  // Pick the earliest qualifying home date from TMDB.
+  const homeCandidates = [tmdbDates.digital, tmdbDates.physical]
+    .map(inWindowRaw)
+    .filter(Boolean)
+    .sort();
+  if (homeCandidates.length) {
+    return { releaseDate: homeCandidates[0], releaseType: 'home', source: 'tmdb' };
+  }
+
+  // No home date anywhere. If Radarr already supplied a cinema fallback,
+  // keep it — it's likely just as good and avoids a flicker on cache miss.
+  if (radarrPick && radarrPick.releaseType === 'cinema') return null;
+
+  const cinema = inWindowRaw(tmdbDates.theatrical);
+  if (cinema) {
+    return { releaseDate: cinema, releaseType: 'cinema', source: 'tmdb' };
+  }
+  return null;
 }
 
 // Pick the visible release date for a Radarr movie.
@@ -79,12 +175,11 @@ async function fetchRadarrItems({ config, fetchImpl, start, end, now }) {
 // inCinemas, and we tag releaseType: 'cinema' so the UI can label it as a
 // theatrical date rather than imply digital/physical availability.
 //
-// TMDB feasibility note: when Radarr lacks digital/physical metadata, TMDB's
-// /movie/{id}/release_dates endpoint exposes typed release dates (theatrical,
-// digital, physical, etc.) per region and could be used as a fallback. That
-// would require a TMDB API token, configurable region, and result caching, so
-// it's intentionally out of scope here. IMDb has no equivalent simple public
-// API and is not a practical alternative.
+// TMDB enrichment (#91): when configured, maybeEnrichWithTmdb() runs after
+// this picker and may overwrite a null/cinema pick with TMDB's typed
+// digital/physical/theatrical dates for the configured region. Radarr stays
+// the primary source; TMDB only touches the result when Radarr's calendar
+// answer has nothing usable to display.
 function pickRadarrReleaseDate(item, start, end) {
   const startMs = start.getTime();
   const endMs = end.getTime();
@@ -230,3 +325,8 @@ function ordinal(n) {
   const v = n % 100;
   return `${n}${suffixes[(v - 20) % 10] || suffixes[v] || suffixes[0]}`;
 }
+
+const defaultLogger = {
+  warn: (msg) => console.warn(msg),
+  info: (msg) => console.info(msg),
+};

--- a/server/src/config.js
+++ b/server/src/config.js
@@ -49,6 +49,10 @@ export function loadConfig(env = process.env) {
     stateTtl: parseInt(env.STATE_TTL_MS || '3000', 10),
     mediaInfoTtl: parseInt(env.MEDIA_INFO_TTL_MS || '600000', 10), // 10 min
     comingSoonTtl: parseInt(env.COMING_SOON_TTL_MS || '900000', 10), // 15 min
+    // TMDB enrichment cache TTL (#91). Independent from the Coming Soon page
+    // cache so a fresh /api/coming-soon doesn't always re-query TMDB. 6 h
+    // covers a normal screensaver day with one round-trip per movie.
+    tmdbTtl: parseInt(env.TMDB_TTL_MS || '21600000', 10),
     comingSoon: {
       title: env.COMING_SOON_TITLE || 'Coming Soon',
       radarrUrl: (env.RADARR_URL || '').replace(/\/$/, ''),
@@ -64,6 +68,19 @@ export function loadConfig(env = process.env) {
       // meaningful; upper bound of 365 mirrors daysOffset.
       lookaheadDays: parseIntClamped(env.COMING_SOON_LOOKAHEAD_DAYS, 90, 1, 365),
       imageType: parseEnum(env.COMING_SOON_IMAGE_TYPE, ['poster', 'fanart'], 'poster'),
+      // Optional TMDB enrichment (#91). Disabled unless an API token is
+      // supplied. Fills in digital/physical/theatrical release dates by
+      // region when Radarr's calendar response lacks them — Radarr stays the
+      // primary source. Region defaults to AU per the issue; when missing or
+      // unmatched at TMDB we fall back to the movie's first available region.
+      tmdb: {
+        apiKey: env.TMDB_API_KEY || '',
+        region: parseRegion(env.TMDB_REGION, 'AU'),
+        // TMDB API accepts both v3 keys and v4 read-tokens. v4 tokens go in
+        // the Authorization header; v3 keys go in ?api_key=. Heuristic: v4
+        // tokens are JWTs (contain two dots and start with "eyJ"); anything
+        // else is treated as a v3 key.
+      },
     },
     // Fully Kiosk auto-switcher (#48). Disabled by default; users who prefer
     // the HA Blueprint (#47) can leave it off and vice versa.
@@ -191,6 +208,17 @@ function parseFloatClamped(v, defaultValue, min, max) {
   return Math.min(Math.max(n, min), max);
 }
 
+// ISO 3166-1 alpha-2 country code, e.g. AU, US, GB. TMDB rejects anything
+// else, so we normalise to upper-case and reject non-letters; bad input
+// returns the default ('AU' per #91) so a typo can't silently disable the
+// fallback path.
+function parseRegion(v, defaultValue) {
+  if (v == null) return defaultValue;
+  const s = String(v).trim().toUpperCase();
+  if (s === '') return defaultValue;
+  return /^[A-Z]{2}$/.test(s) ? s : defaultValue;
+}
+
 // Validate a #RRGGBB hex colour string. Anything else (including #RGB short
 // form, named colours, rgba(), garbage) returns defaultValue so a typo in
 // add-on config can't render the kiosk unstyled. Trims and lower-cases for
@@ -210,6 +238,7 @@ function validate(c) {
   if (!Number.isFinite(c.port) || c.port < 1 || c.port > 65535) errors.push('port must be between 1 and 65535');
   if (!Number.isFinite(c.poll) || c.poll < 1000) errors.push('poll must be \u2265 1000 ms');
   if (!Number.isFinite(c.comingSoonTtl) || c.comingSoonTtl < 10000) errors.push('comingSoonTtl must be \u2265 10000 ms');
+  if (!Number.isFinite(c.tmdbTtl) || c.tmdbTtl < 10000) errors.push('tmdbTtl must be \u2265 10000 ms');
   if (c.displayMode === 'coming_soon') {
     const hasSource = !!((c.comingSoon.radarrUrl && c.comingSoon.radarrApiKey)
       || (c.comingSoon.sonarrUrl && c.comingSoon.sonarrApiKey));

--- a/server/src/routes/comingSoon.js
+++ b/server/src/routes/comingSoon.js
@@ -4,7 +4,7 @@
 import { Router } from 'express';
 import { fetchComingSoonItems, hasComingSoonSource } from '../comingSoon.js';
 
-export function comingSoonRoute({ cache, config, fetchImpl = globalThis.fetch }) {
+export function comingSoonRoute({ cache, tmdbCache = null, config, fetchImpl = globalThis.fetch }) {
   const r = Router();
 
   r.get('/api/coming-soon', async (_req, res) => {
@@ -15,7 +15,7 @@ export function comingSoonRoute({ cache, config, fetchImpl = globalThis.fetch })
     try {
       let payload = cache.get('coming-soon');
       if (payload === undefined) {
-        const items = await fetchComingSoonItems({ config, fetchImpl });
+        const items = await fetchComingSoonItems({ config, fetchImpl, tmdbCache });
         payload = {
           title: config.comingSoon?.title || 'Coming Soon',
           imageType: config.comingSoon?.imageType || 'poster',

--- a/server/src/routes/config.js
+++ b/server/src/routes/config.js
@@ -27,6 +27,13 @@ export function configRoute({ config }) {
         daysOffset: config.comingSoon?.daysOffset ?? 0,
         lookaheadDays: config.comingSoon?.lookaheadDays ?? 90,
         imageType: config.comingSoon?.imageType || 'poster',
+        // #91 — surface whether TMDB enrichment is wired up so the kiosk
+        // setup UI can light up a status pill ("TMDB region: AU"). The
+        // token itself stays server-side.
+        tmdb: {
+          enabled: !!config.comingSoon?.tmdb?.apiKey,
+          region: config.comingSoon?.tmdb?.region || 'AU',
+        },
       },
       visual: {
         progressBar: !!config.visual?.progressBar,

--- a/server/src/server.js
+++ b/server/src/server.js
@@ -60,6 +60,9 @@ export function createApp({ config, haClient }) {
   const stateCache = createCache(config.stateTtl);
   const mediaInfoCache = createCache(config.mediaInfoTtl);
   const comingSoonCache = createCache(config.comingSoonTtl);
+  // Long-lived TMDB cache: typed release dates rarely change, and we want
+  // them to outlive a single Coming Soon page refresh.
+  const tmdbCache = createCache(config.tmdbTtl);
 
   app.use(rootRoute({ config, version: pkg.version }));
   app.use(healthzRoute({ config, version: pkg.version }));
@@ -69,7 +72,7 @@ export function createApp({ config, haClient }) {
   app.use(artworkRoute({ config }));
   app.use(plexArtRoute({ config }));
   app.use(nightModeRoute({ haClient, config }));
-  app.use(comingSoonRoute({ cache: comingSoonCache, config }));
+  app.use(comingSoonRoute({ cache: comingSoonCache, tmdbCache, config }));
 
   // Static HTML last so /api/* wins on overlap.
   app.use(express.static(config.staticDir, {

--- a/server/src/tmdb.js
+++ b/server/src/tmdb.js
@@ -1,0 +1,204 @@
+// Optional TMDB enrichment for the Coming Soon feed (#91).
+//
+// Radarr stays the primary source: TMDB only fills in release-date metadata
+// when Radarr's calendar response is missing the typed home-release dates we
+// need (digitalRelease / physicalRelease) or, as a last resort, an inCinemas
+// date. The kiosk works fine without TMDB — when the API token is empty
+// hasTmdb() returns false and fetchTmdbReleaseDates() short-circuits with no
+// network calls.
+//
+// Matching strategy
+// -----------------
+// Radarr stores the TMDB id on every movie record (`tmdbId`). We use that
+// directly when present — it's the most robust identifier. If TMDB id is
+// missing but we have an IMDb id we use the /find/{imdb_id} endpoint. We do
+// not fall back to title-only search: Radarr's existing dates are good enough
+// in that edge case, and a fuzzy title match risks pulling release dates from
+// the wrong movie.
+//
+// Region handling
+// ---------------
+// TMDB exposes /movie/{id}/release_dates which returns { results: [{ iso_3166_1,
+// release_dates: [{ type, release_date, ... }] }] }. The numeric `type`
+// codes from the TMDB docs are:
+//   1 = Premiere
+//   2 = Theatrical (limited)
+//   3 = Theatrical
+//   4 = Digital
+//   5 = Physical
+//   6 = TV
+// We pick the configured region first; if that region has no release_dates
+// entry at all we fall back to the first region that does (typically US).
+// Within a region we prefer the earliest qualifying date for each kind (a
+// movie can have multiple staggered theatrical or digital releases).
+//
+// Caching
+// -------
+// Lookups for the same TMDB id + region are cached in the supplied TTL cache
+// (see cache.js). Negative results (no match, auth failure) are cached too
+// so a misconfigured token doesn't hammer the API every Coming Soon refresh.
+
+const TMDB_BASE = 'https://api.themoviedb.org/3';
+
+const TYPE_PREMIERE = 1;
+const TYPE_THEATRICAL_LIMITED = 2;
+const TYPE_THEATRICAL = 3;
+const TYPE_DIGITAL = 4;
+const TYPE_PHYSICAL = 5;
+
+export function hasTmdb(config) {
+  return !!(config?.comingSoon?.tmdb?.apiKey);
+}
+
+// Returns { digital, physical, theatrical } for the matched movie + region.
+// Each value is an ISO date string or null. Failures (no token, no match,
+// auth/network error) resolve to null release dates rather than throwing —
+// the caller treats TMDB enrichment as best-effort.
+export async function fetchTmdbReleaseDates({
+  config,
+  radarrItem,
+  cache,
+  fetchImpl = globalThis.fetch,
+  logger = defaultLogger,
+}) {
+  const empty = { digital: null, physical: null, theatrical: null, region: null };
+  if (!hasTmdb(config)) return empty;
+
+  const tmdb = config.comingSoon.tmdb;
+  const region = tmdb.region || 'AU';
+  const tmdbId = await resolveTmdbId({ radarrItem, tmdb, fetchImpl, logger, cache, region });
+  if (!tmdbId) return empty;
+
+  const cacheKey = `tmdb:release_dates:${tmdbId}:${region}`;
+  if (cache) {
+    const hit = cache.get(cacheKey);
+    if (hit !== undefined) return hit;
+  }
+
+  const url = `${TMDB_BASE}/movie/${encodeURIComponent(tmdbId)}/release_dates`;
+  let payload;
+  try {
+    payload = await tmdbFetch(url, tmdb, fetchImpl, logger);
+  } catch (err) {
+    logger.warn(`[tmdb] release_dates fetch failed for tmdbId=${tmdbId}: ${err.message}`);
+    if (cache) cache.set(cacheKey, empty);
+    return empty;
+  }
+  if (!payload) {
+    if (cache) cache.set(cacheKey, empty);
+    return empty;
+  }
+
+  const picked = pickReleaseDates(payload, region);
+  if (cache) cache.set(cacheKey, picked);
+  return picked;
+}
+
+// Pick earliest digital/physical/theatrical date from /movie/{id}/release_dates
+// for the requested region. Falls back to the first region that has any data
+// when the requested region isn't listed at all.
+export function pickReleaseDates(payload, region) {
+  const empty = { digital: null, physical: null, theatrical: null, region: null };
+  const results = Array.isArray(payload?.results) ? payload.results : [];
+  if (!results.length) return empty;
+
+  const upper = String(region || '').toUpperCase();
+  let entry = results.find(r => String(r?.iso_3166_1 || '').toUpperCase() === upper);
+  let usedRegion = upper;
+  if (!entry) {
+    entry = results.find(r => Array.isArray(r?.release_dates) && r.release_dates.length);
+    usedRegion = entry ? String(entry.iso_3166_1 || '').toUpperCase() : null;
+  }
+  if (!entry) return empty;
+
+  const dates = Array.isArray(entry.release_dates) ? entry.release_dates : [];
+  const earliest = (...types) => {
+    const matches = dates
+      .filter(d => types.includes(Number(d.type)) && d.release_date)
+      .map(d => d.release_date)
+      .filter(Boolean)
+      .sort();
+    return matches[0] || null;
+  };
+
+  return {
+    digital: earliest(TYPE_DIGITAL),
+    physical: earliest(TYPE_PHYSICAL),
+    // Theatrical: prefer wide-release theatrical (3) but accept limited (2)
+    // and premieres (1) as a labelled cinema fallback so we don't drop a
+    // movie just because the wide rollout isn't typed yet.
+    theatrical: earliest(TYPE_THEATRICAL, TYPE_THEATRICAL_LIMITED, TYPE_PREMIERE),
+    region: usedRegion,
+  };
+}
+
+async function resolveTmdbId({ radarrItem, tmdb, fetchImpl, logger, cache, region }) {
+  const direct = numberOr(radarrItem?.tmdbId, null);
+  if (direct) return direct;
+
+  const imdbId = String(radarrItem?.imdbId || '').trim();
+  if (!imdbId) return null;
+
+  const cacheKey = `tmdb:find:imdb:${imdbId}:${region}`;
+  if (cache) {
+    const hit = cache.get(cacheKey);
+    if (hit !== undefined) return hit;
+  }
+  const url = `${TMDB_BASE}/find/${encodeURIComponent(imdbId)}?external_source=imdb_id`;
+  let payload;
+  try {
+    payload = await tmdbFetch(url, tmdb, fetchImpl, logger);
+  } catch (err) {
+    logger.warn(`[tmdb] /find lookup failed for imdb=${imdbId}: ${err.message}`);
+    if (cache) cache.set(cacheKey, null);
+    return null;
+  }
+  const movie = Array.isArray(payload?.movie_results) ? payload.movie_results[0] : null;
+  const id = movie ? numberOr(movie.id, null) : null;
+  if (cache) cache.set(cacheKey, id);
+  return id;
+}
+
+async function tmdbFetch(url, tmdb, fetchImpl, logger) {
+  const headers = { Accept: 'application/json' };
+  let finalUrl = url;
+  const apiKey = String(tmdb.apiKey || '');
+  if (looksLikeV4Token(apiKey)) {
+    headers.Authorization = `Bearer ${apiKey}`;
+  } else {
+    const join = url.includes('?') ? '&' : '?';
+    finalUrl = `${url}${join}api_key=${encodeURIComponent(apiKey)}`;
+  }
+
+  const resp = await fetchImpl(finalUrl, { headers });
+  if (!resp.ok) {
+    if (resp.status === 401 || resp.status === 403) {
+      logger.warn(`[tmdb] auth rejected (HTTP ${resp.status}) — check TMDB_API_KEY`);
+    } else if (resp.status === 429) {
+      logger.warn('[tmdb] rate-limited (HTTP 429); backing off this lookup');
+    } else if (resp.status === 404) {
+      // Not an error — movie just isn't in TMDB. Don't log noisily.
+      return null;
+    } else {
+      logger.warn(`[tmdb] HTTP ${resp.status} from ${finalUrl.replace(apiKey, '***')}`);
+    }
+    return null;
+  }
+  return resp.json();
+}
+
+function looksLikeV4Token(value) {
+  // TMDB v4 read tokens are JWTs: three base64 segments separated by dots,
+  // header always starts with "eyJ". v3 keys are 32 hex characters.
+  return /^eyJ[\w-]+\.[\w-]+\.[\w-]+$/.test(value);
+}
+
+function numberOr(value, fallback) {
+  const n = Number(value);
+  return Number.isFinite(n) && n > 0 ? n : fallback;
+}
+
+const defaultLogger = {
+  warn: (msg) => console.warn(msg),
+  info: (msg) => console.info(msg),
+};

--- a/server/test/comingSoon.test.js
+++ b/server/test/comingSoon.test.js
@@ -2,6 +2,7 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 
 import { fetchComingSoonItems, formatCountdown, formatReleaseDate } from '../src/comingSoon.js';
+import { createCache } from '../src/cache.js';
 
 function response(body, ok = true, status = 200) {
   return {
@@ -9,6 +10,14 @@ function response(body, ok = true, status = 200) {
     status,
     json: async () => body,
   };
+}
+
+function tmdbReleaseDates({ region = 'AU', digital, physical, theatrical } = {}) {
+  const dates = [];
+  if (theatrical) dates.push({ type: 3, release_date: theatrical });
+  if (digital) dates.push({ type: 4, release_date: digital });
+  if (physical) dates.push({ type: 5, release_date: physical });
+  return { results: [{ iso_3166_1: region, release_dates: dates }] };
 }
 
 test('fetchComingSoonItems interleaves Radarr movies and first Sonarr episode per series', async () => {
@@ -522,4 +531,357 @@ test('configurable lookaheadDays widens the request window', async () => {
   });
   assert.equal(widened.length, 1);
   assert.equal(widened[0].title, 'Far Future');
+});
+
+// ---- TMDB enrichment (#91) ------------------------------------------------
+
+test('TMDB is not called when tmdb_api_key is empty (no enrichment)', async () => {
+  const calls = [];
+  const fetchImpl = async (url) => {
+    calls.push(url);
+    if (url.includes('radarr')) {
+      return response([
+        {
+          id: 100,
+          title: 'No Home Date',
+          tmdbId: 99,
+          inCinemas: '2026-06-01T00:00:00Z',
+          hasFile: false,
+        },
+      ]);
+    }
+    if (url.includes('themoviedb')) {
+      throw new Error('TMDB should not be called when api key is empty');
+    }
+    return response([]);
+  };
+  const items = await fetchComingSoonItems({
+    config: {
+      comingSoon: {
+        radarrUrl: 'http://radarr.local:7878',
+        radarrApiKey: 'rk',
+        moviesCount: 5,
+        showsCount: 5,
+        lookaheadDays: 90,
+      },
+    },
+    fetchImpl,
+    now: new Date('2026-05-02T12:00:00Z'),
+  });
+  assert.equal(items.length, 1);
+  assert.equal(items[0].releaseType, 'cinema');
+  assert.ok(!calls.some(u => u.includes('themoviedb')));
+});
+
+test('TMDB enrichment fills in a missing digital date so the entry becomes home', async () => {
+  const fetchImpl = async (url) => {
+    if (url.includes('radarr')) {
+      return response([
+        {
+          id: 200,
+          title: 'Cinema Now Digital Soon',
+          tmdbId: 9000,
+          inCinemas: '2026-05-15T00:00:00Z',
+          hasFile: false,
+        },
+      ]);
+    }
+    if (url.includes('/movie/9000/release_dates')) {
+      return response(tmdbReleaseDates({
+        region: 'AU',
+        digital: '2026-06-20T00:00:00Z',
+      }));
+    }
+    return response([]);
+  };
+  const [item] = await fetchComingSoonItems({
+    config: {
+      comingSoon: {
+        radarrUrl: 'http://radarr.local:7878',
+        radarrApiKey: 'rk',
+        moviesCount: 5,
+        showsCount: 5,
+        lookaheadDays: 90,
+        tmdb: { apiKey: 'k', region: 'AU' },
+      },
+    },
+    fetchImpl,
+    now: new Date('2026-05-02T12:00:00Z'),
+  });
+  assert.equal(item.releaseType, 'home');
+  assert.equal(item.releaseDate, '2026-06-20T00:00:00Z');
+  assert.equal(item.releaseLabel, '20th of June 2026');
+});
+
+test('TMDB region preference picks AU dates over US dates', async () => {
+  const fetchImpl = async (url) => {
+    if (url.includes('radarr')) {
+      return response([
+        {
+          id: 201,
+          title: 'Region Aware',
+          tmdbId: 9001,
+          hasFile: false,
+        },
+      ]);
+    }
+    if (url.includes('/movie/9001/release_dates')) {
+      return response({
+        results: [
+          {
+            iso_3166_1: 'US',
+            release_dates: [{ type: 4, release_date: '2026-05-30T00:00:00Z' }],
+          },
+          {
+            iso_3166_1: 'AU',
+            release_dates: [{ type: 4, release_date: '2026-06-25T00:00:00Z' }],
+          },
+        ],
+      });
+    }
+    return response([]);
+  };
+  const [item] = await fetchComingSoonItems({
+    config: {
+      comingSoon: {
+        radarrUrl: 'http://radarr.local:7878',
+        radarrApiKey: 'rk',
+        moviesCount: 5,
+        showsCount: 5,
+        lookaheadDays: 90,
+        tmdb: { apiKey: 'k', region: 'AU' },
+      },
+    },
+    fetchImpl,
+    now: new Date('2026-05-02T12:00:00Z'),
+  });
+  assert.equal(item.releaseType, 'home');
+  assert.equal(item.releaseDate, '2026-06-25T00:00:00Z');
+});
+
+test('TMDB falls back to a labelled cinema date when only theatrical is available', async () => {
+  const fetchImpl = async (url) => {
+    if (url.includes('radarr')) {
+      return response([
+        {
+          id: 202,
+          title: 'Theatrical Only',
+          tmdbId: 9002,
+          // Radarr knows nothing about this movie's dates.
+          hasFile: false,
+        },
+      ]);
+    }
+    if (url.includes('/movie/9002/release_dates')) {
+      return response(tmdbReleaseDates({
+        region: 'AU',
+        theatrical: '2026-06-05T00:00:00Z',
+      }));
+    }
+    return response([]);
+  };
+  const [item] = await fetchComingSoonItems({
+    config: {
+      comingSoon: {
+        radarrUrl: 'http://radarr.local:7878',
+        radarrApiKey: 'rk',
+        moviesCount: 5,
+        showsCount: 5,
+        lookaheadDays: 90,
+        tmdb: { apiKey: 'k', region: 'AU' },
+      },
+    },
+    fetchImpl,
+    now: new Date('2026-05-02T12:00:00Z'),
+  });
+  assert.equal(item.releaseType, 'cinema');
+  assert.equal(item.releaseDate, '2026-06-05T00:00:00Z');
+  assert.equal(item.releaseLabel, 'In cinemas: 5th of June 2026');
+});
+
+test('TMDB API failure does not break Coming Soon — Radarr cinema fallback still shows', async () => {
+  const fetchImpl = async (url) => {
+    if (url.includes('radarr')) {
+      return response([
+        {
+          id: 203,
+          title: 'TMDB Down',
+          tmdbId: 9003,
+          inCinemas: '2026-05-20T00:00:00Z',
+          hasFile: false,
+        },
+      ]);
+    }
+    if (url.includes('themoviedb')) {
+      return response({}, false, 500);
+    }
+    return response([]);
+  };
+  const [item] = await fetchComingSoonItems({
+    config: {
+      comingSoon: {
+        radarrUrl: 'http://radarr.local:7878',
+        radarrApiKey: 'rk',
+        moviesCount: 5,
+        showsCount: 5,
+        lookaheadDays: 90,
+        tmdb: { apiKey: 'k', region: 'AU' },
+      },
+    },
+    fetchImpl,
+    logger: { warn() {}, info() {} },
+    now: new Date('2026-05-02T12:00:00Z'),
+  });
+  assert.equal(item.releaseType, 'cinema');
+  assert.equal(item.releaseDate, '2026-05-20T00:00:00Z');
+});
+
+test('TMDB enrichment is skipped for movies with hasFile=true', async () => {
+  let tmdbCalls = 0;
+  const fetchImpl = async (url) => {
+    if (url.includes('radarr')) {
+      return response([
+        {
+          id: 204,
+          title: 'Already Downloaded',
+          tmdbId: 9004,
+          inCinemas: '2026-05-20T00:00:00Z',
+          hasFile: true,
+        },
+      ]);
+    }
+    if (url.includes('themoviedb')) {
+      tmdbCalls += 1;
+      return response(tmdbReleaseDates({ digital: '2026-06-01T00:00:00Z' }));
+    }
+    return response([]);
+  };
+  const items = await fetchComingSoonItems({
+    config: {
+      comingSoon: {
+        radarrUrl: 'http://radarr.local:7878',
+        radarrApiKey: 'rk',
+        moviesCount: 5,
+        showsCount: 5,
+        lookaheadDays: 90,
+        tmdb: { apiKey: 'k', region: 'AU' },
+      },
+    },
+    fetchImpl,
+    now: new Date('2026-05-02T12:00:00Z'),
+  });
+  assert.deepEqual(items, []);
+  assert.equal(tmdbCalls, 0);
+});
+
+test('TMDB enrichment is skipped when Radarr already provides a home release date', async () => {
+  let tmdbCalls = 0;
+  const fetchImpl = async (url) => {
+    if (url.includes('radarr')) {
+      return response([
+        {
+          id: 205,
+          title: 'Already Has Home Date',
+          tmdbId: 9005,
+          digitalRelease: '2026-06-01T00:00:00Z',
+          hasFile: false,
+        },
+      ]);
+    }
+    if (url.includes('themoviedb')) {
+      tmdbCalls += 1;
+      return response(tmdbReleaseDates({ digital: '2026-05-10T00:00:00Z' }));
+    }
+    return response([]);
+  };
+  const [item] = await fetchComingSoonItems({
+    config: {
+      comingSoon: {
+        radarrUrl: 'http://radarr.local:7878',
+        radarrApiKey: 'rk',
+        moviesCount: 5,
+        showsCount: 5,
+        lookaheadDays: 90,
+        tmdb: { apiKey: 'k', region: 'AU' },
+      },
+    },
+    fetchImpl,
+    now: new Date('2026-05-02T12:00:00Z'),
+  });
+  assert.equal(item.releaseType, 'home');
+  assert.equal(item.releaseDate, '2026-06-01T00:00:00Z');
+  assert.equal(tmdbCalls, 0);
+});
+
+test('TMDB lookups are cached across movies in the same Coming Soon refresh', async () => {
+  let tmdbCalls = 0;
+  const fetchImpl = async (url) => {
+    if (url.includes('radarr')) {
+      return response([
+        { id: 1, title: 'A', tmdbId: 7777, inCinemas: '2026-05-15T00:00:00Z', hasFile: false },
+      ]);
+    }
+    if (url.includes('themoviedb')) {
+      tmdbCalls += 1;
+      return response(tmdbReleaseDates({ digital: '2026-06-01T00:00:00Z' }));
+    }
+    return response([]);
+  };
+  const cache = createCache(60000);
+  const args = {
+    config: {
+      comingSoon: {
+        radarrUrl: 'http://radarr.local:7878',
+        radarrApiKey: 'rk',
+        moviesCount: 5,
+        showsCount: 5,
+        lookaheadDays: 90,
+        tmdb: { apiKey: 'k', region: 'AU' },
+      },
+    },
+    fetchImpl,
+    tmdbCache: cache,
+    now: new Date('2026-05-02T12:00:00Z'),
+  };
+  await fetchComingSoonItems(args);
+  await fetchComingSoonItems(args);
+  await fetchComingSoonItems(args);
+  assert.equal(tmdbCalls, 1);
+});
+
+test('TMDB digital date out of look-ahead window is ignored', async () => {
+  const fetchImpl = async (url) => {
+    if (url.includes('radarr')) {
+      return response([
+        {
+          id: 206,
+          title: 'Far Out Digital',
+          tmdbId: 9006,
+          inCinemas: '2026-05-20T00:00:00Z',
+          hasFile: false,
+        },
+      ]);
+    }
+    if (url.includes('themoviedb')) {
+      return response(tmdbReleaseDates({ digital: '2027-08-01T00:00:00Z' }));
+    }
+    return response([]);
+  };
+  const [item] = await fetchComingSoonItems({
+    config: {
+      comingSoon: {
+        radarrUrl: 'http://radarr.local:7878',
+        radarrApiKey: 'rk',
+        moviesCount: 5,
+        showsCount: 5,
+        lookaheadDays: 90,
+        tmdb: { apiKey: 'k', region: 'AU' },
+      },
+    },
+    fetchImpl,
+    now: new Date('2026-05-02T12:00:00Z'),
+  });
+  // Out-of-window TMDB date is dropped; Radarr's cinema fallback wins.
+  assert.equal(item.releaseType, 'cinema');
+  assert.equal(item.releaseDate, '2026-05-20T00:00:00Z');
 });

--- a/server/test/config.test.js
+++ b/server/test/config.test.js
@@ -420,3 +420,33 @@ test('switcher is off by default, on requires FULLY_KIOSKS', () => {
   });
   assert.deepEqual(enabled.errors, []);
 });
+
+// ---- TMDB enrichment (#91) ------------------------------------------------
+
+test('TMDB defaults: empty key, AU region, 6h cache TTL', () => {
+  const { config, errors } = loadConfig({ SUPERVISOR_TOKEN: 'x' });
+  assert.equal(config.comingSoon.tmdb.apiKey, '');
+  assert.equal(config.comingSoon.tmdb.region, 'AU');
+  assert.equal(config.tmdbTtl, 21600000);
+  assert.deepEqual(errors, []);
+});
+
+test('TMDB region is normalised to upper-case ISO 3166-1 alpha-2', () => {
+  const { config: lower } = loadConfig({ SUPERVISOR_TOKEN: 'x', TMDB_REGION: 'us' });
+  assert.equal(lower.comingSoon.tmdb.region, 'US');
+
+  const { config: spaced } = loadConfig({ SUPERVISOR_TOKEN: 'x', TMDB_REGION: '  gb  ' });
+  assert.equal(spaced.comingSoon.tmdb.region, 'GB');
+
+  const { config: bogus } = loadConfig({ SUPERVISOR_TOKEN: 'x', TMDB_REGION: 'USA' });
+  assert.equal(bogus.comingSoon.tmdb.region, 'AU'); // falls back to default
+});
+
+test('TMDB API key is preserved verbatim (both v3 and v4 shapes)', () => {
+  const v3 = loadConfig({ SUPERVISOR_TOKEN: 'x', TMDB_API_KEY: 'abcdef0123456789abcdef0123456789' });
+  assert.equal(v3.config.comingSoon.tmdb.apiKey, 'abcdef0123456789abcdef0123456789');
+
+  const v4Token = 'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ4In0.zzz';
+  const v4 = loadConfig({ SUPERVISOR_TOKEN: 'x', TMDB_API_KEY: v4Token });
+  assert.equal(v4.config.comingSoon.tmdb.apiKey, v4Token);
+});

--- a/server/test/routes.test.js
+++ b/server/test/routes.test.js
@@ -134,6 +134,10 @@ test('GET /api/config defaults every visual toggle off', async () => {
         daysOffset: 0,
         lookaheadDays: 90,
         imageType: 'poster',
+        tmdb: {
+          enabled: false,
+          region: 'AU',
+        },
       },
       visual: {
         progressBar: false,

--- a/server/test/tmdb.test.js
+++ b/server/test/tmdb.test.js
@@ -1,0 +1,224 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { fetchTmdbReleaseDates, hasTmdb, pickReleaseDates } from '../src/tmdb.js';
+import { createCache } from '../src/cache.js';
+
+const silentLogger = { warn() {}, info() {} };
+
+function jsonResponse(body, ok = true, status = 200) {
+  return {
+    ok,
+    status,
+    json: async () => body,
+  };
+}
+
+function configWithTmdb({ apiKey = 'demo-v3-key', region = 'AU' } = {}) {
+  return {
+    comingSoon: {
+      tmdb: { apiKey, region },
+    },
+  };
+}
+
+const SAMPLE_RELEASE_DATES = {
+  results: [
+    {
+      iso_3166_1: 'AU',
+      release_dates: [
+        { type: 3, release_date: '2026-06-15T00:00:00.000Z', note: 'wide' },
+        { type: 4, release_date: '2026-08-01T00:00:00.000Z' },
+      ],
+    },
+    {
+      iso_3166_1: 'US',
+      release_dates: [
+        { type: 3, release_date: '2026-05-30T00:00:00.000Z' },
+        { type: 4, release_date: '2026-07-15T00:00:00.000Z' },
+        { type: 5, release_date: '2026-09-15T00:00:00.000Z' },
+      ],
+    },
+  ],
+};
+
+test('hasTmdb is false when no API key is set', () => {
+  assert.equal(hasTmdb({}), false);
+  assert.equal(hasTmdb({ comingSoon: {} }), false);
+  assert.equal(hasTmdb({ comingSoon: { tmdb: {} } }), false);
+  assert.equal(hasTmdb({ comingSoon: { tmdb: { apiKey: '' } } }), false);
+});
+
+test('hasTmdb is true once an API key is supplied', () => {
+  assert.equal(hasTmdb(configWithTmdb()), true);
+});
+
+test('pickReleaseDates picks earliest typed dates for the requested region', () => {
+  const picked = pickReleaseDates(SAMPLE_RELEASE_DATES, 'US');
+  assert.equal(picked.theatrical, '2026-05-30T00:00:00.000Z');
+  assert.equal(picked.digital, '2026-07-15T00:00:00.000Z');
+  assert.equal(picked.physical, '2026-09-15T00:00:00.000Z');
+  assert.equal(picked.region, 'US');
+});
+
+test('pickReleaseDates falls back to first listed region when configured region is missing', () => {
+  const onlyJp = {
+    results: [
+      {
+        iso_3166_1: 'JP',
+        release_dates: [{ type: 3, release_date: '2026-06-01T00:00:00.000Z' }],
+      },
+    ],
+  };
+  const picked = pickReleaseDates(onlyJp, 'AU');
+  assert.equal(picked.theatrical, '2026-06-01T00:00:00.000Z');
+  assert.equal(picked.region, 'JP');
+});
+
+test('pickReleaseDates returns nulls when payload has no usable results', () => {
+  assert.deepEqual(pickReleaseDates({ results: [] }, 'AU'), {
+    digital: null, physical: null, theatrical: null, region: null,
+  });
+  assert.deepEqual(pickReleaseDates(null, 'AU'), {
+    digital: null, physical: null, theatrical: null, region: null,
+  });
+});
+
+test('fetchTmdbReleaseDates short-circuits when TMDB is not configured', async () => {
+  let called = false;
+  const fetchImpl = async () => { called = true; return jsonResponse({}); };
+  const dates = await fetchTmdbReleaseDates({
+    config: { comingSoon: {} },
+    radarrItem: { tmdbId: 1234 },
+    fetchImpl,
+    logger: silentLogger,
+  });
+  assert.equal(called, false);
+  assert.deepEqual(dates, { digital: null, physical: null, theatrical: null, region: null });
+});
+
+test('fetchTmdbReleaseDates uses Radarr tmdbId directly and returns AU dates', async () => {
+  const calls = [];
+  const fetchImpl = async (url, options) => {
+    calls.push({ url, headers: options?.headers || {} });
+    if (url.includes('/movie/9001/release_dates')) {
+      return jsonResponse(SAMPLE_RELEASE_DATES);
+    }
+    throw new Error(`unexpected url: ${url}`);
+  };
+  const dates = await fetchTmdbReleaseDates({
+    config: configWithTmdb({ region: 'AU' }),
+    radarrItem: { tmdbId: 9001 },
+    fetchImpl,
+    cache: createCache(60000),
+    logger: silentLogger,
+  });
+  assert.equal(dates.region, 'AU');
+  assert.equal(dates.theatrical, '2026-06-15T00:00:00.000Z');
+  assert.equal(dates.digital, '2026-08-01T00:00:00.000Z');
+  assert.equal(dates.physical, null);
+  assert.equal(calls.length, 1);
+  // v3 keys go in the query string, not the Authorization header.
+  assert.ok(calls[0].url.includes('api_key=demo-v3-key'));
+  assert.equal(calls[0].headers.Authorization, undefined);
+});
+
+test('fetchTmdbReleaseDates uses Authorization header for v4 read tokens', async () => {
+  const calls = [];
+  const fetchImpl = async (url, options) => {
+    calls.push({ url, headers: options?.headers || {} });
+    return jsonResponse(SAMPLE_RELEASE_DATES);
+  };
+  // Three-segment JWT shape; the value doesn't need to be valid.
+  const v4 = 'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ4In0.signature';
+  await fetchTmdbReleaseDates({
+    config: configWithTmdb({ apiKey: v4 }),
+    radarrItem: { tmdbId: 5 },
+    fetchImpl,
+    logger: silentLogger,
+  });
+  assert.equal(calls[0].headers.Authorization, `Bearer ${v4}`);
+  assert.ok(!calls[0].url.includes('api_key='));
+});
+
+test('fetchTmdbReleaseDates resolves IMDb id via /find when tmdbId is missing', async () => {
+  const urls = [];
+  const fetchImpl = async (url) => {
+    urls.push(url);
+    if (url.includes('/find/tt')) {
+      return jsonResponse({ movie_results: [{ id: 4242 }] });
+    }
+    if (url.includes('/movie/4242/release_dates')) {
+      return jsonResponse(SAMPLE_RELEASE_DATES);
+    }
+    throw new Error(`unexpected url: ${url}`);
+  };
+  const dates = await fetchTmdbReleaseDates({
+    config: configWithTmdb(),
+    radarrItem: { imdbId: 'tt7654321' },
+    fetchImpl,
+    cache: createCache(60000),
+    logger: silentLogger,
+  });
+  assert.equal(dates.theatrical, '2026-06-15T00:00:00.000Z');
+  assert.equal(urls.length, 2);
+  assert.ok(urls[0].includes('/find/tt7654321'));
+  assert.ok(urls[1].includes('/movie/4242/release_dates'));
+});
+
+test('fetchTmdbReleaseDates does not call when neither tmdbId nor imdbId is present', async () => {
+  let called = false;
+  const fetchImpl = async () => { called = true; return jsonResponse({}); };
+  const dates = await fetchTmdbReleaseDates({
+    config: configWithTmdb(),
+    radarrItem: { title: 'Mystery Movie' },
+    fetchImpl,
+    logger: silentLogger,
+  });
+  assert.equal(called, false);
+  assert.deepEqual(dates, { digital: null, physical: null, theatrical: null, region: null });
+});
+
+test('fetchTmdbReleaseDates caches release_dates by tmdbId+region', async () => {
+  let calls = 0;
+  const fetchImpl = async () => { calls += 1; return jsonResponse(SAMPLE_RELEASE_DATES); };
+  const cache = createCache(60000);
+  const args = {
+    config: configWithTmdb(),
+    radarrItem: { tmdbId: 7 },
+    fetchImpl,
+    cache,
+    logger: silentLogger,
+  };
+  await fetchTmdbReleaseDates(args);
+  await fetchTmdbReleaseDates(args);
+  await fetchTmdbReleaseDates(args);
+  assert.equal(calls, 1);
+});
+
+test('fetchTmdbReleaseDates returns nulls (and does not throw) on auth failure', async () => {
+  const fetchImpl = async () => jsonResponse({ status_message: 'Invalid API key' }, false, 401);
+  const warnings = [];
+  const dates = await fetchTmdbReleaseDates({
+    config: configWithTmdb(),
+    radarrItem: { tmdbId: 9001 },
+    fetchImpl,
+    cache: createCache(60000),
+    logger: { warn: (m) => warnings.push(m), info() {} },
+  });
+  assert.deepEqual(dates, { digital: null, physical: null, theatrical: null, region: null });
+  assert.ok(warnings.some(w => w.includes('auth rejected')));
+});
+
+test('fetchTmdbReleaseDates returns nulls on network errors thrown by fetch', async () => {
+  const fetchImpl = async () => { throw new Error('boom'); };
+  const warnings = [];
+  const dates = await fetchTmdbReleaseDates({
+    config: configWithTmdb(),
+    radarrItem: { tmdbId: 9001 },
+    fetchImpl,
+    logger: { warn: (m) => warnings.push(m), info() {} },
+  });
+  assert.deepEqual(dates, { digital: null, physical: null, theatrical: null, region: null });
+  assert.ok(warnings.some(w => w.includes('release_dates fetch failed')));
+});

--- a/www/now_showing.config.example.js
+++ b/www/now_showing.config.example.js
@@ -33,6 +33,9 @@ window.NOW_SHOWING_CONFIG = {
   comingSoonDaysOffset: 0,
   comingSoonLookaheadDays: 90, // forward window in days; widen if Coming Soon doesn't fill up
   comingSoonImageType: 'poster',
+  // TMDB enrichment (#91) is server-side only. Configure tmdb_api_key /
+  // TMDB_API_KEY on the add-on or Docker container so the server can fill in
+  // any digital/physical/theatrical release dates Radarr is missing.
 
   // Plex filtering
   plexUsername: '',   // your Plex username - filters to only your playback


### PR DESCRIPTION
## Summary

Adds an opt-in **TMDB enrichment path** so Radarr movies that are missing digital/physical/theatrical release dates can still appear in the Coming Soon footer with a clearly-labelled date — and so Coming Soon doesn't fall back to a misleading-looking `In cinemas: …` label when a home-release date is in fact known to TMDB.

Radarr stays the primary source. TMDB is only consulted when the configured `tmdb_api_key` is non-empty AND Radarr's calendar pick is either nothing-in-window or an `inCinemas`-only fallback. The kiosk works exactly as before when TMDB is left disabled.

Closes #91.

## What's new

- **Add-on / Docker options** (all default off / `AU` / 6 h):
  - `tmdb_api_key` / `TMDB_API_KEY` — empty disables the path entirely
  - `tmdb_region` / `TMDB_REGION` — ISO 3166-1 country code, default `AU`
  - `tmdb_ttl_ms` / `TMDB_TTL_MS` — TMDB lookup cache TTL
- **`server/src/tmdb.js`** — fetches `/movie/{id}/release_dates` by region with TTL caching, supports both v3 keys and v4 read-tokens (Bearer header), falls back to TMDB's first listed region if the configured region is unmatched, matches by Radarr `tmdbId` first and falls back to `/find/{imdbId}`. No fragile title-only matching.
- **`server/src/comingSoon.js`** — runs Radarr first; if Radarr's pick is null or only `inCinemas`, asks TMDB for typed dates. TMDB digital/physical inside the look-ahead window upgrades the entry to `home`; only-theatrical TMDB dates become a labelled cinema fallback. `home` Radarr picks short-circuit the TMDB call so well-tagged libraries don't pay for a round-trip.
- **Graceful failure** — auth errors, rate limits, network errors, and no-match cases log a single warning and are swallowed; Coming Soon never breaks because TMDB is unreachable.
- **`/api/config`** now exposes `comingSoon.tmdb.enabled` + `region` (the token never leaves the server).
- **Docs** — `README.md`, addon `DOCS.md`, addon `translations/en.yaml`, the `run` script, `docker-compose.example.yml`, `.env.example`, and the frontend config example all describe the new option.

## Behaviour preserved

- `hasFile`, monitored / unmonitored filtering, and the configured Coming Soon look-ahead are unchanged.
- The existing #87 (`inCinemas` eligibility) and #92 (home-vs-cinema labelling) semantics are untouched — TMDB only fills in dates Radarr doesn't have, and the labelling rules in `comingSoon.js` decide how the result is rendered.
- TMDB is never queried for `hasFile === true` movies (filtered out before the second pass).

## Test plan

- [x] `node --test server/test/*.js` — **170 / 170 passing** (was 145 before this change; +25 new tests):
  - `tmdb.test.js` — token shape (v3 vs v4), region fallback, IMDb-id resolution via `/find`, no-id no-call path, cache hit semantics, 401 auth failure, network throw.
  - `comingSoon.test.js` — disabled TMDB makes no API calls, digital enrichment promotes cinema-only Radarr to `home`, region preference picks AU over US, theatrical-only fallback is labelled cinema, TMDB 500 keeps Radarr cinema fallback, `hasFile=true` skips TMDB entirely, Radarr `home` short-circuits TMDB, repeated calls reuse the TTL cache, out-of-window TMDB dates are dropped.
  - `config.test.js` — defaults (empty key, `AU` region, 6 h TTL), region normalised to upper-case alpha-2 (with bogus values falling back to default), v3 and v4 keys stored verbatim.
  - `routes.test.js` — `/api/config` payload includes the new `tmdb` block.
- [ ] Manual smoke against a real TMDB account on a future install.

## Caveats / notes

- Per-movie TMDB lookups are sequential so the cache warms naturally; one round-trip per uncached movie. With the default 6 h cache, a typical 5-movie Coming Soon refresh issues at most 5 TMDB requests per cache cycle.
- v4 token detection is heuristic (`^eyJ\\w+\\.\\w+\\.\\w+$`). Any token shaped like a JWT goes in the `Authorization: Bearer …` header; everything else is treated as a v3 key in the `?api_key=` query string. Both are documented as supported by TMDB.
- This is feature work, not a release — the version bump and CHANGELOG entry are deliberately deferred to a follow-up release commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)