### PR TITLE
feat: add live config sync and coming soon crossfade

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@
   </a>
 </p>
 
-> This README describes Now Showing v2.3.0. This release builds on the
-> v2.1.0 foundation with a live streaming architecture, poster framing,
-> film-grain overlay, Ken Burns pan, self-hosted fonts, and more.
+> This README describes Now Showing v2.3.4. This release builds on the
+> v2.3.x live streaming architecture with instant setup propagation,
+> Coming Soon auto-cycling, and smooth poster crossfades.
 
 A full-screen cinema marquee display for Home Assistant that shows what is
 currently playing on Plex, Jellyfin, Emby, Kodi, Apple TV, generic streaming
@@ -50,23 +50,18 @@ All three paths use the same kiosk UI. The add-on and Docker paths add the
 Node server that proxies Home Assistant and Plex metadata so API tokens are
 not exposed to the tablet browser.
 
-## What's Changed From V2.1.0 To V2.3.0
+## What's Changed Since The Last Release
 
-V2.3.0 is the "cinematic depth" release. It refactors the live data feed, adds film-grade visual effects, self-hosts all resources, and gives fine-grained control over every info panel section.
+V2.3.4 focuses on live kiosk behaviour: configuration changes now reach open browsers immediately, Coming Soon screens cycle themselves, and poster transitions stay smooth.
 
-| Area | V2.3.0 change |
+| Area | V2.3.4 change |
 |------|---------------|
-| Live streaming architecture | **#10** — replaced polling with WebSocket (HA events) + SSE push to the browser. The kiosh now receives state changes in real time instead of hammering `/api/state` every 5 seconds. Graceful fallback to polling if SSE fails. Server-side WebSocket reconnection with exponential backoff. |
-| Poster framing | **#67** — new `visual_poster_framing` option (`centred` / `cover` / `matted`). `centred` renders the poster at natural aspect ratio with letterbox bars (closest to the classic cinema look). `cover` fills the poster frame entirely (crops portrait posters). `matted` shrinks the poster with a dark matte border and rounded corners. |
-| Film-grain overlay | **#27** — `visual_film_grain` toggle. When on, a subtle SVG noise texture overlays the entire screen for cinematic warmth. GPU-composited via CSS `mix-blend-mode: overlay; display: none` when off means zero performance impact. |
-| Ken Burns poster pan | **#22** — `visual_ken_burns` toggle. Slow zoom-in + translate on poster art, CSS `@keyframes` driven so it's GPU-composited with no JS timer overhead. |
-| Self-hosted Google Fonts | **#40** — 23 woff2 files bundled in `www/fonts/`, 48 inline `@font-face` declarations. Eliminates the Google Fonts CDN dependency (works offline, no external DNS/privacy leak, works behind firewalls). |
-| Per-section info toggles | **#64** — six new booleans (`visual_info_show_title`, `visual_info_show_subtitle`, `visual_info_show_meta`, `visual_info_show_summary`, `visual_info_show_techbox`, `visual_info_show_player`) that independently hide/show each section of the info panel. All default `true` for backward compatibility. Editable from the in-app setup overlay. |
-| Cross-device sync | Overlay store now persists every visual toggle server-side so the same values apply across browsers, tablets, and phones without per-device configuration. |
-| Bulb chase animation | **#16** — CSS `@keyframes` chase pattern on the bulb frame. GPU-composited animation replaces the static bulb glow from v2.1.0. Off (`display: none`) when `visual_frame_style` is not `bulbs`, so zero CPU cost. |
-| Connection status + debug | **#15** — live connection indicator (green dot / red dot) on the kiosk overlay. Debug mode logs connection events, SSE state, and reconnection attempts to the browser console. |
-| Dev health docs | **#37** — added `CONTRIBUTING.md`, issue templates (`bug.md`, `feature_request.md`), pull request template, and `CHANGELOG.md`. |
-| Release package | Home Assistant add-on versioned at `2.3.0`, with multi-arch Docker images built and published to GHCR via CI. |
+| Live setup sync | Saving or resetting `/api/setup` now broadcasts a sanitized `config_changed` event on `/api/events`, so open kiosks apply display mode, backend, Coming Soon, and visual setting changes without refresh. Secrets are still represented only as `*Set` booleans. |
+| Coming Soon cycle | Coming Soon mode starts a browser-side timer from `coming_soon_cycle_interval` and re-polls `/api/coming-soon` on that cadence, giving Radarr/Sonarr posters a screensaver-style rotation. SSE config changes restart or stop the timer immediately. |
+| Poster transition | Artwork updates now preload into a second poster layer and crossfade into the active layer, avoiding black flashes during rotations while keeping the existing `/api/artwork` proxy path intact. Slow stale image loads are ignored. |
+| Visual compatibility | Ken Burns animation is scoped to the active poster layer so it does not fight the crossfade buffer. Existing poster framing, overlay, backdrop, and artwork proxy behaviour is preserved. |
+| Test reliability | Added an SSE broadcast test for setup saves and made the Coming Soon route test date-relative so it does not fail after a fixed release date passes. |
+| Release package | Home Assistant add-on and Node server are versioned at `2.3.4`, with the release notes above replacing the old v2.3.0 comparison table. |
 
 ## Features
 
@@ -77,7 +72,8 @@ V2.3.0 is the "cinematic depth" release. It refactors the live data feed, adds f
 - Streaming app-name badges with app icons when Home Assistant exposes
   `app_name`, including Disney+, YouTube, Netflix, Plex, and similar apps.
 - Coming Soon mode for Radarr/Sonarr upcoming movies and episodes, with
-  rotating poster or fanart art for Fully Kiosk screensavers and automations.
+  configurable auto-cycling poster or fanart art for Fully Kiosk screensavers
+  and automations.
 - Optional exact player pinning via `player`.
 - Plex username filtering so shared Plex servers can show only your sessions.
 - Tap-for-info panel with synopsis, player, rating, duration, progress, and
@@ -90,6 +86,8 @@ V2.3.0 is the "cinematic depth" release. It refactors the live data feed, adds f
 - Optional film-grain overlay for cinematic warmth (GPU-composited, zero impact
   when off).
 - Optional Ken Burns poster pan (GPU-composited CSS `@keyframes` zoom + translate).
+- Smooth double-buffered poster crossfade for live artwork changes and Coming
+  Soon rotations.
 - Optional info-panel modes: `on_tap`, `on_pause`, or `always`.
 - Optional backdrop art on pause, either fullscreen landscape fade or ambient
   blurred fanart.
@@ -107,6 +105,8 @@ V2.3.0 is the "cinematic depth" release. It refactors the live data feed, adds f
   `playfair-display`.
 - Optional Fully Kiosk Browser auto-switching between your dashboard and the
   Now Showing page.
+- Open kiosks receive server-side setup changes instantly over SSE; saving or
+  resetting the setup overlay no longer requires a browser refresh.
 - Setup Automation tab with Blueprint import/download links and a built-in
   Fully Kiosk switcher config helper.
 - Setup page scrolling is fixed for Home Assistant add-on Ingress, including
@@ -187,7 +187,7 @@ http://<docker-host>:8099/now_showing.html
 ```
 
 For the stable v2 release, keep `TAG=latest` or pin this release with
-`TAG=2.3.0`. For the rolling `dev` branch image, set this in `docker/.env`:
+`TAG=2.3.4`. For the rolling `dev` branch image, set this in `docker/.env`:
 
 ```env
 TAG=dev

--- a/addons/plex-now-showing/CHANGELOG.md
+++ b/addons/plex-now-showing/CHANGELOG.md
@@ -3,6 +3,32 @@
 All notable changes to the Now Showing add-on will be documented here.
 The project follows [Semantic Versioning](https://semver.org/).
 
+## 2.3.4 - 2026-06-09
+
+### Added
+- Setup saves and resets now broadcast `config_changed` over the existing SSE
+  channel, so connected kiosks apply server-side configuration changes without a
+  manual refresh. Display mode, backend, Coming Soon, and visual settings update
+  from the sanitized `/api/setup` view; secret values are never sent.
+- Coming Soon mode now auto-cycles on the configured
+  `coming_soon_cycle_interval`, reloading the next upcoming item without a page
+  reload and restarting the timer immediately when that setting changes.
+- Poster changes now use a double-buffered crossfade with stale-image guards, so
+  Coming Soon rotations and live artwork changes do not flash black or regress to
+  an older slow-loading image.
+
+### Fixed
+- Ken Burns animation is restricted to the active poster layer so it does not
+  fight the crossfade buffer.
+- The Coming Soon route test now uses a date relative to the test run instead of
+  a fixed past date.
+
+## 2.3.3 - 2026-06-06
+
+### Changed
+- Maintenance release: dependency updates for the Node server (`ws` and
+  `express`) plus the non-standard entity artwork fix already present on main.
+
 ## 2.3.2 - 2026-05-19
 
 ### Fixed

--- a/addons/plex-now-showing/README.md
+++ b/addons/plex-now-showing/README.md
@@ -4,6 +4,19 @@ Cinema-style now-playing and coming-soon kiosk for Home Assistant, installed
 straight from the Home Assistant add-on store. One click, no long-lived access
 token, no Docker command line.
 
+## What's new in 2.3.4
+
+- **Instant setup propagation** — saving or resetting the in-app setup overlay
+  broadcasts a sanitized `config_changed` event over SSE. Open kiosks switch
+  between Now Showing and Coming Soon, update backend/source settings, and apply
+  visual changes without a browser refresh.
+- **Coming Soon auto-cycle** — Coming Soon mode rotates on the configured
+  `coming_soon_cycle_interval` without full-page reloads, and timer changes take
+  effect immediately.
+- **Smooth poster crossfade** — artwork now preloads into a second poster layer
+  and crossfades into place, preventing black flashes during Coming Soon rotation
+  while preserving the server `/api/artwork` proxy path.
+
 ## What's new in 2.3.2
 
 - **Fixed all requests returning `:ok`** — the SSE endpoint was registered with

--- a/addons/plex-now-showing/config.yaml
+++ b/addons/plex-now-showing/config.yaml
@@ -9,7 +9,7 @@
 # Docs on each field: https://developers.home-assistant.io/docs/add-ons/configuration
 
 name: Now Showing
-version: "2.3.2"
+version: "2.3.4"
 slug: plex_now_showing
 description: Cinema-style now-playing and coming-soon kiosk for Home Assistant.
 url: https://github.com/rusty4444/now-showing-ha

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "plex-now-showing-server",
-  "version": "2.3.2",
+  "version": "2.3.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "plex-now-showing-server",
-      "version": "2.3.2",
+      "version": "2.3.4",
       "license": "MIT",
       "dependencies": {
         "express": "^5.2.1",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plex-now-showing-server",
-  "version": "2.3.2",
+  "version": "2.3.4",
   "description": "Serves the Now Showing kiosk and proxies Home Assistant plus Plex metadata so tokens stay server-side.",
   "type": "module",
   "engines": {

--- a/server/src/routes/setup.js
+++ b/server/src/routes/setup.js
@@ -530,7 +530,7 @@ function mutateInPlace(target, next) {
   for (const k of Object.keys(next.visual || {})) target.visual[k] = next.visual[k];
 }
 
-export function setupRoute({ baseConfig, liveConfig, store }) {
+export function setupRoute({ baseConfig, liveConfig, store, eventBus }) {
   const r = Router();
 
   r.get('/api/setup', (_req, res) => {
@@ -549,7 +549,9 @@ export function setupRoute({ baseConfig, liveConfig, store }) {
       store.write(merged);
       const effective = applyOverlay(baseConfig, merged);
       mutateInPlace(liveConfig, effective);
-      return res.json(effectiveSetupView(liveConfig));
+      const view = effectiveSetupView(liveConfig);
+      if (eventBus) eventBus.broadcast({ type: 'config_changed', config: view });
+      return res.json(view);
     } catch (err) {
       console.error('[setup] save failed:', err.message);
       return res.status(500).json({ error: 'setup_save_failed', message: err.message });
@@ -561,7 +563,9 @@ export function setupRoute({ baseConfig, liveConfig, store }) {
       store.clear();
       const effective = applyOverlay(baseConfig, {});
       mutateInPlace(liveConfig, effective);
-      return res.json(effectiveSetupView(liveConfig));
+      const view = effectiveSetupView(liveConfig);
+      if (eventBus) eventBus.broadcast({ type: 'config_changed', config: view });
+      return res.json(view);
     } catch (err) {
       console.error('[setup] reset failed:', err.message);
       return res.status(500).json({ error: 'setup_reset_failed', message: err.message });

--- a/server/src/server.js
+++ b/server/src/server.js
@@ -102,7 +102,7 @@ export function createApp({ config, haClient, overlayStore, baseConfig }) {
   app.use(rootRoute({ config, version: pkg.version }));
   app.use(healthzRoute({ config, version: pkg.version }));
   app.use(configRoute({ config }));
-  app.use(setupRoute({ baseConfig: baseline, liveConfig: config, store }));
+  app.use(setupRoute({ baseConfig: baseline, liveConfig: config, store, eventBus }));
   app.use(stateRoute({ haClient, cache: stateCache, config }));
   app.use(mediaInfoRoute({ cache: mediaInfoCache, config }));
   app.use(artworkRoute({ config }));

--- a/server/test/routes.test.js
+++ b/server/test/routes.test.js
@@ -345,6 +345,7 @@ test('GET /api exposes the configured backend', async () => {
 
 test('GET /api/coming-soon returns configured upcoming items', async () => {
   const originalFetch = globalThis.fetch;
+  const futureRelease = new Date(Date.now() + 14 * 86400000).toISOString();
   globalThis.fetch = async () => ({
     ok: true,
     status: 200,
@@ -352,7 +353,7 @@ test('GET /api/coming-soon returns configured upcoming items', async () => {
       id: 1,
       title: 'The Future',
       year: 2026,
-      digitalRelease: '2026-06-01T00:00:00Z',
+      digitalRelease: futureRelease,
       hasFile: false,
       images: [{ coverType: 'poster', remoteUrl: 'https://img/poster.jpg' }],
     }],

--- a/server/test/setup.test.js
+++ b/server/test/setup.test.js
@@ -156,6 +156,44 @@ test('POST /api/setup persists settings server-side and another client sees them
   assert.equal(JSON.stringify(seen).includes('fresh-radarr-key'), false);
 });
 
+async function readNextSseData(reader) {
+  const decoder = new TextDecoder();
+  let buffer = '';
+  for (;;) {
+    const { value, done } = await reader.read();
+    if (done) return null;
+    buffer += decoder.decode(value, { stream: true });
+    const match = buffer.match(/^data: (.*)$/m);
+    if (match) return JSON.parse(match[1]);
+  }
+}
+
+test('POST /api/setup broadcasts config_changed over SSE', async (t) => {
+  const a = await startApp(t, { config: envBaseConfig({ haToken: 'super-secret-ha-token' }) });
+  const events = await fetch(`${a.url}/api/events`);
+  assert.equal(events.status, 200);
+  const reader = events.body.getReader();
+  t.after(() => reader.cancel().catch(() => {}));
+
+  // Wait until the SSE route has registered the client; the initial heartbeat
+  // is written before registration, so the next tick is enough for Express to
+  // finish adding the response to the broadcaster set.
+  await new Promise(resolve => setImmediate(resolve));
+
+  const saveResp = await fetch(`${a.url}/api/setup`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ displayMode: 'coming_soon', comingSoon: { moviesCount: 7 } }),
+  });
+  assert.equal(saveResp.status, 200);
+
+  const event = await readNextSseData(reader);
+  assert.equal(event.type, 'config_changed');
+  assert.equal(event.config.displayMode, 'coming_soon');
+  assert.equal(event.config.comingSoon.moviesCount, 7);
+  assert.equal(JSON.stringify(event).includes('super-secret-ha-token'), false, 'SSE config event must not leak HA token');
+});
+
 test('POST /api/setup with blank secret preserves the existing saved secret', async (t) => {
   const overlayPath = tmpStorePath(t);
   const a = await startApp(t, { overlayPath });

--- a/www/now_showing.html
+++ b/www/now_showing.html
@@ -901,7 +901,7 @@
       50%  { transform: scale(1.08) translate(-2%, -1%); }
       100% { transform: scale(1.0) translate(0, 0); }
     }
-    body.visual-ken-burns .poster-area.loaded {
+    body.visual-ken-burns #posterArea.loaded {
       animation: ken-burns 30s ease-in-out infinite;
       will-change: transform;
     }
@@ -1063,6 +1063,11 @@
 
     .poster-area.loaded {
       opacity: 1;
+    }
+
+    .poster-area-next {
+      z-index: 1;
+      pointer-events: none;
     }
 
     /* ===== BACKDROP ART ON PAUSE (#21) =====
@@ -2678,6 +2683,7 @@
       <div class="poster-bg-blur" id="posterBgBlur"></div>
       <!-- Poster foreground -->
       <div class="poster-area" id="posterArea"></div>
+      <div class="poster-area poster-area-next" id="posterAreaNext"></div>
 
       <!-- Overlays on top of poster -->
       <div class="poster-overlay" id="posterOverlay" style="display:none;"></div>
@@ -3027,6 +3033,67 @@
       return Math.max(min, Math.min(max, n));
     }
 
+
+    function applyServerRuntimeConfig(body) {
+      if (!body || typeof body !== 'object') return;
+      if (body.backend) ACTIVE_BACKEND = readBackend(body.backend);
+      if (body.displayMode) DISPLAY_MODE = readDisplayMode(body.displayMode);
+      if (body.comingSoon) {
+        const cs = body.comingSoon;
+        if (typeof cs.title === 'string') COMING_SOON.title = cs.title || 'Coming Soon';
+        if (Number.isFinite(cs.moviesCount)) COMING_SOON.moviesCount = cs.moviesCount;
+        if (Number.isFinite(cs.showsCount)) COMING_SOON.showsCount = cs.showsCount;
+        if (Number.isFinite(cs.cycleInterval)) COMING_SOON.cycleInterval = Math.max(2, Math.min(300, cs.cycleInterval));
+        if (Number.isFinite(cs.daysOffset)) COMING_SOON.daysOffset = cs.daysOffset;
+        if (Number.isFinite(cs.lookaheadDays)) COMING_SOON.lookaheadDays = cs.lookaheadDays;
+        if (cs.imageType === 'poster' || cs.imageType === 'fanart') COMING_SOON.imageType = cs.imageType;
+        if (typeof cs.includeCinemaReleases === 'boolean') COMING_SOON.includeCinemaReleases = cs.includeCinemaReleases;
+      }
+      const v = body.visual;
+      if (v && typeof v.progressBar === 'boolean') VISUAL.progressBar = v.progressBar;
+      if (v && typeof v.ratingsBadges === 'boolean') VISUAL.ratingsBadges = v.ratingsBadges;
+      if (v && typeof v.genreChips === 'boolean') VISUAL.genreChips = v.genreChips;
+      if (v && typeof v.infoPanelMode === 'string' && INFO_PANEL_MODES.includes(v.infoPanelMode)) VISUAL.infoPanelMode = v.infoPanelMode;
+      if (v && typeof v.frameStyle === 'string' && FRAME_STYLES.includes(v.frameStyle)) VISUAL.frameStyle = v.frameStyle;
+      if (v && Number.isFinite(v.bulbSizePx)) VISUAL.bulbSizePx = Math.max(12, Math.min(48, v.bulbSizePx));
+      if (v && typeof v.marqueeFont === 'string' && MARQUEE_FONTS.includes(v.marqueeFont)) VISUAL.marqueeFont = v.marqueeFont;
+      if (v && typeof v.posterFraming === 'string' && POSTER_FRAMINGS.includes(v.posterFraming)) VISUAL.posterFraming = v.posterFraming;
+      if (v && typeof v.filmGrain === 'boolean') VISUAL.filmGrain = v.filmGrain;
+      if (v && typeof v.kenBurns === 'boolean') VISUAL.kenBurns = v.kenBurns;
+      if (v && typeof v.useBackdrops === 'boolean') VISUAL.useBackdrops = v.useBackdrops;
+      if (v && typeof v.backdropStyle === 'string' && BACKDROP_STYLES.includes(v.backdropStyle)) VISUAL.backdropStyle = v.backdropStyle;
+      if (v && Number.isFinite(v.backdropDelayMs)) VISUAL.backdropDelayMs = Math.max(1000, Math.min(600000, v.backdropDelayMs));
+      if (v && typeof v.burnInMitigation === 'boolean') VISUAL.burnInMitigation = v.burnInMitigation;
+      if (v && Number.isFinite(v.nudgeIntervalMs)) VISUAL.nudgeIntervalMs = v.nudgeIntervalMs;
+      if (v && Number.isFinite(v.nudgeAmplitudePx)) VISUAL.nudgeAmplitudePx = v.nudgeAmplitudePx;
+      if (v && typeof v.nightModeEntity === 'string') VISUAL.nightModeEntity = v.nightModeEntity;
+      if (v && Number.isFinite(v.nightModeOpacity)) VISUAL.nightModeOpacity = v.nightModeOpacity;
+      if (v && typeof v.theme === 'string' && VISUAL_THEMES.includes(v.theme)) VISUAL.theme = v.theme;
+      if (v && typeof v.accentColor === 'string') {
+        const c = v.accentColor.trim().toLowerCase();
+        if (c === '' || HEX_RE.test(c)) VISUAL.accentColor = c;
+        else {
+          console.warn('[plex-now-showing] Ignoring invalid server accentColor:', c);
+          VISUAL.accentColor = '';
+        }
+      }
+      if (v && typeof v.marqueeBgColor === 'string') {
+        const c = v.marqueeBgColor.trim().toLowerCase();
+        if (c === '' || HEX_RE.test(c)) VISUAL.marqueeBgColor = c;
+        else {
+          console.warn('[plex-now-showing] Ignoring invalid server marqueeBgColor:', c);
+          VISUAL.marqueeBgColor = '';
+        }
+      }
+      if (v && Number.isFinite(v.cornerRadiusPx)) VISUAL.cornerRadiusPx = Math.max(0, Math.min(48, v.cornerRadiusPx));
+      if (v && typeof v.infoShowTitle === 'boolean') VISUAL.infoShowTitle = v.infoShowTitle;
+      if (v && typeof v.infoShowSubtitle === 'boolean') VISUAL.infoShowSubtitle = v.infoShowSubtitle;
+      if (v && typeof v.infoShowMeta === 'boolean') VISUAL.infoShowMeta = v.infoShowMeta;
+      if (v && typeof v.infoShowSummary === 'boolean') VISUAL.infoShowSummary = v.infoShowSummary;
+      if (v && typeof v.infoShowTechbox === 'boolean') VISUAL.infoShowTechbox = v.infoShowTechbox;
+      if (v && typeof v.infoShowPlayer === 'boolean') VISUAL.infoShowPlayer = v.infoShowPlayer;
+    }
+
     async function loadVisualConfig() {
       // Local overrides apply first so the tablet still looks right even if
       // the server is briefly unreachable.
@@ -3069,84 +3136,7 @@
         const resp = await fetch('/api/config', { cache: 'no-store' });
         if (!resp.ok) return;
         const body = await resp.json();
-        if (body && body.backend) ACTIVE_BACKEND = readBackend(body.backend);
-        if (body && body.displayMode) DISPLAY_MODE = readDisplayMode(body.displayMode);
-        if (body && body.comingSoon) {
-          const cs = body.comingSoon;
-          if (typeof cs.title === 'string') COMING_SOON.title = cs.title || 'Coming Soon';
-          if (Number.isFinite(cs.moviesCount)) COMING_SOON.moviesCount = cs.moviesCount;
-          if (Number.isFinite(cs.showsCount)) COMING_SOON.showsCount = cs.showsCount;
-          if (Number.isFinite(cs.cycleInterval)) COMING_SOON.cycleInterval = cs.cycleInterval;
-          if (Number.isFinite(cs.daysOffset)) COMING_SOON.daysOffset = cs.daysOffset;
-          if (Number.isFinite(cs.lookaheadDays)) COMING_SOON.lookaheadDays = cs.lookaheadDays;
-          if (cs.imageType === 'poster' || cs.imageType === 'fanart') COMING_SOON.imageType = cs.imageType;
-          if (typeof cs.includeCinemaReleases === 'boolean') COMING_SOON.includeCinemaReleases = cs.includeCinemaReleases;
-        }
-        const v = body && body.visual;
-        if (v && typeof v.progressBar === 'boolean') VISUAL.progressBar = v.progressBar;
-        if (v && typeof v.ratingsBadges === 'boolean') VISUAL.ratingsBadges = v.ratingsBadges;
-        if (v && typeof v.genreChips === 'boolean') VISUAL.genreChips = v.genreChips;
-        if (v && typeof v.infoPanelMode === 'string' && INFO_PANEL_MODES.includes(v.infoPanelMode)) {
-          VISUAL.infoPanelMode = v.infoPanelMode;
-        }
-        if (v && typeof v.frameStyle === 'string' && FRAME_STYLES.includes(v.frameStyle)) {
-          VISUAL.frameStyle = v.frameStyle;
-        }
-        if (v && Number.isFinite(v.bulbSizePx)) {
-          VISUAL.bulbSizePx = Math.max(12, Math.min(48, v.bulbSizePx));
-        }
-        if (v && typeof v.marqueeFont === 'string' && MARQUEE_FONTS.includes(v.marqueeFont)) {
-          VISUAL.marqueeFont = v.marqueeFont;
-        }
-        if (v && typeof v.posterFraming === 'string' && POSTER_FRAMINGS.includes(v.posterFraming)) {
-          VISUAL.posterFraming = v.posterFraming;
-        }
-        if (v && typeof v.filmGrain === 'boolean') VISUAL.filmGrain = v.filmGrain;
-        if (v && typeof v.kenBurns === 'boolean') VISUAL.kenBurns = v.kenBurns;
-        if (v && typeof v.useBackdrops === 'boolean') VISUAL.useBackdrops = v.useBackdrops;
-        if (v && typeof v.backdropStyle === 'string' && BACKDROP_STYLES.includes(v.backdropStyle)) {
-          VISUAL.backdropStyle = v.backdropStyle;
-        }
-        if (v && Number.isFinite(v.backdropDelayMs)) {
-          VISUAL.backdropDelayMs = Math.max(1000, Math.min(600000, v.backdropDelayMs));
-        }
-        if (v && typeof v.burnInMitigation === 'boolean') VISUAL.burnInMitigation = v.burnInMitigation;
-        if (v && Number.isFinite(v.nudgeIntervalMs))     VISUAL.nudgeIntervalMs   = v.nudgeIntervalMs;
-        if (v && Number.isFinite(v.nudgeAmplitudePx))    VISUAL.nudgeAmplitudePx  = v.nudgeAmplitudePx;
-        if (v && typeof v.nightModeEntity === 'string')  VISUAL.nightModeEntity   = v.nightModeEntity;
-        if (v && Number.isFinite(v.nightModeOpacity))    VISUAL.nightModeOpacity  = v.nightModeOpacity;
-        if (v && typeof v.theme === 'string' && VISUAL_THEMES.includes(v.theme)) {
-          VISUAL.theme = v.theme;
-        }
-        // Server validates accentColor as #RRGGBB or empty; trust it but
-        // double-check on the client to defend against a stale or modified
-        // response.
-        if (v && typeof v.accentColor === 'string') {
-          const c = v.accentColor.trim().toLowerCase();
-          if (c === '' || HEX_RE.test(c)) VISUAL.accentColor = c;
-          else {
-            console.warn('[plex-now-showing] Ignoring invalid server accentColor:', c);
-            VISUAL.accentColor = '';
-          }
-        }
-        if (v && typeof v.marqueeBgColor === 'string') {
-          const c = v.marqueeBgColor.trim().toLowerCase();
-          if (c === '' || HEX_RE.test(c)) VISUAL.marqueeBgColor = c;
-          else {
-            console.warn('[plex-now-showing] Ignoring invalid server marqueeBgColor:', c);
-            VISUAL.marqueeBgColor = '';
-          }
-        }
-        if (v && Number.isFinite(v.cornerRadiusPx)) {
-          VISUAL.cornerRadiusPx = Math.max(0, Math.min(48, v.cornerRadiusPx));
-        }
-        // #64 — per-section info panel visibility (server override)
-        if (v && typeof v.infoShowTitle    === 'boolean') VISUAL.infoShowTitle    = v.infoShowTitle;
-        if (v && typeof v.infoShowSubtitle === 'boolean') VISUAL.infoShowSubtitle = v.infoShowSubtitle;
-        if (v && typeof v.infoShowMeta     === 'boolean') VISUAL.infoShowMeta     = v.infoShowMeta;
-        if (v && typeof v.infoShowSummary  === 'boolean') VISUAL.infoShowSummary  = v.infoShowSummary;
-        if (v && typeof v.infoShowTechbox  === 'boolean') VISUAL.infoShowTechbox  = v.infoShowTechbox;
-        if (v && typeof v.infoShowPlayer   === 'boolean') VISUAL.infoShowPlayer   = v.infoShowPlayer;
+        applyServerRuntimeConfig(body);
       } catch (err) {
         console.warn('[plex-now-showing] /api/config fetch failed — using local defaults.', err);
       }
@@ -4544,6 +4534,7 @@
 
     // ===== DOM REFS =====
     const posterArea = document.getElementById('posterArea');
+    const posterAreaNext = document.getElementById('posterAreaNext');
     const posterBgBlur = document.getElementById('posterBgBlur');
     const posterOverlay = document.getElementById('posterOverlay');
     const posterTitle = document.getElementById('posterTitle');
@@ -4569,6 +4560,9 @@
     let currentMediaData = null;
     let infoTimeout = null;
     let cachedMediaInfo = {};  // Cache Plex media info by ratingKey
+    let posterLoadSeq = 0;
+    let posterSwapTimer = null;
+    let posterTransitionResetTimer = null;
     const infoOverlay = document.getElementById('infoOverlay');
     const infoTitle = document.getElementById('infoTitle');
     const infoSubtitle = document.getElementById('infoSubtitle');
@@ -5710,16 +5704,37 @@
       isShowingMedia = true;
       hideInfo();
 
-      // Update poster background image
+      // Update poster via a double-buffered crossfade. Keep the current
+      // poster visible while the next image preloads, then swap layers after
+      // the CSS fade completes. This avoids black flashes during Coming Soon
+      // cycling and preserves the /api/artwork same-origin proxy path above.
+      const loadSeq = ++posterLoadSeq;
       const img = new Image();
       img.onload = () => {
-        posterArea.style.backgroundImage = `url(${artworkUrl})`;
-        posterArea.classList.add('loaded');
+        if (loadSeq !== posterLoadSeq) return;
+        if (posterSwapTimer) clearTimeout(posterSwapTimer);
+        if (posterTransitionResetTimer) clearTimeout(posterTransitionResetTimer);
+        posterAreaNext.style.transition = '';
+        posterAreaNext.style.backgroundImage = `url(${artworkUrl})`;
+        posterAreaNext.classList.add('loaded');
         // Also update blurred background for landscape mode
         posterBgBlur.style.backgroundImage = `url(${artworkUrl})`;
         posterBgBlur.classList.add('loaded');
+        posterSwapTimer = setTimeout(() => {
+          posterArea.style.backgroundImage = posterAreaNext.style.backgroundImage;
+          posterArea.classList.add('loaded');
+          posterAreaNext.style.transition = 'none';
+          posterAreaNext.classList.remove('loaded');
+          posterAreaNext.style.backgroundImage = '';
+          posterTransitionResetTimer = setTimeout(() => {
+            posterAreaNext.style.transition = '';
+            posterTransitionResetTimer = null;
+          }, 50);
+          posterSwapTimer = null;
+        }, 900);
       };
-      posterArea.classList.remove('loaded');
+      posterAreaNext.classList.remove('loaded');
+      posterAreaNext.style.backgroundImage = '';
       posterBgBlur.classList.remove('loaded');
       img.src = artworkUrl;
 
@@ -5804,8 +5819,14 @@
       currentMediaData = null;
       hideInfo();
 
+      posterLoadSeq++;
+      if (posterSwapTimer) { clearTimeout(posterSwapTimer); posterSwapTimer = null; }
+      if (posterTransitionResetTimer) { clearTimeout(posterTransitionResetTimer); posterTransitionResetTimer = null; }
       posterArea.classList.remove('loaded');
       posterArea.style.backgroundImage = '';
+      posterAreaNext.classList.remove('loaded');
+      posterAreaNext.style.transition = '';
+      posterAreaNext.style.backgroundImage = '';
       posterBgBlur.classList.remove('loaded');
       posterBgBlur.style.backgroundImage = '';
       posterOverlay.style.display = 'none';
@@ -5824,6 +5845,7 @@
     // Falls back to 30s polling if SSE fails or is unavailable.
     let sseSource = null;
     let sseFallbackTimer = null;
+    let comingSoonCycleTimer = null;
     const SSE_FALLBACK_INTERVAL = 30000;
 
     function startSseConnection() {
@@ -5847,6 +5869,22 @@
       sseSource.onmessage = (event) => {
         try {
           const data = JSON.parse(event.data);
+          if (data && data.type === 'config_changed' && data.config) {
+            const previousMode = DISPLAY_MODE;
+            applyServerRuntimeConfig(data.config);
+            applyVisualToggles();
+            syncDisplayModeText();
+            syncFrameStyle();
+            if (DISPLAY_MODE === 'coming_soon') {
+              startComingSoonCycle();
+              poll();
+            } else {
+              stopComingSoonCycle();
+              if (previousMode !== DISPLAY_MODE) poll();
+            }
+            debugLogMsg(`[SSE] Config changed — displayMode: ${DISPLAY_MODE}`);
+            return;
+          }
           // Server sends null payload when nothing is playing
           if (data && data.state) {
             showMedia(data);
@@ -5881,6 +5919,22 @@
 
     // ===== POLLING LOOP =====
     // Primary: SSE push from server. Fallback: 30s poll.
+    // In Coming Soon mode, cycle by re-polling /api/coming-soon on the
+    // configured interval so posters rotate without a full page refresh.
+    function startComingSoonCycle() {
+      stopComingSoonCycle();
+      const ms = Math.max(2, Number(COMING_SOON.cycleInterval) || 8) * 1000;
+      comingSoonCycleTimer = setInterval(() => { void poll(); }, ms);
+      debugLogMsg(`[coming-soon] cycle started — every ${ms / 1000}s`);
+    }
+
+    function stopComingSoonCycle() {
+      if (!comingSoonCycleTimer) return;
+      clearInterval(comingSoonCycleTimer);
+      comingSoonCycleTimer = null;
+      debugLogMsg('[coming-soon] cycle stopped');
+    }
+
     async function poll() {
       const data = await fetchNowShowingData();
       if (data) {
@@ -5902,7 +5956,8 @@
       // Start SSE push connection — falls back to 30s poll automatically
       startSseConnection();
       // Do an immediate poll so the first render is instant (before SSE delivers)
-      poll();
+      void poll();
+      if (DISPLAY_MODE === 'coming_soon') startComingSoonCycle();
       startConnectionPolling();
       if (window.DEBUG_MODE) debugLogMsg('Debug mode enabled');
     }
@@ -5930,6 +5985,7 @@
     window.addEventListener('beforeunload', () => {
       if (sseSource) { sseSource.close(); sseSource = null; }
       if (sseFallbackTimer) { clearInterval(sseFallbackTimer); sseFallbackTimer = null; }
+      stopComingSoonCycle();
     });
   </script>
 </body>


### PR DESCRIPTION
## Summary
- Broadcast sanitized `config_changed` events over SSE after setup save/reset so open kiosks apply display mode, backend, Coming Soon, and visual config changes without refresh.
- Add Coming Soon auto-cycle using `coming_soon_cycle_interval`, plus double-buffered poster crossfade with stale image guards.
- Update release docs/versioning to 2.3.4 and replace the README changes-since-last-release table with the new changes.

## Review / fixes
- Sequential review attempted via delegated reviewer; provider returned HTTP 429, so I completed two local review passes instead.
- Fixed review findings before commit: scoped Ken Burns to the active poster layer and added stale image protection for slow artwork loads.

## Test plan
- `node --check /tmp/now_showing_inline.js`
- `git diff --check`
- `cd server && npm test` (201/201 passing)
