### PR TITLE
fix: persist add-on setup state across browsers; surface TMDB status (#95)

### DIFF
--- a/addons/plex-now-showing/CHANGELOG.md
+++ b/addons/plex-now-showing/CHANGELOG.md
@@ -3,6 +3,57 @@
 All notable changes to the Now Showing add-on will be documented here.
 The project follows [Semantic Versioning](https://semver.org/).
 
+## Unreleased
+
+### Fixed
+- Add-on setup state now persists across browsers, devices, and the HA
+  app (closes #95). The in-app setup overlay was previously the only
+  mechanism for configuring connection / Coming Soon / TMDB values and
+  it stored everything in per-tablet `localStorage`, so a phone or HA
+  app opening the kiosk on a different origin saw blank fields even
+  though the operator had filled them in on Master Panel. The canonical
+  setup now lives in the add-on **Configuration** tab (or Docker env
+  vars). The unified server reads it once at boot and exposes a
+  non-secret summary at `GET /api/config`; every browser hits the same
+  endpoint, so a fresh phone shows the same configured state without
+  any per-device re-entry.
+- The setup overlay now renders a "Settings are managed by the Now
+  Showing add-on" banner in unified-server mode with a read-only
+  summary of what the server actually loaded (mode, display mode,
+  backend/player, Plex/Radarr/Sonarr URLs, TMDB region + configured
+  status). Connection / Coming Soon password fields are still hidden
+  for security; the banner shows a `(key set)` / `(token set)` marker
+  instead of the secret. localStorage values continue to work as
+  per-device overrides for visual preferences.
+- The first-run setup auto-open is now suppressed in unified-server
+  mode — the server already has a working HA token, so a brand-new
+  phone is no longer forced through a setup form pretending to need
+  credentials.
+- Save-button validation no longer demands an HA / Radarr / Sonarr
+  token in unified-server mode (the server already has them).
+
+### Added
+- `GET /api/config` now exposes `mode`, `managed`, the canonical
+  Plex / Radarr / Sonarr URLs, plex username, and `*Set` booleans for
+  every secret. No secrets are returned. This is what the in-app
+  setup overlay uses to render the read-only summary.
+- The setup overlay's Coming Soon section gained an inline TMDB
+  status panel showing whether the server has a TMDB API key
+  configured and which region is active (driven by the existing
+  `tmdb_api_key` / `tmdb_region` add-on options). This is a status
+  display only — the API key remains a server-side option in the
+  add-on Configuration tab (or `TMDB_API_KEY` env var); the kiosk
+  frontend never calls TMDB directly.
+
+### Migration
+- No action required for the canonical Connection / Coming Soon /
+  TMDB values: they are already read from add-on options. If you
+  previously filled in the in-app setup overlay and the values only
+  appeared on one tablet, copy those same values into **Settings →
+  Add-ons → Now Showing → Configuration** once and every device will
+  pick them up automatically. The per-device localStorage overrides
+  are left untouched and continue to work.
+
 ## 2.1.3 - 2026-05-09
 
 ### Added

--- a/addons/plex-now-showing/DOCS.md
+++ b/addons/plex-now-showing/DOCS.md
@@ -103,6 +103,31 @@ writes the same per-tablet `pns.*` keys the kiosk reads at runtime.
 In the Home Assistant add-on, the setup overlay opens at the top and scrolls
 inside Ingress, so all controls remain reachable on smaller tablet or desktop
 iframes without zooming out.
+
+### Where setup lives (server-managed vs per-device) — #95
+
+When you install the add-on (or run the unified server in Docker), the
+**canonical setup** lives in **Settings → Add-ons → Now Showing →
+Configuration** (or, for Docker, your `docker-compose.yml` / `.env`). The
+server reads those values once at boot and exposes a non-secret summary at
+`GET /api/config` so every tablet, phone, kiosk, or HA app shares the same
+values, regardless of how the kiosk was opened.
+
+The in-app setup overlay (the gear icon on the live display, or `#setup`)
+is now a **per-device override**: it stores values in this browser's
+`localStorage` so a single tablet can pin display preferences (theme,
+backdrops, frame style, etc.) without affecting the rest of the fleet. It
+is **not** the source of truth for connection details, Coming Soon, or
+TMDB. When you open the overlay on a fresh phone you'll see a
+"Settings are managed by the Now Showing add-on" banner with a read-only
+summary of what the server has loaded.
+
+If you upgraded from v2.1.3 or earlier and the kiosk used to look
+configured on Master Panel but blank on your phone, that's because v2.1.3
+wrote setup values only to each browser's `localStorage`. Re-save the
+values once in **Settings → Add-ons → Now Showing → Configuration** and
+every device will pick them up automatically — no per-tablet re-entry
+needed.
 Advanced users can still set `pns.visualProgressBar=true` /
 `pns.visualRatingsBadges=true` / `pns.visualGenreChips=true` /
 `pns.visualInfoPanelMode=on_pause` / `pns.visualFrameStyle=gold-line` /

--- a/server/src/routes/config.js
+++ b/server/src/routes/config.js
@@ -3,6 +3,13 @@
 // Only ships non-sensitive values. Tokens and internal settings (TTLs, cache,
 // kiosk URLs) are deliberately excluded. Visual toggles let the frontend
 // conditionally render new v2 UI without a rebuild.
+//
+// #95 — also surfaces the canonical setup state (server mode, configured
+// URLs, plex username, secret-set flags) so the in-app setup overlay can
+// show what the add-on/server is actually using rather than relying on a
+// per-browser localStorage copy. Secret values themselves are never
+// returned; only an `*Set` boolean. The frontend uses these to render a
+// "managed by add-on" read-only view.
 
 import { Router } from 'express';
 
@@ -14,9 +21,22 @@ export function configRoute({ config }) {
     // browsers on the wall might live for days. Let them re-read on reload.
     res.set('Cache-Control', 'no-store');
     res.json({
+      // #95 — `mode` lets the frontend tell add-on/Docker installs (where
+      // the server is the source of truth for setup) apart from HACS-only
+      // installs (where there is no server, so localStorage stays canonical
+      // per-tablet).
+      mode: config.mode || 'standalone',
+      managed: !!config.haToken, // server already has a working HA token
       displayMode: config.displayMode || 'now_showing',
       backend: config.backend || 'plex',
       player: config.player || '',
+      // Plex metadata API surfaces (URL non-sensitive; token boolean only).
+      plex: {
+        urlSet: !!config.plexUrl,
+        url: config.plexUrl || '',
+        tokenSet: !!config.plexToken,
+        username: config.plexUsername || '',
+      },
       comingSoon: {
         title: config.comingSoon?.title || 'Coming Soon',
         enabled: !!((config.comingSoon?.radarrUrl && config.comingSoon?.radarrApiKey)
@@ -27,11 +47,18 @@ export function configRoute({ config }) {
         daysOffset: config.comingSoon?.daysOffset ?? 0,
         lookaheadDays: config.comingSoon?.lookaheadDays ?? 90,
         imageType: config.comingSoon?.imageType || 'poster',
+        // #95 — Radarr/Sonarr URLs are non-secret (typically a LAN IP); the
+        // API keys stay server-side and we only surface a boolean.
+        radarrUrl: config.comingSoon?.radarrUrl || '',
+        radarrApiKeySet: !!config.comingSoon?.radarrApiKey,
+        sonarrUrl: config.comingSoon?.sonarrUrl || '',
+        sonarrApiKeySet: !!config.comingSoon?.sonarrApiKey,
         // #91 — surface whether TMDB enrichment is wired up so the kiosk
         // setup UI can light up a status pill ("TMDB region: AU"). The
         // token itself stays server-side.
         tmdb: {
           enabled: !!config.comingSoon?.tmdb?.apiKey,
+          apiKeySet: !!config.comingSoon?.tmdb?.apiKey,
           region: config.comingSoon?.tmdb?.region || 'AU',
         },
       },

--- a/server/test/routes.test.js
+++ b/server/test/routes.test.js
@@ -122,9 +122,17 @@ test('GET /api/config defaults every visual toggle off', async () => {
     assert.equal(resp.headers.get('cache-control'), 'no-store');
     const body = await resp.json();
     assert.deepEqual(body, {
+      mode: 'addon',
+      managed: true,
       displayMode: 'now_showing',
       backend: 'plex',
       player: '',
+      plex: {
+        urlSet: true,
+        url: 'https://plex.example:32400',
+        tokenSet: true,
+        username: 'rusty',
+      },
       comingSoon: {
         title: 'Coming Soon',
         enabled: false,
@@ -134,8 +142,13 @@ test('GET /api/config defaults every visual toggle off', async () => {
         daysOffset: 0,
         lookaheadDays: 90,
         imageType: 'poster',
+        radarrUrl: '',
+        radarrApiKeySet: false,
+        sonarrUrl: '',
+        sonarrApiKeySet: false,
         tmdb: {
           enabled: false,
+          apiKeySet: false,
           region: 'AU',
         },
       },
@@ -161,6 +174,145 @@ test('GET /api/config defaults every visual toggle off', async () => {
         cornerRadiusPx: 0,
       },
     });
+  } finally { server.close(); }
+});
+
+// #95 — server-side config must survive per-browser localStorage swaps.
+// When configured with Radarr/TMDB tokens, /api/config exposes the URLs
+// and a `*Set` boolean for the secret without ever leaking the secret
+// itself, so the in-app setup form can render canonical state on a fresh
+// browser without the user having to re-enter anything.
+test('GET /api/config surfaces canonical setup state without leaking secrets', async () => {
+  const haClient = { getStates: async () => haStates };
+  const { server, url } = await startApp(
+    baseConfig({
+      mode: 'addon',
+      backend: 'jellyfin',
+      player: 'media_player.jellyfin_living_room',
+      plexUrl: 'https://plex.example:32400',
+      plexToken: 'super-secret-plex-token',
+      plexUsername: 'rusty',
+      comingSoon: {
+        title: 'Coming Soon',
+        radarrUrl: 'http://radarr.lan:7878',
+        radarrApiKey: 'super-secret-radarr-key',
+        sonarrUrl: 'http://sonarr.lan:8989',
+        sonarrApiKey: 'super-secret-sonarr-key',
+        moviesCount: 5,
+        showsCount: 5,
+        cycleInterval: 8,
+        daysOffset: 0,
+        lookaheadDays: 90,
+        imageType: 'poster',
+        tmdb: { apiKey: 'super-secret-tmdb-key', region: 'GB' },
+      },
+    }),
+    haClient,
+  );
+  try {
+    const body = await fetch(`${url}/api/config`).then(r => r.json());
+    // Canonical state surfaces correctly.
+    assert.equal(body.mode, 'addon');
+    assert.equal(body.managed, true);
+    assert.equal(body.backend, 'jellyfin');
+    assert.equal(body.player, 'media_player.jellyfin_living_room');
+    assert.equal(body.plex.url, 'https://plex.example:32400');
+    assert.equal(body.plex.urlSet, true);
+    assert.equal(body.plex.tokenSet, true);
+    assert.equal(body.plex.username, 'rusty');
+    assert.equal(body.comingSoon.radarrUrl, 'http://radarr.lan:7878');
+    assert.equal(body.comingSoon.radarrApiKeySet, true);
+    assert.equal(body.comingSoon.sonarrUrl, 'http://sonarr.lan:8989');
+    assert.equal(body.comingSoon.sonarrApiKeySet, true);
+    assert.equal(body.comingSoon.tmdb.enabled, true);
+    assert.equal(body.comingSoon.tmdb.apiKeySet, true);
+    assert.equal(body.comingSoon.tmdb.region, 'GB');
+    // Secrets must never appear anywhere in the response.
+    const dump = JSON.stringify(body);
+    for (const secret of [
+      'super-secret-plex-token',
+      'super-secret-radarr-key',
+      'super-secret-sonarr-key',
+      'super-secret-tmdb-key',
+    ]) {
+      assert.equal(dump.includes(secret), false, `secret ${secret} leaked into /api/config`);
+    }
+  } finally { server.close(); }
+});
+
+// #95 — when no secrets are set the *Set booleans are false. This is what
+// the frontend uses to render "needs configuration" hints (vs "configured"
+// when true), so the inverted case matters too.
+test('GET /api/config reports *Set booleans as false when secrets are blank', async () => {
+  const haClient = { getStates: async () => haStates };
+  const { server, url } = await startApp(
+    baseConfig({
+      plexUrl: '',
+      plexToken: '',
+      plexUsername: '',
+    }),
+    haClient,
+  );
+  try {
+    const body = await fetch(`${url}/api/config`).then(r => r.json());
+    assert.equal(body.plex.urlSet, false);
+    assert.equal(body.plex.tokenSet, false);
+    assert.equal(body.plex.username, '');
+    assert.equal(body.comingSoon.radarrApiKeySet, false);
+    assert.equal(body.comingSoon.sonarrApiKeySet, false);
+    assert.equal(body.comingSoon.tmdb.apiKeySet, false);
+    assert.equal(body.comingSoon.tmdb.enabled, false);
+  } finally { server.close(); }
+});
+
+// #95 — a fresh browser opening the kiosk on a different origin must be
+// able to read all canonical setup fields from /api/config alone, so the
+// in-app setup form is never rendered "blank" just because that tablet's
+// localStorage hasn't been seeded. This is the regression we want to
+// prevent.
+test('GET /api/config returns full canonical state on a fresh request (no cookies / no auth)', async () => {
+  const haClient = { getStates: async () => haStates };
+  const { server, url } = await startApp(
+    baseConfig({
+      backend: 'plex',
+      plexUrl: 'https://plex.example:32400',
+      plexUsername: 'rusty',
+      comingSoon: {
+        title: 'My Coming Soon',
+        radarrUrl: 'http://radarr.lan:7878',
+        radarrApiKey: 'rk',
+        sonarrUrl: '',
+        sonarrApiKey: '',
+        moviesCount: 7,
+        showsCount: 3,
+        cycleInterval: 12,
+        daysOffset: 0,
+        lookaheadDays: 60,
+        imageType: 'fanart',
+        tmdb: { apiKey: 'tk', region: 'US' },
+      },
+    }),
+    haClient,
+  );
+  try {
+    // No headers at all — simulates the very first phone hitting the
+    // ingress URL or the LAN URL without any prior state.
+    const body = await fetch(`${url}/api/config`).then(r => r.json());
+    // Connection
+    assert.equal(body.backend, 'plex');
+    assert.equal(body.plex.url, 'https://plex.example:32400');
+    assert.equal(body.plex.username, 'rusty');
+    // Coming Soon
+    assert.equal(body.comingSoon.title, 'My Coming Soon');
+    assert.equal(body.comingSoon.radarrUrl, 'http://radarr.lan:7878');
+    assert.equal(body.comingSoon.moviesCount, 7);
+    assert.equal(body.comingSoon.showsCount, 3);
+    assert.equal(body.comingSoon.cycleInterval, 12);
+    assert.equal(body.comingSoon.lookaheadDays, 60);
+    assert.equal(body.comingSoon.imageType, 'fanart');
+    // TMDB
+    assert.equal(body.comingSoon.tmdb.enabled, true);
+    assert.equal(body.comingSoon.tmdb.region, 'US');
   } finally { server.close(); }
 });
 

--- a/www/now_showing.html
+++ b/www/now_showing.html
@@ -1575,7 +1575,35 @@
   <div class="setup-overlay" id="setupOverlay">
     <form class="setup-card" id="setupForm" autocomplete="off" onsubmit="return false;">
       <h1>Now Showing &mdash; Setup</h1>
-      <div class="setup-sub">Values are saved to this device's localStorage. Nothing is sent anywhere else.</div>
+      <div class="setup-sub" id="setupSub">Values are saved to this device's localStorage. Nothing is sent anywhere else.</div>
+
+      <!--
+        #95 — When the page is served by the unified add-on / Docker server,
+        the canonical setup lives in add-on options / docker env, not in this
+        per-tablet localStorage. Show a banner pointing the user at the
+        Configuration tab, plus a read-only summary of what the server
+        actually loaded, so a phone or kiosk on a different origin doesn't
+        appear "blank" just because that browser hasn't filled the form
+        locally.
+      -->
+      <div id="setupServerBanner"
+           style="display:none;margin:0 0 14px;padding:12px 14px;border-radius:6px;
+                  border:1px solid #6b5520;background:#221a08;color:#e6d8a6;
+                  font-size:0.85rem;line-height:1.4;">
+        <strong style="color:var(--accent-light);display:block;margin-bottom:4px;">
+          Settings are managed by the Now Showing add-on
+        </strong>
+        <span id="setupServerBannerText">
+          Connection, Coming Soon, and Plex metadata values come from the
+          Home Assistant add-on Configuration tab (or your Docker
+          <code>.env</code>). Changes you make below are remembered on this
+          device only and override the server values for this browser.
+          Update the add-on config to apply changes everywhere.
+        </span>
+        <div id="setupServerBannerSummary"
+             style="margin-top:8px;font-family:'Roboto Mono',monospace;font-size:0.78rem;
+                    color:#bfa75e;white-space:pre-wrap;"></div>
+      </div>
 
       <div class="setup-tabs" role="tablist" aria-label="Setup sections">
         <button class="setup-tab active" id="setupTabConnection" type="button" role="tab" aria-selected="true" aria-controls="setupPanelConnection" data-setup-tab="connection">Connection</button>
@@ -1691,6 +1719,28 @@
               <label for="cfgComingSoonLookaheadDays">Look-ahead Days</label>
               <input id="cfgComingSoonLookaheadDays" type="number" min="1" max="365" step="1" inputmode="numeric" autocomplete="off">
               <div class="hint">Forward window for upcoming releases. Default 90.</div>
+            </div>
+          </div>
+
+          <!--
+            #91 / #95 — TMDB enrichment. Server-side only: the kiosk
+            frontend never calls TMDB directly, so this is a status panel,
+            not an input. The enabled/region values come from /api/config;
+            the API key itself stays server-side.
+          -->
+          <div class="setup-section-title" style="margin-top:14px;">TMDB enrichment (server-side)</div>
+          <div class="setup-field" id="cfgTmdbStatusField">
+            <div id="cfgTmdbStatus" class="hint" style="color:var(--accent-light);">
+              TMDB fallback status will appear when the unified server is reachable.
+            </div>
+            <div class="hint" style="margin-top:6px;">
+              Configure <code>tmdb_api_key</code> and <code>tmdb_region</code>
+              (default <code>AU</code>) in the Home Assistant add-on
+              Configuration tab, or as <code>TMDB_API_KEY</code> /
+              <code>TMDB_REGION</code> env vars on the Docker container.
+              When set, TMDB fills in digital/physical/theatrical release
+              dates Radarr's calendar is missing. Leave the API key blank
+              to disable the fallback completely.
             </div>
           </div>
         </details>
@@ -2796,6 +2846,104 @@
         syncCornerRadiusField();
         initSetupAutomationLinks();
       } catch (_) { /* storage unavailable */ }
+      // #95 — overlay the canonical server-side config so the form doesn't
+      // look "blank" on a phone that has never visited this origin before.
+      // Async on purpose: it shouldn't block the local-storage values
+      // showing instantly.
+      void hydrateSetupFromServer();
+    }
+
+    // #95 — fetch /api/config (already used for visual toggles) and use it
+    // to drive the in-app setup overlay's "managed by add-on" banner plus
+    // the TMDB status pill. Fields the user has saved locally always win
+    // (they are the per-tablet override) — server values are only used to
+    // fill blanks and to render an informational read-only summary.
+    async function hydrateSetupFromServer() {
+      const banner = document.getElementById('setupServerBanner');
+      const summary = document.getElementById('setupServerBannerSummary');
+      const sub = document.getElementById('setupSub');
+      const tmdbStatus = document.getElementById('cfgTmdbStatus');
+      const tmdbField = document.getElementById('cfgTmdbStatusField');
+      let body = null;
+      try {
+        const resp = await fetch('/api/config', { cache: 'no-store' });
+        if (!resp.ok) throw new Error('http ' + resp.status);
+        body = await resp.json();
+      } catch (_) {
+        // No unified server (HACS-only install) — keep the original
+        // localStorage-only messaging and hide the server banner.
+        if (banner) banner.style.display = 'none';
+        if (tmdbField) tmdbField.style.display = 'none';
+        return;
+      }
+      if (!body || typeof body !== 'object') return;
+      const isAddon = body.mode === 'addon';
+      const isServer = isAddon || body.mode === 'standalone';
+      if (banner && isServer) {
+        banner.style.display = 'block';
+        if (sub) {
+          sub.textContent = isAddon
+            ? 'Connection, Coming Soon, and TMDB values are loaded from the add-on Configuration tab. Display settings can be overridden per-device below.'
+            : 'Connection, Coming Soon, and TMDB values are loaded from the server (Docker .env / env vars). Display settings can be overridden per-device below.';
+        }
+      }
+      if (summary) {
+        const cs = body.comingSoon || {};
+        const plex = body.plex || {};
+        const tmdb = (cs.tmdb || {});
+        const lines = [];
+        lines.push(`mode: ${body.mode || 'standalone'}`);
+        lines.push(`display: ${body.displayMode || 'now_showing'}`);
+        lines.push(`backend: ${body.backend || 'plex'}${body.player ? ' (' + body.player + ')' : ''}`);
+        if (plex.urlSet) lines.push(`plex: ${plex.url}${plex.tokenSet ? ' (token set)' : ' (no token)'}${plex.username ? ' user=' + plex.username : ''}`);
+        if (cs.radarrUrl) lines.push(`radarr: ${cs.radarrUrl}${cs.radarrApiKeySet ? ' (key set)' : ' (no key)'}`);
+        if (cs.sonarrUrl) lines.push(`sonarr: ${cs.sonarrUrl}${cs.sonarrApiKeySet ? ' (key set)' : ' (no key)'}`);
+        lines.push(`tmdb: ${tmdb.enabled ? 'configured' : 'not configured'}, region=${tmdb.region || 'AU'}`);
+        summary.textContent = lines.join('\n');
+      }
+      if (tmdbStatus) {
+        const tmdb = (body.comingSoon && body.comingSoon.tmdb) || {};
+        if (tmdb.enabled) {
+          tmdbStatus.innerHTML = `✅ TMDB API key is configured on the server. Region: <strong>${(tmdb.region || 'AU').toUpperCase()}</strong>.`;
+        } else {
+          tmdbStatus.innerHTML = `⚠️ TMDB fallback is <strong>not configured</strong>. Add <code>tmdb_api_key</code> to the add-on options (or <code>TMDB_API_KEY</code> env var) to enable.`;
+        }
+      }
+      // Fill any blank fields from canonical server values so a brand-new
+      // browser doesn't render the form as empty just because localStorage
+      // is fresh. We only fill blanks — anything the user has saved locally
+      // is treated as a deliberate per-device override and left alone.
+      const fillIfBlank = (id, value) => {
+        const el = document.getElementById(id);
+        if (!el) return;
+        if (typeof value === 'undefined' || value === null) return;
+        if (el.tagName === 'INPUT' && el.type === 'checkbox') {
+          // Only overwrite when localStorage doesn't have an explicit value.
+          return;
+        }
+        if (!el.value) el.value = String(value);
+      };
+      const cs2 = body.comingSoon || {};
+      const plex2 = body.plex || {};
+      fillIfBlank('cfgDisplayMode', body.displayMode);
+      fillIfBlank('cfgBackend', body.backend);
+      fillIfBlank('cfgPlayer', body.player);
+      fillIfBlank('cfgPlexUrl', plex2.url);
+      fillIfBlank('cfgPlexUsername', plex2.username);
+      fillIfBlank('cfgComingSoonTitle', cs2.title);
+      fillIfBlank('cfgRadarrUrl', cs2.radarrUrl);
+      fillIfBlank('cfgSonarrUrl', cs2.sonarrUrl);
+      if (Number.isFinite(cs2.moviesCount)) fillIfBlank('cfgComingSoonMoviesCount', cs2.moviesCount);
+      if (Number.isFinite(cs2.showsCount)) fillIfBlank('cfgComingSoonShowsCount', cs2.showsCount);
+      if (Number.isFinite(cs2.cycleInterval)) fillIfBlank('cfgComingSoonCycleInterval', cs2.cycleInterval);
+      if (Number.isFinite(cs2.daysOffset)) fillIfBlank('cfgComingSoonDaysOffset', cs2.daysOffset);
+      if (Number.isFinite(cs2.lookaheadDays)) fillIfBlank('cfgComingSoonLookaheadDays', cs2.lookaheadDays);
+      fillIfBlank('cfgComingSoonImageType', cs2.imageType);
+      // Re-run dependent toggles in case we just filled the backend/displayMode.
+      try {
+        syncSetupDisplayModeFields();
+        syncSetupBackendFields();
+      } catch (_) { /* form not ready */ }
     }
 
     function syncSetupBackendFields() {
@@ -3315,8 +3463,18 @@
     function setupSave() {
       const haTok = document.getElementById('cfgHaToken').value.trim();
       const displayMode = readDisplayMode(document.getElementById('cfgDisplayMode')?.value || DISPLAY_MODE);
-      if (!haTok && displayMode !== 'coming_soon') { setupStatus('HA token is required.', 'err'); return; }
-      if (displayMode === 'coming_soon') {
+      // #95 — in unified-server mode (add-on / Docker) the server already
+      // has a working HA token. The browser never needs one. Skip the
+      // "HA token is required" guard so a phone or kiosk on a different
+      // origin can still save per-device display preferences without
+      // re-entering credentials. Same logic for Radarr/Sonarr in Coming
+      // Soon mode: the server's API keys are authoritative.
+      const serverManaged = !!SERVER_MODE;
+      if (!serverManaged && !haTok && displayMode !== 'coming_soon') {
+        setupStatus('HA token is required.', 'err');
+        return;
+      }
+      if (!serverManaged && displayMode === 'coming_soon') {
         const hasSource = (document.getElementById('cfgRadarrUrl')?.value.trim()
           && document.getElementById('cfgRadarrApiKey')?.value.trim())
           || (document.getElementById('cfgSonarrUrl')?.value.trim()
@@ -3453,7 +3611,10 @@
       });
 
       // Show the gear icon on the live display whenever we have any saved
-      // config — it's the escape hatch to reopen setup.
+      // config — it's the escape hatch to reopen setup. #95: also show it
+      // on first-run unified-server mode tablets so the user can still
+      // reach setup without typing #setup, since auto-open is suppressed
+      // when the server is authoritative.
       const hasSavedConfig = (() => {
         try {
           return !!(window.localStorage.getItem('pns.haToken')
@@ -3462,14 +3623,20 @@
       })();
       if (gear && hasSavedConfig) gear.style.display = 'block';
 
-      // First-run: if we have no HA token at all and no config script supplied
-      // one, auto-open setup. Also honour explicit `#setup` in the hash.
+      // First-run: if we have no HA token at all and no config script
+      // supplied one, auto-open setup. Honour explicit `#setup` in the hash
+      // either way. #95 — but skip the auto-open in unified-server mode:
+      // the server has its own HA token, so a brand-new browser shouldn't
+      // be forced through a setup form pretending to need credentials.
       const forceSetup = /(^|&)setup(=|&|$)/.test(window.location.hash.replace(/^#/, ''));
-      if (forceSetup || (!HA_TOKEN && DISPLAY_MODE !== 'coming_soon')) {
-        switchSetupTab('connection');
-        populateSetupForm();
-        setupVisible(true);
-      }
+      void serverModeReady.then(() => {
+        if (gear && SERVER_MODE) gear.style.display = 'block';
+        if (forceSetup || (!SERVER_MODE && !HA_TOKEN && DISPLAY_MODE !== 'coming_soon')) {
+          switchSetupTab('connection');
+          populateSetupForm();
+          setupVisible(true);
+        }
+      });
     }
 
     if (document.readyState === 'loading') {


### PR DESCRIPTION
## Summary

Closes #95.

The in-app setup overlay stored every value (HA token, Plex URL, Radarr/Sonarr URLs and keys, TMDB region) in each browser's `localStorage`, so the user reported the kiosk looked configured on Master Panel but blank on a phone or the HA app. The canonical Connection / Coming Soon / TMDB config has always lived in the add-on Configuration tab (or Docker env vars) — the unified server reads it once at boot. This PR teaches the frontend to trust the server, and teaches the server to expose a non-secret summary the frontend can render.

### Changes
- **`GET /api/config`** now also exposes `mode`, `managed`, the canonical Plex / Radarr / Sonarr URLs, the configured Plex username, and `*Set` booleans for every secret. **Secrets are never returned**; only an `apiKeySet: true|false` flag.
- **Setup overlay**:
  - New "Settings are managed by the Now Showing add-on" banner appears in unified-server mode with a read-only summary of what the server loaded (mode, display, backend/player, Plex/Radarr/Sonarr URLs, TMDB region + configured status).
  - Blank non-secret fields are pre-filled from `/api/config` so a fresh phone never renders an empty form just because that browser hasn't been seeded. Secrets are deliberately left blank (and the password input stays redacted) — leaving them blank means "use the server value", so we can never accidentally overwrite a configured server token with an empty string.
  - First-run auto-open is suppressed in unified-server mode (the server already has a working HA token; a brand-new phone shouldn't be forced through a setup form pretending to need credentials).
  - Save-button validation no longer demands an HA / Radarr / Sonarr token in unified-server mode.
  - The setup gear icon is shown unconditionally in server mode so the overlay stays reachable.
  - Subtitle copy updated: "Values are saved to this device's localStorage" was the misleading claim that gave rise to #95. It now correctly explains that connection/Coming Soon/TMDB are server-managed and only display preferences are per-device.
- **TMDB status panel** (#91 follow-up): the Coming Soon section now shows whether `tmdb_api_key` is configured on the server and which `tmdb_region` is active, with an inline pointer to the add-on Configuration tab. The kiosk frontend never calls TMDB directly, so this is intentionally a status display rather than an input.
- **Docs**: new "Where setup lives (server-managed vs per-device) — #95" section in `addons/plex-now-showing/DOCS.md`, plus a one-time migration note for users upgrading from v2.1.3 or earlier.
- **Changelog**: documented under an Unreleased section (no version bump).

### What changed for HACS-only / standalone direct-HTML installs
Nothing functional. Those installs have no `/api/config` endpoint, so the banner stays hidden and the form continues to work exactly as before, writing per-tablet `pns.*` keys to `localStorage`.

### Migration
- No action required for the canonical values — they were already read from add-on options.
- Users who previously filled in the in-app setup overlay should copy those same values into **Settings → Add-ons → Now Showing → Configuration** once. Every device picks them up automatically on the next reload.
- Per-device localStorage values are left untouched and continue to work as display-preference overrides.

## Test plan

- [x] All 173 server tests pass (`node --test test/*.test.js`)
- [x] New regression test: `GET /api/config` surfaces canonical setup state (mode, plex URL, Radarr/Sonarr URLs, TMDB region + configured boolean) without leaking any secret value
- [x] New test: `*Set` booleans are `false` when secrets are blank
- [x] New test: a fresh request (no headers, no cookies) returns the full canonical state — i.e. a brand-new phone hitting either the ingress or LAN URL gets the same answer as Master Panel
- [x] Existing `GET /api/config` regression test updated for the new fields
- [x] HTML JS syntax checked (no parse errors)
- [ ] Manual smoke test in HA add-on after merge: open the kiosk on a phone that has never visited that origin and confirm the banner + summary render with the values from add-on Configuration

🤖 Generated with [Claude Code](https://claude.com/claude-code)