### PR TITLE
docs(addon): surface 2.1.3 highlights on add-on page

### DIFF
--- a/addons/plex-now-showing/CHANGELOG.md
+++ b/addons/plex-now-showing/CHANGELOG.md
@@ -3,6 +3,38 @@
 All notable changes to the Now Showing add-on will be documented here.
 The project follows [Semantic Versioning](https://semver.org/).
 
+## Unreleased
+
+### Added
+- Optional TMDB enrichment for Coming Soon (closes #91, PR #93). New
+  `tmdb_api_key`, `tmdb_region`, and `tmdb_ttl_ms` add-on options
+  (env: `TMDB_API_KEY`, `TMDB_REGION` default `AU`, `TMDB_TTL_MS` default
+  6 h) let the server fall back to The Movie Database for movies whose
+  Radarr calendar entry has no usable digital/physical release date.
+  Radarr stays the primary source — TMDB is only consulted when Radarr
+  lacks usable home-release metadata, and any TMDB digital/physical date
+  inside the look-ahead window upgrades the entry to a `home` release.
+  If only a TMDB theatrical date is available it is used as a labelled
+  cinema fallback. Movies are matched by Radarr `tmdbId` first and fall
+  back to `imdbId` via TMDB's `/find` endpoint; title-only matching is
+  deliberately avoided. Disabled by default — leave `tmdb_api_key`
+  blank for identical behaviour to 2.1.2. Both v3 keys and v4
+  read-tokens are accepted. Auth, rate-limit, and network failures are
+  logged and silently swallowed so Coming Soon never breaks because
+  TMDB is unreachable. `hasFile`, monitored filtering, and the
+  configurable look-ahead window are unchanged.
+
+### Changed
+- Coming Soon footer now prefers the earliest qualifying home-release
+  date (`digitalRelease` / `physicalRelease`) inside the look-ahead
+  window for Radarr movies (closes #90, PR #92). The kiosk only falls
+  back to `inCinemas` when no home date qualifies, and cinema-only
+  items are tagged with `releaseType: 'cinema'` and prefixed with
+  `In cinemas: <date>` so the footer is not mistaken for home
+  availability. Both the Node server and the frontend-only path apply
+  the same rule. `hasFile`, monitored filtering, and the configurable
+  look-ahead behaviour are unchanged.
+
 ## 2.1.2 - 2026-05-08
 
 ### Changed

--- a/addons/plex-now-showing/DOCS.md
+++ b/addons/plex-now-showing/DOCS.md
@@ -43,7 +43,7 @@ probe of `/api`) and switches to `/api/state`. Plex-only metadata calls use
 | `coming_soon_shows_count` | `5` | Number of Sonarr series to include. |
 | `coming_soon_cycle_interval` | `8` | Seconds each upcoming title stays on screen. |
 | `coming_soon_days_offset` | `0` | Include releases from this many days in the past. |
-| `coming_soon_lookahead_days` | `90` | Forward window (days) for upcoming releases. Radarr considers `digitalRelease`, `physicalRelease`, and `inCinemas`; the earliest qualifying date inside the window wins. |
+| `coming_soon_lookahead_days` | `90` | Forward window (days) for upcoming releases. Radarr eligibility accepts `digitalRelease`, `physicalRelease`, or `inCinemas`. The displayed footer date prefers the earliest qualifying home-release date; cinema-only items are labelled `In cinemas: <date>` so the footer is not mistaken for home availability. |
 | `coming_soon_image_type` | `poster` | `poster` or `fanart`. |
 | `tmdb_api_key` | _empty_ | Optional TMDB API key (v3 or v4). When set, fills in digital/physical/theatrical release dates Radarr's calendar is missing. Empty disables the fallback completely. |
 | `tmdb_region` | `AU` | ISO 3166-1 country code used to select region-specific release dates from TMDB. Falls back to whatever region TMDB lists first if there's no match. |

--- a/addons/plex-now-showing/README.md
+++ b/addons/plex-now-showing/README.md
@@ -4,6 +4,28 @@ Cinema-style now-playing and coming-soon kiosk for Home Assistant, installed
 straight from the Home Assistant add-on store. One click, no long-lived access
 token, no Docker command line.
 
+## What's new in 2.1.3
+
+- Optional TMDB enrichment for Coming Soon. Set `tmdb_api_key` (and
+  optionally `tmdb_region`, default `AU`) to let the server fill in
+  digital, physical, or theatrical release dates that Radarr's calendar
+  is missing. Disabled by default — leave the key blank to keep Coming
+  Soon fully Radarr-driven. Both v3 keys and v4 read-tokens work.
+- Radarr stays the primary source. TMDB is only consulted when Radarr
+  has no usable home-release date inside the look-ahead window. A TMDB
+  digital or physical date upgrades the entry to a `home` release; a
+  theatrical-only TMDB date is used as a labelled cinema fallback.
+- Lookups are cached for `tmdb_ttl_ms` (default 6 h) and TMDB failures
+  (auth, rate limit, network, no match) are logged and silently
+  swallowed, so Coming Soon never breaks because TMDB is unreachable.
+- The Coming Soon footer now prefers the earliest qualifying
+  home-release date for Radarr movies and only falls back to
+  `inCinemas` when no home date qualifies. Cinema-only items are
+  prefixed with `In cinemas: <date>` so the footer is not mistaken for
+  home availability.
+- `hasFile === false`, monitored filtering, and the configurable
+  `coming_soon_lookahead_days` window are still respected.
+
 ## What's new in 2.1.2
 
 - Radarr Coming Soon eligibility now also accepts `inCinemas` as a release-date


### PR DESCRIPTION
## Summary

The add-on README is what Home Assistant renders on the add-on store's
**Info** tab, so users browsing the store see this page before
installing or updating. PRs #92 and #93 landed two notable Coming Soon
improvements that are not yet reflected there or in the CHANGELOG.

This PR is documentation-only — it prepares the add-on page and the
CHANGELOG for an upcoming v2.1.3 release. It does **not** bump
\`config.yaml\` / \`server/package.json\` versions; that happens in a
separate \`release: prepare v2.1.3\` commit, matching the v2.1.1 and
v2.1.2 flow in this repo.

### Changes

- **\`addons/plex-now-showing/README.md\`** — new \"What's new in 2.1.3\"
  section above the existing 2.1.2 block, covering:
  - Optional TMDB enrichment (\`tmdb_api_key\` / \`tmdb_region\` /
    \`tmdb_ttl_ms\`), Radarr-primary, disabled by default, both v3 keys
    and v4 read-tokens supported, failures degrade gracefully.
  - Coming Soon footer prefers the earliest qualifying home-release
    date; cinema-only items are labelled \`In cinemas: <date>\`.
  - \`hasFile\` / monitored filtering / look-ahead window unchanged.
- **\`addons/plex-now-showing/CHANGELOG.md\`** — new \`## Unreleased\`
  section with **Added** (TMDB enrichment, closes #91, PR #93) and
  **Changed** (home-vs-cinema footer, closes #90, PR #92) entries. The
  release commit later renames \`Unreleased\` → \`2.1.3 - <date>\`.
- **\`addons/plex-now-showing/DOCS.md\`** — \`coming_soon_lookahead_days\`
  row reconciled with the clearer home-vs-cinema language PR #92 added
  to the root README, so the HA add-on **Documentation** tab matches.

### Why this is doc-only

The TMDB add-on options (\`tmdb_api_key\`, \`tmdb_region\`,
\`tmdb_ttl_ms\`) and translations were already added to
\`config.yaml\` / \`translations/en.yaml\` by PR #93, and the home-vs-
cinema language for the root README was already added by PR #92. What
was missing was the user-facing add-on page narrative and the
CHANGELOG.

## Test plan

- [x] \`node --test test/*.js\` from \`server/\` — all 170 tests still
      pass (no source changes; sanity check only).
- [ ] Reviewer eyeballs the rendered \"What's new in 2.1.3\" section in
      \`addons/plex-now-showing/README.md\`.
- [ ] Reviewer confirms \`Unreleased\` CHANGELOG entry is the right
      shape for the upcoming \`release: prepare v2.1.3\` commit to
      promote it to \`2.1.3 - <date>\`.
- [ ] Reviewer confirms version bump is correctly deferred to the
      release commit (matches v2.1.1 / v2.1.2 flow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)