### PR TITLE
Persistent server-side setup overlay (#98)

### DIFF
--- a/addons/plex-now-showing/CHANGELOG.md
+++ b/addons/plex-now-showing/CHANGELOG.md
@@ -3,6 +3,45 @@
 All notable changes to the Now Showing add-on will be documented here.
 The project follows [Semantic Versioning](https://semver.org/).
 
+## Unreleased
+
+### Added
+- Server-side persistent setup overlay (closes #98). The in-app setup
+  overlay (gear icon / `#setup`) is now a real persistent configuration
+  editor: every relevant field, including TMDB API key + region, HA
+  token, Plex/Radarr/Sonarr URLs and keys, Coming Soon counts, and
+  visual settings, is editable in the overlay and saves server-side via
+  `POST /api/setup`. Values are stored in `/data/overlay.json` on the
+  add-on disk and propagate to every browser, kiosk, and phone on the
+  next page load. No more "configured on Master Panel, blank on the
+  phone" — saving from any device updates them all.
+- New API surface: `GET /api/setup`, `POST /api/setup`,
+  `POST /api/setup/reset`. Secrets are never returned by the server —
+  only `*Set` booleans — and saving a blank secret preserves the
+  existing value so users can edit non-secret fields without re-typing
+  tokens. Reset deletes the overlay file and reverts every device to
+  the add-on/Docker defaults.
+- `/api/config` now also surfaces `haUrl`, `haUrlSet`, `haTokenSet`,
+  and `landscape` so the in-app overlay can prefill non-secret fields
+  consistently across clients.
+
+### Changed
+- Setup overlay now POSTs to the server in add-on/Docker mode instead
+  of writing to `localStorage` only. localStorage is still written as
+  a per-device cache so HACS-only installs (no server) keep working
+  unchanged.
+- Config precedence is now explicit: env / add-on options provide
+  *defaults*, the persistent overlay file *overrides* them where set.
+  Clearing a non-secret overlay field falls back to the env default;
+  the explicit `/api/setup/reset` endpoint wipes the file entirely.
+
+### Fixed
+- TMDB section in the setup overlay no longer leaves the heading
+  orphaned when `/api/config` fails — a fallback hint is shown
+  instead, and TMDB API key + region are now editable from the overlay
+  itself (closes #97). Existing add-on options / Docker env values
+  remain supported as defaults.
+
 ## 2.1.4 - 2026-05-09
 
 ### Fixed

--- a/addons/plex-now-showing/DOCS.md
+++ b/addons/plex-now-showing/DOCS.md
@@ -104,30 +104,44 @@ In the Home Assistant add-on, the setup overlay opens at the top and scrolls
 inside Ingress, so all controls remain reachable on smaller tablet or desktop
 iframes without zooming out.
 
-### Where setup lives (server-managed vs per-device) — #95
+### Where setup lives (server-managed vs per-device) — #95 / #98
 
-When you install the add-on (or run the unified server in Docker), the
-**canonical setup** lives in **Settings → Add-ons → Now Showing →
-Configuration** (or, for Docker, your `docker-compose.yml` / `.env`). The
-server reads those values once at boot and exposes a non-secret summary at
-`GET /api/config` so every tablet, phone, kiosk, or HA app shares the same
-values, regardless of how the kiosk was opened.
+The add-on (and the unified Docker server) keeps a **single shared,
+persistent configuration** that every browser, phone, kiosk, and HA app
+sees the same way. Settings now have two equivalent edit paths:
 
-The in-app setup overlay (the gear icon on the live display, or `#setup`)
-is now a **per-device override**: it stores values in this browser's
-`localStorage` so a single tablet can pin display preferences (theme,
-backdrops, frame style, etc.) without affecting the rest of the fleet. It
-is **not** the source of truth for connection details, Coming Soon, or
-TMDB. When you open the overlay on a fresh phone you'll see a
-"Settings are managed by the Now Showing add-on" banner with a read-only
-summary of what the server has loaded.
+1. **In-app setup overlay** (gear icon on the live display, or `#setup`)
+   — saves values to `/data/overlay.json` inside the add-on (or the path
+   pointed to by `OVERLAY_CONFIG_PATH` for Docker), via `POST /api/setup`.
+   These persist across add-on updates and HA restarts and apply to every
+   device on the next page load. **TMDB API key + region, HA token,
+   Plex/Radarr/Sonarr URLs and keys, Coming Soon counts, and visual
+   settings are all editable here.**
+2. **Add-on Configuration tab** (or Docker `.env` / env vars) — provides
+   the **defaults** the server falls back to when nothing has been saved
+   from the overlay. Add-on/Docker values stay supported so existing
+   installs keep working without any change.
+
+**Precedence:** overlay-saved values override add-on/Docker defaults.
+Saving a blank value clears that override and lets the add-on/Docker
+default re-apply. Saving a blank **secret** field (token / API key)
+**preserves the existing saved/default secret** so you can edit a
+non-secret field without re-typing tokens. To wipe the server-side
+overlay and revert every device to add-on/Docker defaults, click "Clear
+saved settings" in the overlay and confirm both prompts (the second one
+is the server-side reset).
+
+**Secrets safety:** the server never returns saved secret values to the
+browser. The overlay only sees a `*Set` boolean per secret (e.g.
+`tmdb.apiKeySet: true`) and renders the input with a "(saved on server —
+leave blank to keep)" placeholder. Tokens stay in `/data/overlay.json`
+on the add-on disk only.
 
 If you upgraded from v2.1.3 or earlier and the kiosk used to look
 configured on Master Panel but blank on your phone, that's because v2.1.3
-wrote setup values only to each browser's `localStorage`. Re-save the
-values once in **Settings → Add-ons → Now Showing → Configuration** and
-every device will pick them up automatically — no per-tablet re-entry
-needed.
+wrote setup values only to each browser's `localStorage`. With v2.1.5+
+just open the in-app setup overlay once, save, and every other device
+will pick up the same values automatically.
 Advanced users can still set `pns.visualProgressBar=true` /
 `pns.visualRatingsBadges=true` / `pns.visualGenreChips=true` /
 `pns.visualInfoPanelMode=on_pause` / `pns.visualFrameStyle=gold-line` /

--- a/server/README.md
+++ b/server/README.md
@@ -19,7 +19,10 @@ Standalone (HACS-only) installs continue to work against the unmodified
 | GET    | `/api`                            | Version + mode + backend + endpoint listing              |
 | GET    | `/api/state`                      | Normalised now-playing payload (3 s TTL cache)          |
 | GET    | `/api/coming-soon`                | Radarr/Sonarr upcoming items for Coming Soon mode       |
-| GET    | `/api/config`                     | Browser-safe runtime flags (visual toggles)              |
+| GET    | `/api/config`                     | Browser-safe runtime flags (visual toggles + non-secret summary) |
+| GET    | `/api/setup`                      | Effective setup state (incl. `*Set` booleans for secrets) |
+| POST   | `/api/setup`                      | Persist overlay-edited settings to `/data/overlay.json` |
+| POST   | `/api/setup/reset`                | Delete the overlay file → revert to env/options defaults |
 | GET    | `/api/night-mode`                 | `{configured, on}` for the optional night-mode HA entity |
 | GET    | `/api/media-info/:ratingKey`      | Plex metadata for the info panel (10 min TTL cache)      |
 | GET    | `/healthz`                        | Liveness probe (doesn't call upstream)                   |
@@ -41,6 +44,24 @@ For HA Container users running via Docker Compose. Set:
 |---------|----------|-------|
 | `HA_URL`   | yes | e.g. `https://ha.example.com:8123` (trailing slash ok) |
 | `HA_TOKEN` | yes | Long-lived access token |
+
+## Persistent overlay configuration (#98)
+
+The in-app setup overlay (gear icon / `#setup`) is a real persistent
+configuration editor. POST /api/setup writes to a JSON file at
+`/data/overlay.json` (override with `OVERLAY_CONFIG_PATH`) and the next
+GET reflects the saved values across every browser, kiosk, and phone.
+
+**Precedence**: env / add-on options form the *defaults*; the overlay file
+*overrides* them where set. Clearing a non-secret field in the overlay
+falls back to the env default. Saving a blank **secret** preserves the
+existing value (so users can edit non-secret fields without re-typing
+tokens). `POST /api/setup/reset` deletes the overlay file completely.
+
+**Secret safety**: the server never returns saved secrets. `/api/config`
+and `/api/setup` only surface a `*Set` boolean per secret (e.g.
+`comingSoon.tmdb.apiKeySet: true`). Secrets are written to
+`/data/overlay.json` on the add-on disk and never appear in HTTP responses.
 
 ## All environment variables
 
@@ -95,6 +116,7 @@ For HA Container users running via Docker Compose. Set:
 | `VISUAL_MARQUEE_BG_COLOR` | _empty_ | Optional `#RRGGBB` marquee background/curtain override. Empty uses the active theme |
 | `VISUAL_CORNER_RADIUS_PX` | `0` | Inner marquee, poster, and info-panel corner radius in px, clamped 0-48 |
 | `STATIC_DIR` | `../www` | Override where `now_showing.html` is served from |
+| `OVERLAY_CONFIG_PATH` | `/data/overlay.json` | Path to the persistent overlay-config JSON (#98) |
 
 ## Local development
 

--- a/server/src/config.js
+++ b/server/src/config.js
@@ -230,7 +230,7 @@ function parseHexColor(v, defaultValue) {
   return /^#[0-9a-f]{6}$/.test(s) ? s : defaultValue;
 }
 
-function validate(c) {
+export function validate(c) {
   const errors = [];
   if (!c.haUrl) errors.push('haUrl is required (set HA_URL or run as an add-on)');
   if (!c.haToken) errors.push('haToken is required (set HA_TOKEN or run as an add-on so SUPERVISOR_TOKEN is provided)');

--- a/server/src/overlayStore.js
+++ b/server/src/overlayStore.js
@@ -1,0 +1,197 @@
+// Persistent overlay-config store (#98).
+//
+// Storage rationale:
+//   The HA add-on mounts /data, which survives add-on updates and HA restarts
+//   (Supervisor never wipes it). Docker users who want overlay persistence
+//   bind-mount a host directory at /data (or set OVERLAY_CONFIG_PATH to a
+//   different file). HACS-only installs have no server, so this module is
+//   never loaded there.
+//
+// Precedence:
+//   The file holds the *user-edited* values from the in-app setup overlay.
+//   They override the env/options defaults that loadConfig() resolves first.
+//   A blank/cleared field in the overlay file means "fall back to env"; we
+//   never write empty strings for fields the user left blank, so removing a
+//   key from the file is the explicit clear/reset path.
+//
+// Secret handling:
+//   Secrets live alongside non-secret fields but are never returned by the
+//   overlay-aware /api/config or /api/setup endpoints — only their *Set
+//   booleans are. POST /api/setup leaves a blank secret untouched (so the
+//   user can edit a non-secret field without re-typing the token); an
+//   explicit reset endpoint is the only way to clear them.
+//
+// The file is plain JSON, atomically rewritten with tmp+rename so a crash
+// mid-write can't corrupt it.
+
+import { mkdirSync, readFileSync, writeFileSync, renameSync, existsSync, unlinkSync } from 'node:fs';
+import { dirname } from 'node:path';
+
+// Fields the overlay is allowed to write. Anything outside this list is
+// dropped on save — defence in depth against a tampered POST body trying to
+// set fields the schema doesn't expose.
+//
+// Secret keys are listed separately so handlePost() can apply the
+// "blank preserves existing" rule without having to know the wider schema.
+export const OVERLAY_TOP_KEYS = [
+  'haUrl',
+  'displayMode',
+  'backend',
+  'player',
+  'plexUrl',
+  'plexUsername',
+  'landscape',
+  'switcherEnabled',
+  'switcherIntervalMs',
+  'fullyKiosksRaw',
+];
+
+export const OVERLAY_TOP_SECRET_KEYS = [
+  'haToken',
+  'plexToken',
+];
+
+export const OVERLAY_COMING_SOON_KEYS = [
+  'title',
+  'radarrUrl',
+  'sonarrUrl',
+  'moviesCount',
+  'showsCount',
+  'cycleInterval',
+  'daysOffset',
+  'lookaheadDays',
+  'imageType',
+];
+
+export const OVERLAY_COMING_SOON_SECRET_KEYS = [
+  'radarrApiKey',
+  'sonarrApiKey',
+];
+
+export const OVERLAY_TMDB_KEYS = ['region'];
+export const OVERLAY_TMDB_SECRET_KEYS = ['apiKey'];
+
+export const OVERLAY_VISUAL_KEYS = [
+  'progressBar',
+  'ratingsBadges',
+  'genreChips',
+  'infoPanelMode',
+  'useBackdrops',
+  'frameStyle',
+  'bulbSizePx',
+  'marqueeFont',
+  'backdropStyle',
+  'backdropDelayMs',
+  'burnInMitigation',
+  'nudgeIntervalMs',
+  'nudgeAmplitudePx',
+  'nightModeEntity',
+  'nightModeOpacity',
+  'theme',
+  'accentColor',
+  'marqueeBgColor',
+  'cornerRadiusPx',
+];
+
+export function defaultOverlayPath() {
+  // /data is the conventional add-on persistent path; if it exists we use it
+  // even outside add-on mode (Docker users who bind-mount it pick this up).
+  // Otherwise fall back to the repo-local path used in tests.
+  return process.env.OVERLAY_CONFIG_PATH || '/data/overlay.json';
+}
+
+export function createOverlayStore(filePath = defaultOverlayPath()) {
+  function read() {
+    try {
+      if (!existsSync(filePath)) return {};
+      const raw = readFileSync(filePath, 'utf8');
+      if (!raw.trim()) return {};
+      const parsed = JSON.parse(raw);
+      return (parsed && typeof parsed === 'object') ? parsed : {};
+    } catch (err) {
+      // Don't crash the server because of a malformed overlay file — that
+      // would lock the user out of the setup UI that fixes it. Log and act
+      // as if no overlay is present so env defaults apply.
+      console.warn(`[overlay] failed to read ${filePath}: ${err.message}`);
+      return {};
+    }
+  }
+
+  function write(obj) {
+    try {
+      mkdirSync(dirname(filePath), { recursive: true });
+    } catch (_) { /* ignore */ }
+    const tmp = `${filePath}.tmp`;
+    writeFileSync(tmp, JSON.stringify(obj || {}, null, 2));
+    renameSync(tmp, filePath);
+  }
+
+  function clear() {
+    try {
+      if (existsSync(filePath)) unlinkSync(filePath);
+    } catch (err) {
+      console.warn(`[overlay] failed to clear ${filePath}: ${err.message}`);
+    }
+  }
+
+  return { read, write, clear, filePath };
+}
+
+// Apply overlay JSON over a base config produced by loadConfig(). Returns
+// a new config object — never mutates the input. Empty strings in the
+// overlay are treated as "not set" so users can blank a non-secret field
+// to fall back to env (and so a stale empty token can't accidentally
+// override a working env token).
+export function applyOverlay(baseConfig, overlay) {
+  if (!overlay || typeof overlay !== 'object') return baseConfig;
+  const out = { ...baseConfig };
+  out.comingSoon = { ...(baseConfig.comingSoon || {}) };
+  out.comingSoon.tmdb = { ...((baseConfig.comingSoon && baseConfig.comingSoon.tmdb) || {}) };
+  out.visual = { ...(baseConfig.visual || {}) };
+
+  const overrideString = (target, src, key) => {
+    const v = src[key];
+    if (typeof v === 'string' && v.length > 0) target[key] = v;
+  };
+  const overrideBool = (target, src, key) => {
+    if (typeof src[key] === 'boolean') target[key] = src[key];
+  };
+  const overrideNumber = (target, src, key) => {
+    if (typeof src[key] === 'number' && Number.isFinite(src[key])) target[key] = src[key];
+  };
+
+  for (const k of OVERLAY_TOP_KEYS) {
+    if (k === 'landscape' || k === 'switcherEnabled') overrideBool(out, overlay, k);
+    else if (k === 'switcherIntervalMs') overrideNumber(out, overlay, k);
+    else overrideString(out, overlay, k);
+  }
+  for (const k of OVERLAY_TOP_SECRET_KEYS) overrideString(out, overlay, k);
+
+  const cs = overlay.comingSoon || {};
+  for (const k of OVERLAY_COMING_SOON_KEYS) {
+    if (['moviesCount', 'showsCount', 'cycleInterval', 'daysOffset', 'lookaheadDays'].includes(k)) {
+      overrideNumber(out.comingSoon, cs, k);
+    } else {
+      overrideString(out.comingSoon, cs, k);
+    }
+  }
+  for (const k of OVERLAY_COMING_SOON_SECRET_KEYS) overrideString(out.comingSoon, cs, k);
+
+  const tmdb = (cs.tmdb) || {};
+  for (const k of OVERLAY_TMDB_KEYS) overrideString(out.comingSoon.tmdb, tmdb, k);
+  for (const k of OVERLAY_TMDB_SECRET_KEYS) overrideString(out.comingSoon.tmdb, tmdb, k);
+
+  const v = overlay.visual || {};
+  for (const k of OVERLAY_VISUAL_KEYS) {
+    if (['progressBar', 'ratingsBadges', 'genreChips', 'useBackdrops', 'burnInMitigation'].includes(k)) {
+      overrideBool(out.visual, v, k);
+    } else if (['bulbSizePx', 'backdropDelayMs', 'nudgeIntervalMs', 'nudgeAmplitudePx',
+                'nightModeOpacity', 'cornerRadiusPx'].includes(k)) {
+      overrideNumber(out.visual, v, k);
+    } else {
+      overrideString(out.visual, v, k);
+    }
+  }
+
+  return out;
+}

--- a/server/src/routes/config.js
+++ b/server/src/routes/config.js
@@ -27,6 +27,13 @@ export function configRoute({ config }) {
       // per-tablet).
       mode: config.mode || 'standalone',
       managed: !!config.haToken, // server already has a working HA token
+      // #98 — overlay-aware extras so the in-app setup form can prefill
+      // non-secret fields without a separate request. Secrets stay behind
+      // *Set booleans only.
+      haUrl: config.haUrl || '',
+      haUrlSet: !!config.haUrl,
+      haTokenSet: !!config.haToken,
+      landscape: !!config.landscape,
       displayMode: config.displayMode || 'now_showing',
       backend: config.backend || 'plex',
       player: config.player || '',

--- a/server/src/routes/setup.js
+++ b/server/src/routes/setup.js
@@ -1,0 +1,538 @@
+// /api/setup — server-side persistent configuration editor (#98).
+//
+// GET  /api/setup             returns the effective non-secret config plus
+//                              *Set booleans for every secret. Same shape as
+//                              GET /api/config but with the extras the setup
+//                              overlay needs (haUrlSet, switcher fields, …).
+//
+// POST /api/setup             accepts a JSON body of overlay updates. Only
+//                              fields listed in OVERLAY_*_KEYS are honoured;
+//                              everything else is ignored. Blank secret
+//                              fields preserve existing saved/env secrets so
+//                              the user can edit non-secret fields without
+//                              re-typing tokens. Returns 200 + the new
+//                              effective config on success.
+//
+// POST /api/setup/reset       deletes the overlay file. The next GET reflects
+//                              env/options defaults again. Body is ignored.
+//
+// The store and the loaded config are passed in by createApp() so the route
+// can both read the merged effective view and refresh it after a save by
+// re-applying the overlay over the env baseline.
+
+import express, { Router } from 'express';
+import {
+  OVERLAY_TOP_KEYS, OVERLAY_TOP_SECRET_KEYS,
+  OVERLAY_COMING_SOON_KEYS, OVERLAY_COMING_SOON_SECRET_KEYS,
+  OVERLAY_TMDB_KEYS, OVERLAY_TMDB_SECRET_KEYS,
+  OVERLAY_VISUAL_KEYS,
+  applyOverlay,
+} from '../overlayStore.js';
+
+// Whitelisted enum values — match config.js.
+const DISPLAY_MODES = ['now_showing', 'coming_soon'];
+const BACKENDS = ['plex', 'jellyfin', 'emby', 'kodi', 'apple_tv', 'streaming', 'kaleidescape'];
+const IMAGE_TYPES = ['poster', 'fanart'];
+const INFO_PANEL_MODES = ['on_tap', 'on_pause', 'always'];
+const FRAME_STYLES = ['bulbs', 'gold-line', 'none'];
+const MARQUEE_FONTS = ['bebas-neue', 'anton', 'oswald', 'monoton', 'playfair-display'];
+const BACKDROP_STYLES = ['fullscreen', 'ambient'];
+const VISUAL_THEMES = ['classic-gold', 'art-deco-silver', 'neon-80s', 'minimalist-dark'];
+
+const HEX_RE = /^#[0-9a-f]{6}$/;
+const REGION_RE = /^[A-Z]{2}$/;
+
+function clampInt(v, min, max) {
+  const n = parseInt(v, 10);
+  if (!Number.isFinite(n)) return null;
+  return Math.max(min, Math.min(max, n));
+}
+function clampFloat(v, min, max) {
+  const n = parseFloat(v);
+  if (!Number.isFinite(n)) return null;
+  return Math.max(min, Math.min(max, n));
+}
+function asBool(v) {
+  if (typeof v === 'boolean') return v;
+  if (typeof v === 'string') return /^(1|true|yes|on)$/i.test(v);
+  return null;
+}
+function asString(v, max = 1024) {
+  if (v == null) return null;
+  if (typeof v !== 'string') return null;
+  const s = v.trim();
+  return s.length <= max ? s : s.slice(0, max);
+}
+
+// Convert a raw POST body into the on-disk overlay JSON shape. Only fields
+// the schema knows about are forwarded; unknowns are silently dropped so a
+// hostile client can't smuggle in extras. Secrets are merged separately by
+// the route handler so blank values can preserve existing ones.
+export function sanitizeOverlayInput(body) {
+  if (!body || typeof body !== 'object') return { overlay: {}, errors: ['body_must_be_object'] };
+  const errors = [];
+  const out = {};
+
+  // Top level non-secret
+  for (const k of OVERLAY_TOP_KEYS) {
+    if (!(k in body)) continue;
+    const raw = body[k];
+    switch (k) {
+      case 'haUrl':
+      case 'plexUrl': {
+        const s = asString(raw);
+        if (s === null) { errors.push(`${k}_invalid`); break; }
+        // Allow blank string to mean "clear this override" — we drop empties
+        // when writing so they fall back to env. Strip trailing slash to
+        // match loadConfig() normalisation.
+        out[k] = s.replace(/\/$/, '');
+        break;
+      }
+      case 'displayMode': {
+        const s = asString(raw);
+        if (s && !DISPLAY_MODES.includes(s)) { errors.push('displayMode_invalid'); break; }
+        if (s !== null) out[k] = s;
+        break;
+      }
+      case 'backend': {
+        const s = asString(raw);
+        if (s && !BACKENDS.includes(s)) { errors.push('backend_invalid'); break; }
+        if (s !== null) out[k] = s;
+        break;
+      }
+      case 'player':
+      case 'plexUsername':
+      case 'fullyKiosksRaw': {
+        const s = asString(raw, 8192);
+        if (s !== null) out[k] = s;
+        break;
+      }
+      case 'landscape':
+      case 'switcherEnabled': {
+        const b = asBool(raw);
+        if (b === null) { errors.push(`${k}_invalid`); break; }
+        out[k] = b;
+        break;
+      }
+      case 'switcherIntervalMs': {
+        const n = clampInt(raw, 1000, 60000);
+        if (n === null) { errors.push(`${k}_invalid`); break; }
+        out[k] = n;
+        break;
+      }
+    }
+  }
+
+  // Top level secrets — the route applies the blank-preserves rule, but we
+  // still validate type here.
+  for (const k of OVERLAY_TOP_SECRET_KEYS) {
+    if (!(k in body)) continue;
+    const s = asString(body[k], 8192);
+    if (s === null) { errors.push(`${k}_invalid`); continue; }
+    out[k] = s;
+  }
+
+  // Coming Soon
+  if (body.comingSoon && typeof body.comingSoon === 'object') {
+    const cs = body.comingSoon;
+    out.comingSoon = {};
+    for (const k of OVERLAY_COMING_SOON_KEYS) {
+      if (!(k in cs)) continue;
+      const raw = cs[k];
+      switch (k) {
+        case 'title': {
+          const s = asString(raw, 256);
+          if (s !== null) out.comingSoon[k] = s;
+          break;
+        }
+        case 'radarrUrl':
+        case 'sonarrUrl': {
+          const s = asString(raw);
+          if (s !== null) out.comingSoon[k] = s.replace(/\/$/, '');
+          break;
+        }
+        case 'imageType': {
+          const s = asString(raw);
+          if (s && !IMAGE_TYPES.includes(s)) { errors.push('imageType_invalid'); break; }
+          if (s !== null) out.comingSoon[k] = s;
+          break;
+        }
+        case 'moviesCount':
+        case 'showsCount': {
+          const n = clampInt(raw, 0, 50);
+          if (n === null) { errors.push(`${k}_invalid`); break; }
+          out.comingSoon[k] = n;
+          break;
+        }
+        case 'cycleInterval': {
+          const n = clampInt(raw, 2, 300);
+          if (n === null) { errors.push(`${k}_invalid`); break; }
+          out.comingSoon[k] = n;
+          break;
+        }
+        case 'daysOffset': {
+          const n = clampInt(raw, 0, 365);
+          if (n === null) { errors.push(`${k}_invalid`); break; }
+          out.comingSoon[k] = n;
+          break;
+        }
+        case 'lookaheadDays': {
+          const n = clampInt(raw, 1, 365);
+          if (n === null) { errors.push(`${k}_invalid`); break; }
+          out.comingSoon[k] = n;
+          break;
+        }
+      }
+    }
+    for (const k of OVERLAY_COMING_SOON_SECRET_KEYS) {
+      if (!(k in cs)) continue;
+      const s = asString(cs[k], 8192);
+      if (s === null) { errors.push(`${k}_invalid`); continue; }
+      out.comingSoon[k] = s;
+    }
+    if (cs.tmdb && typeof cs.tmdb === 'object') {
+      out.comingSoon.tmdb = {};
+      for (const k of OVERLAY_TMDB_KEYS) {
+        if (!(k in cs.tmdb)) continue;
+        if (k === 'region') {
+          const s = asString(cs.tmdb[k], 4);
+          if (s === null) continue;
+          if (s === '') { out.comingSoon.tmdb[k] = ''; break; }
+          const upper = s.toUpperCase();
+          if (!REGION_RE.test(upper)) { errors.push('tmdb_region_invalid'); break; }
+          out.comingSoon.tmdb[k] = upper;
+        }
+      }
+      for (const k of OVERLAY_TMDB_SECRET_KEYS) {
+        if (!(k in cs.tmdb)) continue;
+        const s = asString(cs.tmdb[k], 8192);
+        if (s === null) { errors.push(`tmdb_${k}_invalid`); continue; }
+        out.comingSoon.tmdb[k] = s;
+      }
+    }
+  }
+
+  // Visual
+  if (body.visual && typeof body.visual === 'object') {
+    const v = body.visual;
+    out.visual = {};
+    for (const k of OVERLAY_VISUAL_KEYS) {
+      if (!(k in v)) continue;
+      const raw = v[k];
+      switch (k) {
+        case 'progressBar':
+        case 'ratingsBadges':
+        case 'genreChips':
+        case 'useBackdrops':
+        case 'burnInMitigation': {
+          const b = asBool(raw);
+          if (b === null) { errors.push(`visual_${k}_invalid`); break; }
+          out.visual[k] = b;
+          break;
+        }
+        case 'infoPanelMode': {
+          const s = asString(raw);
+          if (s && !INFO_PANEL_MODES.includes(s)) { errors.push('visual_infoPanelMode_invalid'); break; }
+          if (s !== null) out.visual[k] = s;
+          break;
+        }
+        case 'frameStyle': {
+          const s = asString(raw);
+          if (s && !FRAME_STYLES.includes(s)) { errors.push('visual_frameStyle_invalid'); break; }
+          if (s !== null) out.visual[k] = s;
+          break;
+        }
+        case 'marqueeFont': {
+          const s = asString(raw);
+          if (s && !MARQUEE_FONTS.includes(s)) { errors.push('visual_marqueeFont_invalid'); break; }
+          if (s !== null) out.visual[k] = s;
+          break;
+        }
+        case 'backdropStyle': {
+          const s = asString(raw);
+          if (s && !BACKDROP_STYLES.includes(s)) { errors.push('visual_backdropStyle_invalid'); break; }
+          if (s !== null) out.visual[k] = s;
+          break;
+        }
+        case 'theme': {
+          const s = asString(raw);
+          if (s && !VISUAL_THEMES.includes(s)) { errors.push('visual_theme_invalid'); break; }
+          if (s !== null) out.visual[k] = s;
+          break;
+        }
+        case 'bulbSizePx': {
+          const n = clampInt(raw, 12, 48);
+          if (n === null) { errors.push('visual_bulbSizePx_invalid'); break; }
+          out.visual[k] = n;
+          break;
+        }
+        case 'backdropDelayMs': {
+          const n = clampInt(raw, 1000, 600000);
+          if (n === null) { errors.push('visual_backdropDelayMs_invalid'); break; }
+          out.visual[k] = n;
+          break;
+        }
+        case 'nudgeIntervalMs': {
+          const n = clampInt(raw, 5000, 600000);
+          if (n === null) { errors.push('visual_nudgeIntervalMs_invalid'); break; }
+          out.visual[k] = n;
+          break;
+        }
+        case 'nudgeAmplitudePx': {
+          const n = clampInt(raw, 1, 16);
+          if (n === null) { errors.push('visual_nudgeAmplitudePx_invalid'); break; }
+          out.visual[k] = n;
+          break;
+        }
+        case 'cornerRadiusPx': {
+          const n = clampInt(raw, 0, 48);
+          if (n === null) { errors.push('visual_cornerRadiusPx_invalid'); break; }
+          out.visual[k] = n;
+          break;
+        }
+        case 'nightModeOpacity': {
+          const n = clampFloat(raw, 0, 0.95);
+          if (n === null) { errors.push('visual_nightModeOpacity_invalid'); break; }
+          out.visual[k] = n;
+          break;
+        }
+        case 'nightModeEntity': {
+          const s = asString(raw, 256);
+          if (s !== null) out.visual[k] = s;
+          break;
+        }
+        case 'accentColor':
+        case 'marqueeBgColor': {
+          const s = asString(raw, 16);
+          if (s === null) { errors.push(`visual_${k}_invalid`); break; }
+          if (s === '') { out.visual[k] = ''; break; }
+          const lower = s.toLowerCase();
+          if (!HEX_RE.test(lower)) { errors.push(`visual_${k}_invalid`); break; }
+          out.visual[k] = lower;
+          break;
+        }
+      }
+    }
+  }
+
+  return { overlay: out, errors };
+}
+
+// Merge `incoming` over `existing` overlay JSON. Drops blank non-secret
+// strings so the user can clear an override; keeps existing secret values
+// when the incoming secret is blank. Empty strings for secrets are an
+// explicit "clear" signal only when `clearSecrets` is true (used by the
+// reset endpoint).
+export function mergeOverlay(existing = {}, incoming = {}) {
+  const out = JSON.parse(JSON.stringify(existing || {}));
+
+  // Top level non-secret
+  for (const k of OVERLAY_TOP_KEYS) {
+    if (!(k in incoming)) continue;
+    const v = incoming[k];
+    if (typeof v === 'string' && v === '') delete out[k];
+    else out[k] = v;
+  }
+  // Top level secrets — blank preserves existing
+  for (const k of OVERLAY_TOP_SECRET_KEYS) {
+    if (!(k in incoming)) continue;
+    const v = incoming[k];
+    if (typeof v === 'string' && v === '') continue;
+    out[k] = v;
+  }
+
+  if (incoming.comingSoon) {
+    out.comingSoon = { ...(out.comingSoon || {}) };
+    for (const k of OVERLAY_COMING_SOON_KEYS) {
+      if (!(k in incoming.comingSoon)) continue;
+      const v = incoming.comingSoon[k];
+      if (typeof v === 'string' && v === '') delete out.comingSoon[k];
+      else out.comingSoon[k] = v;
+    }
+    for (const k of OVERLAY_COMING_SOON_SECRET_KEYS) {
+      if (!(k in incoming.comingSoon)) continue;
+      const v = incoming.comingSoon[k];
+      if (typeof v === 'string' && v === '') continue;
+      out.comingSoon[k] = v;
+    }
+    if (incoming.comingSoon.tmdb) {
+      out.comingSoon.tmdb = { ...((out.comingSoon && out.comingSoon.tmdb) || {}) };
+      for (const k of OVERLAY_TMDB_KEYS) {
+        if (!(k in incoming.comingSoon.tmdb)) continue;
+        const v = incoming.comingSoon.tmdb[k];
+        if (typeof v === 'string' && v === '') delete out.comingSoon.tmdb[k];
+        else out.comingSoon.tmdb[k] = v;
+      }
+      for (const k of OVERLAY_TMDB_SECRET_KEYS) {
+        if (!(k in incoming.comingSoon.tmdb)) continue;
+        const v = incoming.comingSoon.tmdb[k];
+        if (typeof v === 'string' && v === '') continue;
+        out.comingSoon.tmdb[k] = v;
+      }
+    }
+  }
+
+  if (incoming.visual) {
+    out.visual = { ...(out.visual || {}) };
+    for (const k of OVERLAY_VISUAL_KEYS) {
+      if (!(k in incoming.visual)) continue;
+      const v = incoming.visual[k];
+      // Blank string = clear the override; the rest are passed through (a
+      // boolean false is a real saved value, not "unset").
+      if (typeof v === 'string' && v === '' && !['accentColor', 'marqueeBgColor'].includes(k)) {
+        delete out.visual[k];
+      } else {
+        out.visual[k] = v;
+      }
+    }
+  }
+
+  return out;
+}
+
+// Build the response body for GET /api/setup. Same as /api/config but with
+// the extra fields the overlay needs (haUrlSet, fullyKiosksRaw, etc.).
+export function effectiveSetupView(config) {
+  return {
+    mode: config.mode || 'standalone',
+    managed: !!config.haToken,
+    haUrl: config.haUrl || '',
+    haUrlSet: !!config.haUrl,
+    haTokenSet: !!config.haToken,
+    displayMode: config.displayMode || 'now_showing',
+    backend: config.backend || 'plex',
+    player: config.player || '',
+    landscape: !!config.landscape,
+    plex: {
+      urlSet: !!config.plexUrl,
+      url: config.plexUrl || '',
+      tokenSet: !!config.plexToken,
+      username: config.plexUsername || '',
+    },
+    comingSoon: {
+      title: config.comingSoon?.title || 'Coming Soon',
+      enabled: !!((config.comingSoon?.radarrUrl && config.comingSoon?.radarrApiKey)
+        || (config.comingSoon?.sonarrUrl && config.comingSoon?.sonarrApiKey)),
+      moviesCount: config.comingSoon?.moviesCount ?? 5,
+      showsCount: config.comingSoon?.showsCount ?? 5,
+      cycleInterval: config.comingSoon?.cycleInterval ?? 8,
+      daysOffset: config.comingSoon?.daysOffset ?? 0,
+      lookaheadDays: config.comingSoon?.lookaheadDays ?? 90,
+      imageType: config.comingSoon?.imageType || 'poster',
+      radarrUrl: config.comingSoon?.radarrUrl || '',
+      radarrApiKeySet: !!config.comingSoon?.radarrApiKey,
+      sonarrUrl: config.comingSoon?.sonarrUrl || '',
+      sonarrApiKeySet: !!config.comingSoon?.sonarrApiKey,
+      tmdb: {
+        enabled: !!config.comingSoon?.tmdb?.apiKey,
+        apiKeySet: !!config.comingSoon?.tmdb?.apiKey,
+        region: config.comingSoon?.tmdb?.region || 'AU',
+      },
+    },
+    visual: {
+      progressBar: !!config.visual?.progressBar,
+      ratingsBadges: !!config.visual?.ratingsBadges,
+      genreChips: !!config.visual?.genreChips,
+      infoPanelMode: config.visual?.infoPanelMode || 'on_tap',
+      useBackdrops: !!config.visual?.useBackdrops,
+      frameStyle: config.visual?.frameStyle || 'bulbs',
+      bulbSizePx: config.visual?.bulbSizePx ?? 28,
+      marqueeFont: config.visual?.marqueeFont || 'bebas-neue',
+      backdropStyle: config.visual?.backdropStyle || 'fullscreen',
+      backdropDelayMs: Number.isFinite(config.visual?.backdropDelayMs) ? config.visual.backdropDelayMs : 10000,
+      burnInMitigation: !!config.visual?.burnInMitigation,
+      nudgeIntervalMs: config.visual?.nudgeIntervalMs ?? 60000,
+      nudgeAmplitudePx: config.visual?.nudgeAmplitudePx ?? 4,
+      nightModeEntity: config.visual?.nightModeEntity || '',
+      nightModeOpacity: config.visual?.nightModeOpacity ?? 0.4,
+      theme: config.visual?.theme || 'classic-gold',
+      accentColor: config.visual?.accentColor || '',
+      marqueeBgColor: config.visual?.marqueeBgColor || '',
+      cornerRadiusPx: config.visual?.cornerRadiusPx ?? 0,
+    },
+    switcher: {
+      enabled: !!config.switcherEnabled,
+      intervalMs: config.switcherIntervalMs ?? 5000,
+      kiosksRawSet: !!config.fullyKiosksRaw,
+    },
+  };
+}
+
+// Replace each top-level field of `target` with the corresponding field of
+// `next`, recursively for the two nested objects we care about. Keeps the
+// same object reference so other routes that captured `config` see the
+// updated values on their next request.
+function mutateInPlace(target, next) {
+  if (!target || !next) return;
+  for (const k of Object.keys(target)) {
+    if (k === 'comingSoon' || k === 'visual') continue;
+    if (!(k in next)) delete target[k];
+  }
+  for (const k of Object.keys(next)) {
+    if (k === 'comingSoon' || k === 'visual') continue;
+    target[k] = next[k];
+  }
+  // comingSoon (and its tmdb sub-object)
+  if (!target.comingSoon) target.comingSoon = {};
+  for (const k of Object.keys(target.comingSoon)) {
+    if (k === 'tmdb') continue;
+    if (!next.comingSoon || !(k in next.comingSoon)) delete target.comingSoon[k];
+  }
+  for (const k of Object.keys(next.comingSoon || {})) {
+    if (k === 'tmdb') continue;
+    target.comingSoon[k] = next.comingSoon[k];
+  }
+  if (!target.comingSoon.tmdb) target.comingSoon.tmdb = {};
+  const nextTmdb = (next.comingSoon && next.comingSoon.tmdb) || {};
+  for (const k of Object.keys(target.comingSoon.tmdb)) {
+    if (!(k in nextTmdb)) delete target.comingSoon.tmdb[k];
+  }
+  for (const k of Object.keys(nextTmdb)) target.comingSoon.tmdb[k] = nextTmdb[k];
+  // visual
+  if (!target.visual) target.visual = {};
+  for (const k of Object.keys(target.visual)) {
+    if (!next.visual || !(k in next.visual)) delete target.visual[k];
+  }
+  for (const k of Object.keys(next.visual || {})) target.visual[k] = next.visual[k];
+}
+
+export function setupRoute({ baseConfig, liveConfig, store }) {
+  const r = Router();
+
+  r.get('/api/setup', (_req, res) => {
+    res.set('Cache-Control', 'no-store');
+    res.json(effectiveSetupView(liveConfig));
+  });
+
+  r.post('/api/setup', express.json({ limit: '256kb' }), (req, res) => {
+    const { overlay, errors } = sanitizeOverlayInput(req.body);
+    if (errors.length > 0) {
+      return res.status(400).json({ error: 'invalid_setup_payload', details: errors });
+    }
+    try {
+      const existing = store.read();
+      const merged = mergeOverlay(existing, overlay);
+      store.write(merged);
+      const effective = applyOverlay(baseConfig, merged);
+      mutateInPlace(liveConfig, effective);
+      return res.json(effectiveSetupView(liveConfig));
+    } catch (err) {
+      console.error('[setup] save failed:', err.message);
+      return res.status(500).json({ error: 'setup_save_failed', message: err.message });
+    }
+  });
+
+  r.post('/api/setup/reset', (_req, res) => {
+    try {
+      store.clear();
+      const effective = applyOverlay(baseConfig, {});
+      mutateInPlace(liveConfig, effective);
+      return res.json(effectiveSetupView(liveConfig));
+    } catch (err) {
+      console.error('[setup] reset failed:', err.message);
+      return res.status(500).json({ error: 'setup_reset_failed', message: err.message });
+    }
+  });
+
+  return r;
+}

--- a/server/src/server.js
+++ b/server/src/server.js
@@ -12,7 +12,7 @@ import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
-import { loadConfig } from './config.js';
+import { loadConfig, validate as validateRuntime } from './config.js';
 import { createCache } from './cache.js';
 import { createHaClient } from './ha.js';
 import { createSwitcher, parseKiosks } from './switcher.js';
@@ -25,13 +25,41 @@ import { artworkRoute } from './routes/artwork.js';
 import { plexArtRoute } from './routes/plexArt.js';
 import { nightModeRoute } from './routes/nightMode.js';
 import { comingSoonRoute } from './routes/comingSoon.js';
+import { setupRoute } from './routes/setup.js';
+import { createOverlayStore, applyOverlay } from './overlayStore.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const pkg = JSON.parse(readFileSync(join(__dirname, '..', 'package.json'), 'utf8'));
 
-export function createApp({ config, haClient }) {
+export function createApp({ config, haClient, overlayStore, baseConfig }) {
   const app = express();
   app.disable('x-powered-by');
+
+  // The setup route needs the *env-only* baseline so it can re-merge the
+  // overlay from scratch on every save (otherwise clearing an overlay key
+  // would fall back to a previously-overlaid value, not env defaults).
+  // Tests that don't supply baseConfig are env-only, so cloning `config`
+  // works there too.
+  const baseline = baseConfig
+    ? JSON.parse(JSON.stringify(baseConfig))
+    : JSON.parse(JSON.stringify(config));
+  const store = overlayStore || createOverlayStore();
+  // If the caller didn't pre-merge the overlay, do it here so first-request
+  // state reflects the saved overlay even in tests / programmatic setups.
+  // (In direct-run mode, the boot path has already done this; the read+apply
+  // is idempotent, so doing it again is harmless.)
+  try {
+    const persisted = store.read();
+    if (persisted && Object.keys(persisted).length > 0) {
+      const merged = applyOverlay(baseline, persisted);
+      Object.assign(config, merged);
+      config.comingSoon = { ...(merged.comingSoon || {}) };
+      config.comingSoon.tmdb = { ...((merged.comingSoon && merged.comingSoon.tmdb) || {}) };
+      config.visual = { ...(merged.visual || {}) };
+    }
+  } catch (err) {
+    console.warn(`[overlay] failed to apply persisted overlay: ${err.message}`);
+  }
 
   // Optional shared-secret header — only enforced if PROXY_SECRET is set.
   if (config.proxySecret) {
@@ -67,6 +95,7 @@ export function createApp({ config, haClient }) {
   app.use(rootRoute({ config, version: pkg.version }));
   app.use(healthzRoute({ config, version: pkg.version }));
   app.use(configRoute({ config }));
+  app.use(setupRoute({ baseConfig: baseline, liveConfig: config, store }));
   app.use(stateRoute({ haClient, cache: stateCache, config }));
   app.use(mediaInfoRoute({ cache: mediaInfoCache, config }));
   app.use(artworkRoute({ config }));
@@ -87,13 +116,29 @@ export function createApp({ config, haClient }) {
 // Boot when run directly (node src/server.js), not when imported by tests.
 const isDirectRun = import.meta.url === `file://${process.argv[1]}`;
 if (isDirectRun) {
-  const { config, errors } = loadConfig(process.env);
+  // Load env defaults, then merge any persisted overlay config on top before
+  // validating. This means a user who saved a working HA token from the
+  // setup overlay won't get blocked at boot if the env var was left blank.
+  const { config: envConfig } = loadConfig(process.env);
+  // Keep an env-only snapshot to pass through as `baseConfig` so the setup
+  // route always re-merges from a clean baseline.
+  const baseConfig = JSON.parse(JSON.stringify(envConfig));
+  const overlayStore = createOverlayStore();
+  let overlay = {};
+  try { overlay = overlayStore.read() || {}; } catch (_) { overlay = {}; }
+  const effective = applyOverlay(baseConfig, overlay);
+  Object.assign(envConfig, effective);
+  envConfig.comingSoon = { ...(effective.comingSoon || {}) };
+  envConfig.comingSoon.tmdb = { ...((effective.comingSoon && effective.comingSoon.tmdb) || {}) };
+  envConfig.visual = { ...(effective.visual || {}) };
+  const config = envConfig;
+  const errors = validateRuntime(config);
   if (errors.length > 0) {
     for (const e of errors) console.error(`[config] ${e}`);
     process.exit(1);
   }
   const haClient = createHaClient({ haUrl: config.haUrl, haToken: config.haToken });
-  const app = createApp({ config, haClient });
+  const app = createApp({ config, haClient, overlayStore, baseConfig });
 
   // Optional Fully Kiosk auto-switcher (#48).
   if (config.switcherEnabled) {

--- a/server/test/routes.test.js
+++ b/server/test/routes.test.js
@@ -124,6 +124,10 @@ test('GET /api/config defaults every visual toggle off', async () => {
     assert.deepEqual(body, {
       mode: 'addon',
       managed: true,
+      haUrl: 'http://supervisor/core',
+      haUrlSet: true,
+      haTokenSet: true,
+      landscape: false,
       displayMode: 'now_showing',
       backend: 'plex',
       player: '',

--- a/server/test/setup.test.js
+++ b/server/test/setup.test.js
@@ -1,0 +1,359 @@
+// Server-side overlay configuration (#98).
+//
+// Boots the Express app against a temp overlay file and exercises GET/POST
+// /api/setup, including the cross-client persistence guarantee (a save from
+// one client is visible to another), secret-handling rules (blank preserves,
+// secrets never returned), and the TMDB save path.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync, readFileSync, writeFileSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { dirname } from 'node:path';
+
+import { createApp } from '../src/server.js';
+import { createOverlayStore, applyOverlay } from '../src/overlayStore.js';
+import { sanitizeOverlayInput, mergeOverlay, effectiveSetupView } from '../src/routes/setup.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const haStates = JSON.parse(
+  readFileSync(join(__dirname, '..', 'fixtures', 'ha_states.json'), 'utf8'),
+);
+
+function tmpStorePath(t) {
+  const dir = mkdtempSync(join(tmpdir(), 'pns-overlay-'));
+  t.after(() => rmSync(dir, { recursive: true, force: true }));
+  return join(dir, 'overlay.json');
+}
+
+function envBaseConfig(overrides = {}) {
+  return {
+    mode: 'addon',
+    port: 0,
+    haUrl: 'http://supervisor/core',
+    haToken: 'tok',
+    plexUrl: '',
+    plexToken: '',
+    plexUsername: '',
+    plexPlayer: '',
+    landscape: false,
+    theme: 'classic-gold',
+    poll: 5000,
+    proxySecret: '',
+    allowedOrigins: [],
+    stateTtl: 3000,
+    mediaInfoTtl: 600000,
+    comingSoonTtl: 900000,
+    tmdbTtl: 21600000,
+    displayMode: 'now_showing',
+    backend: 'plex',
+    player: '',
+    switcherEnabled: false,
+    switcherIntervalMs: 5000,
+    fullyKiosksRaw: '',
+    comingSoon: {
+      title: 'Coming Soon',
+      radarrUrl: '',
+      radarrApiKey: '',
+      sonarrUrl: '',
+      sonarrApiKey: '',
+      moviesCount: 5,
+      showsCount: 5,
+      cycleInterval: 8,
+      daysOffset: 0,
+      lookaheadDays: 90,
+      imageType: 'poster',
+      tmdb: { apiKey: '', region: 'AU' },
+    },
+    visual: {
+      progressBar: false, ratingsBadges: false, genreChips: false,
+      infoPanelMode: 'on_tap', useBackdrops: false, frameStyle: 'bulbs',
+      bulbSizePx: 28, marqueeFont: 'bebas-neue', backdropStyle: 'fullscreen',
+      backdropDelayMs: 10000, burnInMitigation: false,
+      nudgeIntervalMs: 60000, nudgeAmplitudePx: 4,
+      nightModeEntity: '', nightModeOpacity: 0.4,
+      theme: 'classic-gold', accentColor: '', marqueeBgColor: '', cornerRadiusPx: 0,
+    },
+    staticDir: join(__dirname, '..', 'fixtures'),
+    ...overrides,
+  };
+}
+
+function startApp(t, { config, overlayPath } = {}) {
+  const cfg = config || envBaseConfig();
+  const baseConfig = JSON.parse(JSON.stringify(cfg));
+  const overlayStore = createOverlayStore(overlayPath || tmpStorePath(t));
+  const haClient = { getStates: async () => haStates };
+  const app = createApp({ config: cfg, haClient, overlayStore, baseConfig });
+  return new Promise((resolve) => {
+    const server = app.listen(0, () => {
+      const { port } = server.address();
+      t.after(() => server.close());
+      resolve({ url: `http://127.0.0.1:${port}`, config: cfg, baseConfig, overlayStore });
+    });
+  });
+}
+
+test('GET /api/setup returns effective config with *Set flags and no secrets', async (t) => {
+  const cfg = envBaseConfig({
+    plexUrl: 'http://plex.lan:32400',
+    plexToken: 'top-secret-plex',
+    comingSoon: {
+      ...envBaseConfig().comingSoon,
+      radarrUrl: 'http://radarr.lan:7878',
+      radarrApiKey: 'top-secret-radarr',
+      tmdb: { apiKey: 'top-secret-tmdb', region: 'GB' },
+    },
+  });
+  const { url } = await startApp(t, { config: cfg });
+  const body = await fetch(`${url}/api/setup`).then(r => r.json());
+  assert.equal(body.haUrl, 'http://supervisor/core');
+  assert.equal(body.haTokenSet, true);
+  assert.equal(body.plex.url, 'http://plex.lan:32400');
+  assert.equal(body.plex.tokenSet, true);
+  assert.equal(body.comingSoon.radarrUrl, 'http://radarr.lan:7878');
+  assert.equal(body.comingSoon.radarrApiKeySet, true);
+  assert.equal(body.comingSoon.tmdb.apiKeySet, true);
+  assert.equal(body.comingSoon.tmdb.region, 'GB');
+  // No secrets present anywhere.
+  const dump = JSON.stringify(body);
+  for (const s of ['top-secret-plex', 'top-secret-radarr', 'top-secret-tmdb']) {
+    assert.equal(dump.includes(s), false, `secret ${s} leaked`);
+  }
+});
+
+test('POST /api/setup persists settings server-side and another client sees them', async (t) => {
+  const overlayPath = tmpStorePath(t);
+  // Client A writes via one app instance.
+  const a = await startApp(t, { overlayPath });
+  const saveResp = await fetch(`${a.url}/api/setup`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      backend: 'jellyfin',
+      player: 'media_player.jellyfin_living_room',
+      comingSoon: {
+        radarrUrl: 'http://radarr.lan:7878',
+        radarrApiKey: 'fresh-radarr-key',
+        moviesCount: 9,
+      },
+    }),
+  });
+  assert.equal(saveResp.status, 200);
+
+  // Client B is a *fresh* app instance reading the same overlay file —
+  // simulates a phone hitting the LAN URL after the kiosk saved settings.
+  const b = await startApp(t, { overlayPath });
+  const seen = await fetch(`${b.url}/api/setup`).then(r => r.json());
+  assert.equal(seen.backend, 'jellyfin');
+  assert.equal(seen.player, 'media_player.jellyfin_living_room');
+  assert.equal(seen.comingSoon.radarrUrl, 'http://radarr.lan:7878');
+  assert.equal(seen.comingSoon.radarrApiKeySet, true);
+  assert.equal(seen.comingSoon.moviesCount, 9);
+  // The Radarr API key must not appear in the response or on disk-as-config.
+  assert.equal(JSON.stringify(seen).includes('fresh-radarr-key'), false);
+});
+
+test('POST /api/setup with blank secret preserves the existing saved secret', async (t) => {
+  const overlayPath = tmpStorePath(t);
+  const a = await startApp(t, { overlayPath });
+  // Save a Plex token through the overlay.
+  await fetch(`${a.url}/api/setup`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ plexUrl: 'http://plex.lan:32400', plexToken: 'kept-secret' }),
+  });
+  let view = await fetch(`${a.url}/api/setup`).then(r => r.json());
+  assert.equal(view.plex.tokenSet, true);
+
+  // Now save again with a blank plexToken — non-secret fields can change,
+  // but the saved token must survive.
+  await fetch(`${a.url}/api/setup`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ plexUrl: 'http://plex.lan:32400', plexToken: '' }),
+  });
+  view = await fetch(`${a.url}/api/setup`).then(r => r.json());
+  assert.equal(view.plex.tokenSet, true, 'blank plexToken should preserve saved value');
+  assert.equal(view.plex.url, 'http://plex.lan:32400');
+
+  // And it should still be present on a fresh process.
+  const b = await startApp(t, { overlayPath });
+  const seen = await fetch(`${b.url}/api/setup`).then(r => r.json());
+  assert.equal(seen.plex.tokenSet, true);
+});
+
+test('POST /api/setup/reset clears the overlay file and reverts to env defaults', async (t) => {
+  const overlayPath = tmpStorePath(t);
+  const a = await startApp(t, { overlayPath });
+  await fetch(`${a.url}/api/setup`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ backend: 'jellyfin', plexToken: 'sekret' }),
+  });
+  let view = await fetch(`${a.url}/api/setup`).then(r => r.json());
+  assert.equal(view.backend, 'jellyfin');
+  assert.equal(view.plex.tokenSet, true);
+
+  await fetch(`${a.url}/api/setup/reset`, { method: 'POST' });
+  view = await fetch(`${a.url}/api/setup`).then(r => r.json());
+  // Back to env-only baseline (which sets backend=plex, plexToken='').
+  assert.equal(view.backend, 'plex');
+  assert.equal(view.plex.tokenSet, false);
+  assert.equal(existsSync(overlayPath), false);
+});
+
+test('POST /api/setup persists TMDB key + region; *Set boolean reflects it', async (t) => {
+  const overlayPath = tmpStorePath(t);
+  const a = await startApp(t, { overlayPath });
+  await fetch(`${a.url}/api/setup`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      comingSoon: { tmdb: { apiKey: 'xxxx-tmdb-yyyy', region: 'US' } },
+    }),
+  });
+  const view = await fetch(`${a.url}/api/setup`).then(r => r.json());
+  assert.equal(view.comingSoon.tmdb.apiKeySet, true);
+  assert.equal(view.comingSoon.tmdb.enabled, true);
+  assert.equal(view.comingSoon.tmdb.region, 'US');
+  assert.equal(JSON.stringify(view).includes('xxxx-tmdb-yyyy'), false);
+
+  // The persisted file holds the raw secret (it has to, so the server can
+  // use it on the next restart) but only on disk, never on the wire.
+  const onDisk = JSON.parse(readFileSync(overlayPath, 'utf8'));
+  assert.equal(onDisk.comingSoon.tmdb.apiKey, 'xxxx-tmdb-yyyy');
+  assert.equal(onDisk.comingSoon.tmdb.region, 'US');
+});
+
+test('GET /api/setup falls back to env/options defaults when no overlay exists', async (t) => {
+  const cfg = envBaseConfig({
+    backend: 'plex',
+    comingSoon: {
+      ...envBaseConfig().comingSoon,
+      title: 'From env',
+      moviesCount: 7,
+      tmdb: { apiKey: 'env-tmdb', region: 'CA' },
+    },
+  });
+  const { url } = await startApp(t, { config: cfg });
+  const view = await fetch(`${url}/api/setup`).then(r => r.json());
+  assert.equal(view.comingSoon.title, 'From env');
+  assert.equal(view.comingSoon.moviesCount, 7);
+  assert.equal(view.comingSoon.tmdb.apiKeySet, true);
+  assert.equal(view.comingSoon.tmdb.region, 'CA');
+});
+
+test('Overlay overrides env values where both are set', async (t) => {
+  const cfg = envBaseConfig({
+    backend: 'plex',
+    comingSoon: { ...envBaseConfig().comingSoon, title: 'env-title', moviesCount: 5 },
+  });
+  const overlayPath = tmpStorePath(t);
+  // Pre-write the overlay file before starting the app.
+  writeFileSync(overlayPath, JSON.stringify({
+    backend: 'jellyfin',
+    comingSoon: { title: 'overlay-title', moviesCount: 12 },
+  }));
+  const { url } = await startApp(t, { config: cfg, overlayPath });
+  const view = await fetch(`${url}/api/setup`).then(r => r.json());
+  assert.equal(view.backend, 'jellyfin', 'overlay backend overrides env');
+  assert.equal(view.comingSoon.title, 'overlay-title');
+  assert.equal(view.comingSoon.moviesCount, 12);
+});
+
+test('POST /api/setup rejects invalid enum values', async (t) => {
+  const { url } = await startApp(t);
+  const r = await fetch(`${url}/api/setup`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ backend: 'this-is-not-a-backend' }),
+  });
+  assert.equal(r.status, 400);
+  const body = await r.json();
+  assert.equal(body.error, 'invalid_setup_payload');
+  assert.ok(body.details.includes('backend_invalid'));
+});
+
+test('GET /api/config still works alongside overlay (now exposes haUrl + landscape)', async (t) => {
+  const overlayPath = tmpStorePath(t);
+  const a = await startApp(t, { overlayPath });
+  await fetch(`${a.url}/api/setup`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ landscape: true }),
+  });
+  const cfg = await fetch(`${a.url}/api/config`).then(r => r.json());
+  assert.equal(cfg.landscape, true);
+  assert.equal(cfg.haUrl, 'http://supervisor/core');
+  assert.equal(cfg.haTokenSet, true);
+});
+
+// === Pure-function tests (no server) ===
+
+test('sanitizeOverlayInput drops unknown fields', () => {
+  const { overlay, errors } = sanitizeOverlayInput({
+    backend: 'plex',
+    nefarious: 'do bad things',
+    comingSoon: { sneaky: 1, title: 'ok' },
+  });
+  assert.equal(errors.length, 0);
+  assert.equal(overlay.backend, 'plex');
+  assert.equal('nefarious' in overlay, false);
+  assert.equal('sneaky' in overlay.comingSoon, false);
+  assert.equal(overlay.comingSoon.title, 'ok');
+});
+
+test('mergeOverlay preserves existing secrets when blank, drops blank non-secrets', () => {
+  const existing = {
+    plexUrl: 'http://old',
+    plexToken: 'tok',
+    comingSoon: { radarrApiKey: 'rkey' },
+  };
+  const merged = mergeOverlay(existing, {
+    plexUrl: '',           // non-secret blank → clear
+    plexToken: '',         // secret blank → preserve
+    comingSoon: { radarrApiKey: '' }, // secret blank → preserve
+  });
+  assert.equal('plexUrl' in merged, false);
+  assert.equal(merged.plexToken, 'tok');
+  assert.equal(merged.comingSoon.radarrApiKey, 'rkey');
+});
+
+test('applyOverlay merges nested objects without mutating base', () => {
+  const base = envBaseConfig();
+  const baseClone = JSON.parse(JSON.stringify(base));
+  const merged = applyOverlay(base, { comingSoon: { tmdb: { apiKey: 'k', region: 'GB' } } });
+  assert.equal(merged.comingSoon.tmdb.apiKey, 'k');
+  assert.equal(merged.comingSoon.tmdb.region, 'GB');
+  // Base must be untouched.
+  assert.deepEqual(base, baseClone);
+});
+
+test('effectiveSetupView never includes secret values', () => {
+  const cfg = envBaseConfig({
+    plexToken: 'plex-secret-7777',
+    haToken: 'ha-secret-4444',
+    comingSoon: {
+      ...envBaseConfig().comingSoon,
+      radarrApiKey: 'radarr-secret-1111',
+      sonarrApiKey: 'sonarr-secret-2222',
+      tmdb: { apiKey: 'tmdb-secret-3333', region: 'AU' },
+    },
+  });
+  const view = effectiveSetupView(cfg);
+  const dump = JSON.stringify(view);
+  for (const s of [
+    'plex-secret-7777', 'ha-secret-4444',
+    'radarr-secret-1111', 'sonarr-secret-2222', 'tmdb-secret-3333',
+  ]) {
+    assert.equal(dump.includes(s), false, `secret ${s} leaked`);
+  }
+  assert.equal(view.haTokenSet, true);
+  assert.equal(view.plex.tokenSet, true);
+  assert.equal(view.comingSoon.radarrApiKeySet, true);
+  assert.equal(view.comingSoon.sonarrApiKeySet, true);
+  assert.equal(view.comingSoon.tmdb.apiKeySet, true);
+});

--- a/www/now_showing.html
+++ b/www/now_showing.html
@@ -1578,6 +1578,27 @@
       <div class="setup-sub" id="setupSub">Values are saved to this device's localStorage. Nothing is sent anywhere else.</div>
 
       <!--
+        #98 — When the page is served by the unified add-on / Docker server,
+        the in-app overlay can save settings server-side via POST /api/setup.
+        In that mode the localStorage banner text is replaced and saves go to
+        the server, so all browsers/devices see the same values.
+      -->
+      <div id="setupServerSavedBanner"
+           style="display:none;margin:0 0 14px;padding:12px 14px;border-radius:6px;
+                  border:1px solid #2c5e2c;background:#0f1d0f;color:#bce6bc;
+                  font-size:0.85rem;line-height:1.4;">
+        <strong style="color:#bce6bc;display:block;margin-bottom:4px;">
+          Settings save to the server, not just this device
+        </strong>
+        <span>
+          Saving here writes to the add-on/Docker server and applies to every
+          browser, kiosk and phone that opens this URL. Secrets are stored
+          server-side and shown only as <em>set / not set</em> below — leave
+          a secret blank to keep its current value.
+        </span>
+      </div>
+
+      <!--
         #95 — When the page is served by the unified add-on / Docker server,
         the canonical setup lives in add-on options / docker env, not in this
         per-tablet localStorage. Show a banner pointing the user at the
@@ -1723,24 +1744,29 @@
           </div>
 
           <!--
-            #91 / #95 — TMDB enrichment. Server-side only: the kiosk
-            frontend never calls TMDB directly, so this is a status panel,
-            not an input. The enabled/region values come from /api/config;
-            the API key itself stays server-side.
+            #91 / #95 / #98 — TMDB enrichment. The kiosk frontend never
+            calls TMDB directly; the API key is sent to the server which
+            uses it for date enrichment only. In unified-server mode the
+            inputs save to /api/setup and persist across browsers/devices.
+            HACS-only installs see a status panel pointing at the add-on
+            options instead.
           -->
-          <div class="setup-section-title" style="margin-top:14px;">TMDB enrichment (server-side)</div>
+          <div class="setup-section-title" style="margin-top:14px;">TMDB enrichment</div>
           <div class="setup-field" id="cfgTmdbStatusField">
             <div id="cfgTmdbStatus" class="hint" style="color:var(--accent-light);">
               TMDB fallback status will appear when the unified server is reachable.
             </div>
-            <div class="hint" style="margin-top:6px;">
-              Configure <code>tmdb_api_key</code> and <code>tmdb_region</code>
-              (default <code>AU</code>) in the Home Assistant add-on
-              Configuration tab, or as <code>TMDB_API_KEY</code> /
-              <code>TMDB_REGION</code> env vars on the Docker container.
-              When set, TMDB fills in digital/physical/theatrical release
-              dates Radarr's calendar is missing. Leave the API key blank
-              to disable the fallback completely.
+          </div>
+          <div class="setup-field-grid">
+            <div class="setup-field">
+              <label for="cfgTmdbApiKey">TMDB API Key</label>
+              <input id="cfgTmdbApiKey" type="password" placeholder="(not set)" autocomplete="off" spellcheck="false">
+              <div class="hint">v3 key or v4 read-token. Saved server-side; leave blank to keep the existing key.</div>
+            </div>
+            <div class="setup-field">
+              <label for="cfgTmdbRegion">TMDB Region</label>
+              <input id="cfgTmdbRegion" type="text" maxlength="2" placeholder="AU" autocomplete="off" spellcheck="false">
+              <div class="hint">ISO 3166-1 alpha-2 country code (default AU).</div>
             </div>
           </div>
         </details>
@@ -2661,6 +2687,7 @@
       ['comingSoonDaysOffset', 'cfgComingSoonDaysOffset', '0'],
       ['comingSoonLookaheadDays', 'cfgComingSoonLookaheadDays', '90'],
       ['comingSoonImageType', 'cfgComingSoonImageType', 'poster'],
+      ['tmdbRegion', 'cfgTmdbRegion', 'AU'],
       ['visualTheme', 'cfgVisualTheme', 'classic-gold'],
       ['visualFrameStyle', 'cfgVisualFrameStyle', 'bulbs'],
       ['visualBulbSizePx', 'cfgVisualBulbSizePx', '28'],
@@ -2820,6 +2847,19 @@
       }
     }
 
+    // #98 — secret form field IDs paired with the *Set boolean path under
+    // the /api/config response. Used to render placeholder hints like
+    // "(saved on server, leave blank to keep)" without ever putting the
+    // secret value into the DOM.
+    const SETUP_SECRET_FIELDS = [
+      ['cfgHaToken', 'haTokenSet'],
+      ['cfgPlexToken', 'plex.tokenSet'],
+      ['cfgRadarrApiKey', 'comingSoon.radarrApiKeySet'],
+      ['cfgSonarrApiKey', 'comingSoon.sonarrApiKeySet'],
+      ['cfgTmdbApiKey', 'comingSoon.tmdb.apiKeySet'],
+      ['cfgFullyKioskPassword', null], // not surfaced individually; raw blob
+    ];
+
     function populateSetupForm() {
       try {
         for (const [key, id, defaultValue] of SETUP_VALUE_FIELDS) {
@@ -2853,13 +2893,15 @@
       void hydrateSetupFromServer();
     }
 
-    // #95 — fetch /api/config (already used for visual toggles) and use it
-    // to drive the in-app setup overlay's "managed by add-on" banner plus
-    // the TMDB status pill. Fields the user has saved locally always win
-    // (they are the per-tablet override) — server values are only used to
-    // fill blanks and to render an informational read-only summary.
+    // #95/#98 — fetch /api/config and use it to drive the in-app setup
+    // overlay. In unified-server mode this also tells the form to POST
+    // saves back to /api/setup so values persist server-side. Secrets are
+    // never returned by the server — only their *Set booleans — so we
+    // always show secret inputs as blank and use the boolean to render
+    // a "set / not set" hint underneath.
     async function hydrateSetupFromServer() {
       const banner = document.getElementById('setupServerBanner');
+      const savedBanner = document.getElementById('setupServerSavedBanner');
       const summary = document.getElementById('setupServerBannerSummary');
       const sub = document.getElementById('setupSub');
       const tmdbStatus = document.getElementById('cfgTmdbStatus');
@@ -2871,21 +2913,25 @@
         body = await resp.json();
       } catch (_) {
         // No unified server (HACS-only install) — keep the original
-        // localStorage-only messaging and hide the server banner.
+        // localStorage-only messaging and hide the server banners. Don't
+        // hide the TMDB status block — show a fallback hint instead so the
+        // heading is never orphaned (see #97).
         if (banner) banner.style.display = 'none';
-        if (tmdbField) tmdbField.style.display = 'none';
+        if (savedBanner) savedBanner.style.display = 'none';
+        if (tmdbStatus) {
+          tmdbStatus.innerHTML = `ℹ️ TMDB status is unavailable (could not reach <code>/api/config</code>). When running the unified server, configure <code>tmdb_api_key</code> / <code>TMDB_API_KEY</code>, or save it from the setup overlay if your install supports it.`;
+        }
         return;
       }
       if (!body || typeof body !== 'object') return;
       const isAddon = body.mode === 'addon';
       const isServer = isAddon || body.mode === 'standalone';
-      if (banner && isServer) {
-        banner.style.display = 'block';
-        if (sub) {
-          sub.textContent = isAddon
-            ? 'Connection, Coming Soon, and TMDB values are loaded from the add-on Configuration tab. Display settings can be overridden per-device below.'
-            : 'Connection, Coming Soon, and TMDB values are loaded from the server (Docker .env / env vars). Display settings can be overridden per-device below.';
-        }
+      // #98 — in server mode, show the green "saves go server-side" banner
+      // and hide the older localStorage-only banner.
+      if (savedBanner && isServer) savedBanner.style.display = 'block';
+      if (banner) banner.style.display = 'none';
+      if (sub && isServer) {
+        sub.textContent = 'Settings save to the unified server. They apply to every browser, kiosk and phone that opens this URL.';
       }
       if (summary) {
         const cs = body.comingSoon || {};
@@ -2904,41 +2950,62 @@
       if (tmdbStatus) {
         const tmdb = (body.comingSoon && body.comingSoon.tmdb) || {};
         if (tmdb.enabled) {
-          tmdbStatus.innerHTML = `✅ TMDB API key is configured on the server. Region: <strong>${(tmdb.region || 'AU').toUpperCase()}</strong>.`;
+          tmdbStatus.innerHTML = `✅ TMDB API key is set on the server. Region: <strong>${(tmdb.region || 'AU').toUpperCase()}</strong>. Leave the key field blank below to keep it.`;
         } else {
-          tmdbStatus.innerHTML = `⚠️ TMDB fallback is <strong>not configured</strong>. Add <code>tmdb_api_key</code> to the add-on options (or <code>TMDB_API_KEY</code> env var) to enable.`;
+          tmdbStatus.innerHTML = `⚠️ TMDB fallback is <strong>not configured</strong>. Enter a key below (or set <code>tmdb_api_key</code> in the add-on options / <code>TMDB_API_KEY</code> env var) to enable.`;
         }
       }
-      // Fill any blank fields from canonical server values so a brand-new
-      // browser doesn't render the form as empty just because localStorage
-      // is fresh. We only fill blanks — anything the user has saved locally
-      // is treated as a deliberate per-device override and left alone.
-      const fillIfBlank = (id, value) => {
+      // #98 — In server mode, server values are canonical: prefill non-secret
+      // fields unconditionally so all browsers see the same effective config.
+      // For secret fields, render a placeholder hint based on the *Set
+      // boolean (we never receive the secret itself) and leave the input
+      // blank — saving a blank secret preserves the existing one.
+      const fillFromServer = (id, value) => {
         const el = document.getElementById(id);
         if (!el) return;
         if (typeof value === 'undefined' || value === null) return;
         if (el.tagName === 'INPUT' && el.type === 'checkbox') {
-          // Only overwrite when localStorage doesn't have an explicit value.
+          el.checked = !!value;
           return;
         }
-        if (!el.value) el.value = String(value);
+        el.value = String(value);
       };
       const cs2 = body.comingSoon || {};
       const plex2 = body.plex || {};
-      fillIfBlank('cfgDisplayMode', body.displayMode);
-      fillIfBlank('cfgBackend', body.backend);
-      fillIfBlank('cfgPlayer', body.player);
-      fillIfBlank('cfgPlexUrl', plex2.url);
-      fillIfBlank('cfgPlexUsername', plex2.username);
-      fillIfBlank('cfgComingSoonTitle', cs2.title);
-      fillIfBlank('cfgRadarrUrl', cs2.radarrUrl);
-      fillIfBlank('cfgSonarrUrl', cs2.sonarrUrl);
-      if (Number.isFinite(cs2.moviesCount)) fillIfBlank('cfgComingSoonMoviesCount', cs2.moviesCount);
-      if (Number.isFinite(cs2.showsCount)) fillIfBlank('cfgComingSoonShowsCount', cs2.showsCount);
-      if (Number.isFinite(cs2.cycleInterval)) fillIfBlank('cfgComingSoonCycleInterval', cs2.cycleInterval);
-      if (Number.isFinite(cs2.daysOffset)) fillIfBlank('cfgComingSoonDaysOffset', cs2.daysOffset);
-      if (Number.isFinite(cs2.lookaheadDays)) fillIfBlank('cfgComingSoonLookaheadDays', cs2.lookaheadDays);
-      fillIfBlank('cfgComingSoonImageType', cs2.imageType);
+      const tmdb2 = cs2.tmdb || {};
+      // Secrets — placeholder reflects server state, value stays blank.
+      const setSecretPlaceholder = (id, isSet, label) => {
+        const el = document.getElementById(id);
+        if (!el) return;
+        el.value = '';
+        el.placeholder = isSet
+          ? `(saved on server — leave blank to keep ${label})`
+          : `(not set — enter ${label} to save)`;
+      };
+      setSecretPlaceholder('cfgHaToken', !!body.haTokenSet, 'HA token');
+      setSecretPlaceholder('cfgPlexToken', !!(plex2.tokenSet), 'Plex token');
+      setSecretPlaceholder('cfgRadarrApiKey', !!cs2.radarrApiKeySet, 'Radarr key');
+      setSecretPlaceholder('cfgSonarrApiKey', !!cs2.sonarrApiKeySet, 'Sonarr key');
+      setSecretPlaceholder('cfgTmdbApiKey', !!tmdb2.apiKeySet, 'TMDB key');
+
+      // Non-secret prefill — server is canonical when in server mode.
+      fillFromServer('cfgHaUrl', body.haUrl);
+      fillFromServer('cfgDisplayMode', body.displayMode);
+      fillFromServer('cfgBackend', body.backend);
+      fillFromServer('cfgPlayer', body.player);
+      fillFromServer('cfgLandscape', body.landscape);
+      fillFromServer('cfgPlexUrl', plex2.url);
+      fillFromServer('cfgPlexUsername', plex2.username);
+      fillFromServer('cfgComingSoonTitle', cs2.title);
+      fillFromServer('cfgRadarrUrl', cs2.radarrUrl);
+      fillFromServer('cfgSonarrUrl', cs2.sonarrUrl);
+      if (Number.isFinite(cs2.moviesCount)) fillFromServer('cfgComingSoonMoviesCount', cs2.moviesCount);
+      if (Number.isFinite(cs2.showsCount)) fillFromServer('cfgComingSoonShowsCount', cs2.showsCount);
+      if (Number.isFinite(cs2.cycleInterval)) fillFromServer('cfgComingSoonCycleInterval', cs2.cycleInterval);
+      if (Number.isFinite(cs2.daysOffset)) fillFromServer('cfgComingSoonDaysOffset', cs2.daysOffset);
+      if (Number.isFinite(cs2.lookaheadDays)) fillFromServer('cfgComingSoonLookaheadDays', cs2.lookaheadDays);
+      fillFromServer('cfgComingSoonImageType', cs2.imageType);
+      fillFromServer('cfgTmdbRegion', tmdb2.region);
       // Re-run dependent toggles in case we just filled the backend/displayMode.
       try {
         syncSetupDisplayModeFields();
@@ -3518,19 +3585,134 @@
         setupStatus('Could not save settings: ' + e.message, 'err');
         return;
       }
+
+      // #98 \u2014 in unified-server mode also POST the form to /api/setup so
+      // the values persist on the server and propagate to every other
+      // browser/kiosk on this install. Local localStorage is still written
+      // above so HACS-only installs (no server) keep working as before.
+      if (serverManaged) {
+        const payload = buildServerSetupPayload(accentColor, marqueeBgColor);
+        setupStatus('Saving to server\u2026');
+        fetch('/api/setup', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload),
+        }).then(async (r) => {
+          if (!r.ok) {
+            const err = await r.json().catch(() => ({}));
+            throw new Error(err.details ? err.details.join(', ') : ('http ' + r.status));
+          }
+          setupStatus('Saved on server. Reloading\u2026', 'ok');
+          const clean = window.location.pathname;
+          setTimeout(() => { window.location.replace(clean); }, 350);
+        }).catch((err) => {
+          setupStatus('Server save failed: ' + err.message + ' (local copy was still saved)', 'err');
+        });
+        return;
+      }
+
       setupStatus('Saved. Reloading\u2026', 'ok');
       // Drop any token in the hash/query so it's not kept in history, then reload.
       const clean = window.location.pathname;
       setTimeout(() => { window.location.replace(clean); }, 350);
     }
 
+    // #98 \u2014 Build the JSON body for POST /api/setup. We send blank secrets
+    // as-is and let the server preserve existing values; non-secret fields
+    // ride along regardless. Visual settings are also forwarded so a phone
+    // can flip the theme and have it apply on the kiosk.
+    function buildServerSetupPayload(accentColor, marqueeBgColor) {
+      const val = (id) => (document.getElementById(id)?.value ?? '').trim();
+      const num = (id) => {
+        const raw = val(id);
+        if (raw === '') return null;
+        const n = Number(raw);
+        return Number.isFinite(n) ? n : null;
+      };
+      const bool = (id) => !!document.getElementById(id)?.checked;
+      const out = {
+        haUrl: val('cfgHaUrl'),
+        displayMode: val('cfgDisplayMode'),
+        backend: val('cfgBackend'),
+        player: val('cfgPlayer'),
+        plexUrl: val('cfgPlexUrl'),
+        plexUsername: val('cfgPlexUsername'),
+        landscape: bool('cfgLandscape'),
+        switcherEnabled: bool('cfgSwitcherEnabled'),
+        // Secrets \u2014 blank preserves existing on the server.
+        haToken: val('cfgHaToken'),
+        plexToken: val('cfgPlexToken'),
+        comingSoon: {
+          title: val('cfgComingSoonTitle'),
+          radarrUrl: val('cfgRadarrUrl'),
+          radarrApiKey: val('cfgRadarrApiKey'),
+          sonarrUrl: val('cfgSonarrUrl'),
+          sonarrApiKey: val('cfgSonarrApiKey'),
+          imageType: val('cfgComingSoonImageType'),
+          tmdb: {
+            apiKey: val('cfgTmdbApiKey'),
+            region: val('cfgTmdbRegion'),
+          },
+        },
+        visual: {
+          progressBar: bool('cfgVisualProgressBar'),
+          ratingsBadges: bool('cfgVisualRatingsBadges'),
+          genreChips: bool('cfgVisualGenreChips'),
+          useBackdrops: bool('cfgVisualUseBackdrops'),
+          burnInMitigation: bool('cfgVisualBurnInMitigation'),
+          infoPanelMode: val('cfgVisualInfoPanelMode'),
+          frameStyle: val('cfgVisualFrameStyle'),
+          marqueeFont: val('cfgVisualMarqueeFont'),
+          backdropStyle: val('cfgVisualBackdropStyle'),
+          theme: val('cfgVisualTheme'),
+          nightModeEntity: val('cfgVisualNightModeEntity'),
+          accentColor: accentColor,
+          marqueeBgColor: marqueeBgColor,
+        },
+      };
+      // Numeric fields \u2014 only forward when they parse cleanly.
+      const setNum = (target, key, id) => { const n = num(id); if (n !== null) target[key] = n; };
+      setNum(out.comingSoon, 'moviesCount', 'cfgComingSoonMoviesCount');
+      setNum(out.comingSoon, 'showsCount', 'cfgComingSoonShowsCount');
+      setNum(out.comingSoon, 'cycleInterval', 'cfgComingSoonCycleInterval');
+      setNum(out.comingSoon, 'daysOffset', 'cfgComingSoonDaysOffset');
+      setNum(out.comingSoon, 'lookaheadDays', 'cfgComingSoonLookaheadDays');
+      setNum(out, 'switcherIntervalMs', 'cfgSwitcherIntervalMs');
+      setNum(out.visual, 'bulbSizePx', 'cfgVisualBulbSizePx');
+      setNum(out.visual, 'backdropDelayMs', 'cfgVisualBackdropDelayMs');
+      setNum(out.visual, 'nudgeIntervalMs', 'cfgVisualNudgeIntervalMs');
+      setNum(out.visual, 'nudgeAmplitudePx', 'cfgVisualNudgeAmplitudePx');
+      setNum(out.visual, 'nightModeOpacity', 'cfgVisualNightModeOpacity');
+      setNum(out.visual, 'cornerRadiusPx', 'cfgVisualCornerRadiusPx');
+      return out;
+    }
+
     function setupClear() {
+      // #98 — local clear always runs; in server mode also offer to reset
+      // the server-side overlay so a phone can blow away the whole shared
+      // setup if the user wants a clean slate. The two confirmations are
+      // independent so a user can clear local without touching the server.
       if (!confirm('Clear all saved Now Showing settings on this device?')) return;
       try {
         for (const [key] of SETUP_VALUE_FIELDS) window.localStorage.removeItem('pns.' + key);
         for (const [key] of SETUP_CHECKBOX_FIELDS) window.localStorage.removeItem('pns.' + key);
         window.localStorage.removeItem('pns.plexPlayer');
       } catch (_) {}
+
+      const serverManaged = !!SERVER_MODE;
+      if (serverManaged && confirm(
+        'Also reset the server-side overlay so other devices revert to add-on/Docker defaults? This clears any settings you saved server-side, including secrets.'
+      )) {
+        fetch('/api/setup/reset', { method: 'POST' }).then(() => {
+          populateSetupForm();
+          setupStatus('Local + server settings cleared.', 'ok');
+        }).catch((err) => {
+          populateSetupForm();
+          setupStatus('Local cleared, server reset failed: ' + err.message, 'err');
+        });
+        return;
+      }
+
       populateSetupForm();
       setupStatus('Cleared.', 'ok');
     }


### PR DESCRIPTION
## Summary
- The in-app setup overlay (gear icon / `#setup`) is now a real **persistent server-side configuration editor**. Saves write to `/data/overlay.json` on the add-on disk via `POST /api/setup` and propagate to every browser, kiosk, and phone on the next page load — closes #98.
- Every relevant setting is editable in the overlay, including TMDB API key + region, HA token, Plex/Radarr/Sonarr URLs and keys, Coming Soon counts/lookahead/imageType, and visual preferences. HA add-on options / Docker env vars remain supported as **defaults**; the overlay file *overrides* them. This also resolves the orphaned-TMDB-heading issue from #97 (TMDB has its own input fields now and the heading always renders a status line, even on `/api/config` failure).
- Secrets are handled safely: the server never returns saved secrets — only `*Set` booleans — and a blank secret field preserves the existing saved value. `POST /api/setup/reset` deletes the overlay file and reverts every device to add-on/Docker defaults.

## Architecture
- New `server/src/overlayStore.js` — JSON file-backed store at `/data/overlay.json` (override via `OVERLAY_CONFIG_PATH`). Atomic writes (`tmp + rename`). `applyOverlay(baseConfig, overlay)` merges saved overlay over the env/options baseline; precedence is **overlay > env**.
- New `server/src/routes/setup.js` — `GET /api/setup` (effective config + `*Set` booleans, no secrets), `POST /api/setup` (sanitises + persists; blank secrets preserved), `POST /api/setup/reset` (clears overlay file).
- `createApp()` snapshots an env-only `baseConfig`, applies any persisted overlay, and mutates the live `config` object in place so all routes (state, coming-soon, mediaInfo, …) pick up overlay updates without restart.
- Boot path now applies overlay before validation, so a user who saved a working HA token from the overlay isn't blocked on boot when the env var was left blank.
- Frontend `setupSave()` POSTs to `/api/setup` in server mode (still writes to `localStorage` as a per-device cache so HACS-only installs keep working). `hydrateSetupFromServer()` prefills non-secret fields from canonical server values and renders secret inputs with `(saved on server — leave blank to keep)` placeholders driven by the `*Set` booleans.
- `setupClear()` offers a second confirmation in server mode to also reset the server-side overlay; otherwise it remains a per-device clear.

## Tests
- `server/test/setup.test.js` (13 tests) covers:
  - GET `/api/setup` returns `*Set` flags but no secret values.
  - POST `/api/setup` persists; a fresh app instance reading the same overlay file sees the saved values (cross-client persistence).
  - Blank-secret save preserves the existing saved secret on disk and across restarts.
  - `/api/setup/reset` deletes the overlay file and reverts to env defaults.
  - TMDB key + region save round-trip; key never leaks on the wire.
  - Fallback to env/options defaults when no overlay file exists.
  - Overlay overrides env when both are set.
  - 400 on invalid enum values.
  - `/api/config` still returns the new `haUrl`/`landscape`/`*Set` fields after overlay save.
  - Pure-function tests for `sanitizeOverlayInput` (drops unknowns), `mergeOverlay` (blank-preserve secrets), `applyOverlay` (no-mutation), `effectiveSetupView` (no secret leakage).
- All 186 server tests pass (173 existing + 13 new).

## Test plan
- [x] `node --test test/*.js` — 186/186 pass
- [ ] Manual: HA add-on install — open setup on phone, save TMDB key + Radarr URL, refresh on Master Panel, verify both fields populated and `tmdb.apiKeySet=true` in `GET /api/config`.
- [ ] Manual: clear with confirm-server-reset; verify `/data/overlay.json` deleted and other devices revert to add-on options.

## Migration notes
- No schema changes to the add-on `config.yaml`. Existing add-on options / Docker env vars continue to work as defaults; users do not need to re-enter anything.
- New persistent file: `/data/overlay.json` on the add-on disk. Survives add-on updates and HA restarts. Docker users who want overlay persistence can bind-mount a volume at `/data` (or set `OVERLAY_CONFIG_PATH` to a different path).
- Issue #97 (orphaned TMDB heading + cross-device confusion) is fully addressed by this PR — TMDB now has real inputs, the heading always renders a status line even when `/api/config` fails, and the cross-device persistence problem is resolved at the architecture level.

## Release recommendation
v2.1.5 — feature addition, no breaking changes, fixes user-facing #98 + #97.

🤖 Generated with [Claude Code](https://claude.com/claude-code)